### PR TITLE
WIP: Optimize createmsg

### DIFF
--- a/msg/msg.go
+++ b/msg/msg.go
@@ -60,8 +60,10 @@ func (m *MetricData) DecodeMetricData() error {
 	return nil
 }
 
-func CreateMsg(metrics []*schema.MetricData, id int64, version Format) ([]byte, error) {
-	buf := new(bytes.Buffer)
+// make sure tmp has desired capacity but len zero
+func CreateMsg(tmp []byte, metrics []*schema.MetricData, id int64, version Format) ([]byte, error) {
+	buf := bytes.NewBuffer(tmp)
+
 	err := binary.Write(buf, binary.LittleEndian, uint8(version))
 	if err != nil {
 		return nil, fmt.Errorf("binary.Write failed: %s", err.Error())

--- a/msg/msg_test.go
+++ b/msg/msg_test.go
@@ -24,10 +24,9 @@ func Benchmark_CreateMessage(b *testing.B) {
 			Tags:       []string{"some_tag", "ok"},
 		}
 	}
-	// timestamps start at 1 and go up from there. (we can't use 0, see AggMetric.Add())
-	msgs := make([]*nsq.Message, b.N)
 	b.ResetTimer()
 	var id nsq.MessageID
+	var m *nsq.Message
 	for i := 0; i < b.N; i++ {
 		id = nsq.MessageID{'1', '2', '3', '4', '5', '6', '7', '8', '9', '0', 'a', 's', 'd', 'f', 'g', 'h'}
 		for j := 0; j < len(metrics); j++ {
@@ -37,10 +36,10 @@ func Benchmark_CreateMessage(b *testing.B) {
 		if err != nil {
 			panic(err)
 		}
-		msgs[i] = nsq.NewMessage(id, data)
+		m = nsq.NewMessage(id, data)
 	}
 	// prevents the go compiler from optimizing msgs away. presumably..
-	if msgs[len(msgs)-1].ID != id {
+	if m.ID != id {
 		panic("bad id")
 	}
 	b.StopTimer()

--- a/msg/msg_test.go
+++ b/msg/msg_test.go
@@ -1,0 +1,53 @@
+package msg
+
+import (
+	"fmt"
+	"github.com/nsqio/go-nsq"
+	"github.com/raintank/raintank-metric/schema"
+	"runtime"
+	"testing"
+)
+
+func Benchmark_CreateMessage(b *testing.B) {
+	metrics := make([]*schema.MetricData, 10)
+	for i := 0; i < len(metrics); i++ {
+		metrics[i] = &schema.MetricData{
+			Id:         "some.id.of.a.metric",
+			OrgId:      500,
+			Name:       "some.id",
+			Metric:     "metric",
+			Interval:   60,
+			Value:      1234.567,
+			Unit:       "ms",
+			Time:       int64(i - len(metrics) + 1),
+			TargetType: "gauge",
+			Tags:       []string{"some_tag", "ok"},
+		}
+	}
+	// timestamps start at 1 and go up from there. (we can't use 0, see AggMetric.Add())
+	msgs := make([]*nsq.Message, b.N)
+	b.ResetTimer()
+	var id nsq.MessageID
+	for i := 0; i < b.N; i++ {
+		id = nsq.MessageID{'1', '2', '3', '4', '5', '6', '7', '8', '9', '0', 'a', 's', 'd', 'f', 'g', 'h'}
+		for j := 0; j < len(metrics); j++ {
+			metrics[j].Time += 10
+		}
+		data, err := CreateMsg(metrics, 1, FormatMetricDataArrayMsgp)
+		if err != nil {
+			panic(err)
+		}
+		msgs[i] = nsq.NewMessage(id, data)
+	}
+	// prevents the go compiler from optimizing msgs away. presumably..
+	if msgs[len(msgs)-1].ID != id {
+		panic("bad id")
+	}
+	b.StopTimer()
+	var stats runtime.MemStats
+	runtime.ReadMemStats(&stats)
+	if b.N == 1 {
+		fmt.Println()
+	}
+	fmt.Printf("messages: %6d, system bytes needed: %10d\n", b.N, stats.Sys)
+}


### PR DESCRIPTION
- pretty sure that once a nsq publisher.Publish() returns, we can reuse the buffers, but i want to have this confirmed still.edit confirmed:

> 02:36:40 < jud> Dieterbe, it will have written the command to the tcp conn before Publish returns
- the 3rd commit didn't actually bring the number of allocs per op down, it did bring the size of allocated mem down, I don't understand either one.

in particular, I'ld like to get rid of all allocations in CreateMsg:

```
~/g/s/g/r/r/msg ❯❯❯ go tool pprof --alloc_objects msg.test mem.prof
Entering interactive mode (type "help" for commands)
(pprof) top100
3959391 of 3961128 total (  100%)
Dropped 8 nodes (cum <= 19805)
      flat  flat%   sum%        cum   cum%
   1718054 43.37% 43.37%    3189292 80.51%  github.com/raintank/raintank-metric/msg.CreateMsg
    950286 23.99% 67.36%     950286 23.99%  encoding/binary.Write
    520952 13.15% 80.51%     520952 13.15%  github.com/raintank/raintank-metric/schema.MetricDataArray.MarshalMsg
    458794 11.58% 92.10%     458794 11.58%  github.com/nsqio/go-nsq.NewMessage
    311305  7.86%   100%    3959763   100%  github.com/raintank/raintank-metric/msg.Benchmark_CreateMessage
         0     0%   100%    3959763   100%  runtime.goexit
         0     0%   100%    3959763   100%  testing.(*B).launch
         0     0%   100%    3959763   100%  testing.(*B).runN
(pprof) list CreateMsg
Total: 3961128
ROUTINE ======================== github.com/raintank/raintank-metric/msg.CreateMsg in /home/dieter/go/src/github.com/raintank/raintank-metric/msg/msg.go
   1718054    3189292 (flat, cum) 80.51% of Total
         .          .     60:   return nil
         .          .     61:}
         .          .     62:
         .          .     63:// make sure tmp has desired capacity but len zero
         .          .     64:func CreateMsg(tmp []byte, metrics []*schema.MetricData, id int64, version Format) ([]byte, error) {
    538388     538388     65:   buf := bytes.NewBuffer(tmp)
         .          .     66:
    458759     950286     67:   err := binary.Write(buf, binary.LittleEndian, uint8(version))
         .          .     68:   if err != nil {
         .          .     69:       return nil, fmt.Errorf("binary.Write failed: %s", err.Error())
         .          .     70:   }
    720907    1179666     71:   err = binary.Write(buf, binary.BigEndian, id)
         .          .     72:   if err != nil {
         .          .     73:       return nil, fmt.Errorf("binary.Write failed: %s", err.Error())
         .          .     74:   }
         .          .     75:   var msg []byte
         .          .     76:   switch version {
         .          .     77:   case FormatMetricDataArrayJson:
         .          .     78:       msg, err = json.Marshal(metrics)
         .          .     79:   case FormatMetricDataArrayMsgp:
         .          .     80:       m := schema.MetricDataArray(metrics)
         .     520952     81:       msg, err = m.MarshalMsg(nil)
         .          .     82:   default:
         .          .     83:       return nil, errors.New("unsupported version")
         .          .     84:   }
         .          .     85:   if err != nil {
         .          .     86:       return nil, fmt.Errorf("Failed to marshal metrics payload: %s", err)
(pprof) 
```
