### PR TITLE
uint attribute size reductions

### DIFF
--- a/metric_tank/README.md
+++ b/metric_tank/README.md
@@ -49,3 +49,14 @@ when one primary is down you need to be careful about when to promote a secondar
 * `/render` has a very, very limited subset of the graphite render api. basically you can specify targets by their graphite key, set from, to and maxDataPoints, and use consolidateBy.
 No other function or parameter is currently supported.  Also we don't check org-id so don't expose this publically
 * `/metrics/index.json` is like graphite.  Don't expose this publically
+
+
+# number value limits
+
+* maxDataPoints can be no more than 65535. this way we can use a uint16
+* span of chunks and aggregators: max 65k seconds. so basically daily points is too course. you'll want at least every 12 hours or so. uint16
+* max interval between points: same as above. uint16.
+* number of chunks is limited to 255. this way we can use a uint8.
+* ttl is internally quantized to a number of hours that at least covers the requested amount of seconds. this way we can use uint16.
+* number of archives: 255 (so max 254 rollup bands) -> uint8
+

--- a/metric_tank/aggmetric_test.go
+++ b/metric_tank/aggmetric_test.go
@@ -155,16 +155,16 @@ func BenchmarkAggMetrics1000Metrics1Day(b *testing.B) {
 	clusterStatus = NewClusterStatus("default", false)
 	// we will store 10s metrics in 5 chunks of 2 hours
 	// aggragate them in 5min buckets, stored in 1 chunk of 24hours
-	chunkSpan := uint32(2 * 3600)
-	numChunks := uint32(5)
+	chunkSpan := uint16(2 * 3600)
+	numChunks := uint8(5)
 	chunkMaxStale := uint32(3600)
 	metricMaxStale := uint32(21600)
-	ttl := uint32(84600)
+	ttl := uint16(24)
 	aggSettings := []aggSetting{
 		{
-			span:      uint32(300),
-			chunkSpan: uint32(24 * 3600),
-			numChunks: uint32(1),
+			span:      uint16(300),
+			chunkSpan: uint16(12 * 3600),
+			numChunks: uint8(1),
 		},
 	}
 
@@ -188,20 +188,20 @@ func BenchmarkAggMetrics1kSeries2Chunks1kQueueSize(b *testing.B) {
 	stats, _ := helper.New(false, "", "standard", "metrics_tank", "")
 	initMetrics(stats)
 
-	chunkSpan := uint32(600)
-	numChunks := uint32(5)
+	chunkSpan := uint16(600)
+	numChunks := uint8(5)
 	chunkMaxStale := uint32(3600)
 	metricMaxStale := uint32(21600)
 
 	*topicNotifyPersist = ""
 	clusterStatus = NewClusterStatus("default", true)
 
-	ttl := uint32(84600)
+	ttl := uint16(24)
 	aggSettings := []aggSetting{
 		{
-			span:      uint32(300),
-			chunkSpan: uint32(24 * 3600),
-			numChunks: uint32(2),
+			span:      uint16(300),
+			chunkSpan: uint16(12 * 3600),
+			numChunks: uint8(2),
 		},
 	}
 
@@ -225,8 +225,8 @@ func BenchmarkAggMetrics10kSeries2Chunks10kQueueSize(b *testing.B) {
 	stats, _ := helper.New(false, "", "standard", "metrics_tank", "")
 	initMetrics(stats)
 
-	chunkSpan := uint32(600)
-	numChunks := uint32(5)
+	chunkSpan := uint16(600)
+	numChunks := uint8(5)
 	chunkMaxStale := uint32(3600)
 	metricMaxStale := uint32(21600)
 
@@ -234,12 +234,12 @@ func BenchmarkAggMetrics10kSeries2Chunks10kQueueSize(b *testing.B) {
 
 	clusterStatus = NewClusterStatus("default", true)
 
-	ttl := uint32(84600)
+	ttl := uint16(24)
 	aggSettings := []aggSetting{
 		{
-			span:      uint32(300),
-			chunkSpan: uint32(24 * 3600),
-			numChunks: uint32(2),
+			span:      uint16(300),
+			chunkSpan: uint16(12 * 3600),
+			numChunks: uint8(2),
 		},
 	}
 
@@ -263,8 +263,8 @@ func BenchmarkAggMetrics100kSeries2Chunks100kQueueSize(b *testing.B) {
 	stats, _ := helper.New(false, "", "standard", "metrics_tank", "")
 	initMetrics(stats)
 
-	chunkSpan := uint32(600)
-	numChunks := uint32(5)
+	chunkSpan := uint16(600)
+	numChunks := uint8(5)
 	chunkMaxStale := uint32(3600)
 	metricMaxStale := uint32(21600)
 
@@ -272,12 +272,12 @@ func BenchmarkAggMetrics100kSeries2Chunks100kQueueSize(b *testing.B) {
 
 	clusterStatus = NewClusterStatus("default", true)
 
-	ttl := uint32(84600)
+	ttl := uint16(24)
 	aggSettings := []aggSetting{
 		{
-			span:      uint32(300),
-			chunkSpan: uint32(24 * 3600),
-			numChunks: uint32(2),
+			span:      uint16(300),
+			chunkSpan: uint16(12 * 3600),
+			numChunks: uint8(2),
 		},
 	}
 

--- a/metric_tank/aggregator_test.go
+++ b/metric_tank/aggregator_test.go
@@ -7,7 +7,7 @@ import (
 
 type testcase struct {
 	ts       uint32
-	span     uint32
+	span     uint16
 	boundary uint32
 }
 
@@ -60,13 +60,13 @@ func TestAggregator(t *testing.T) {
 		}
 		clusterStatus.Set(false)
 	}
-	agg := NewAggregator(dnstore, "test", 60, 120, 10, 86400)
+	agg := NewAggregator(dnstore, "test", 60, 120, 10, 24)
 	agg.Add(100, 123.4)
 	agg.Add(110, 5)
 	expected := []schema.Point{}
 	compare("simple-min-unfinished", agg.minMetric, expected)
 
-	agg = NewAggregator(dnstore, "test", 60, 120, 10, 86400)
+	agg = NewAggregator(dnstore, "test", 60, 120, 10, 24)
 	agg.Add(100, 123.4)
 	agg.Add(110, 5)
 	agg.Add(130, 130)
@@ -75,7 +75,7 @@ func TestAggregator(t *testing.T) {
 	}
 	compare("simple-min-one-block", agg.minMetric, expected)
 
-	agg = NewAggregator(dnstore, "test", 60, 120, 10, 86400)
+	agg = NewAggregator(dnstore, "test", 60, 120, 10, 24)
 	agg.Add(100, 123.4)
 	agg.Add(110, 5)
 	agg.Add(120, 4)
@@ -84,7 +84,7 @@ func TestAggregator(t *testing.T) {
 	}
 	compare("simple-min-one-block-done-cause-last-point-just-right", agg.minMetric, expected)
 
-	agg = NewAggregator(dnstore, "test", 60, 120, 10, 86400)
+	agg = NewAggregator(dnstore, "test", 60, 120, 10, 24)
 	agg.Add(100, 123.4)
 	agg.Add(110, 5)
 	agg.Add(150, 1.123)
@@ -95,7 +95,7 @@ func TestAggregator(t *testing.T) {
 	}
 	compare("simple-min-two-blocks-done-cause-last-point-just-right", agg.minMetric, expected)
 
-	agg = NewAggregator(dnstore, "test", 60, 120, 10, 86400)
+	agg = NewAggregator(dnstore, "test", 60, 120, 10, 24)
 	agg.Add(100, 123.4)
 	agg.Add(110, 5)
 	agg.Add(190, 2451.123)

--- a/metric_tank/consolidation/consolidation.go
+++ b/metric_tank/consolidation/consolidation.go
@@ -7,7 +7,7 @@ import (
 
 // consolidator is a highlevel description of a point consolidation method
 // mostly for use by the http api, but can also be used internally for data processing
-type Consolidator int
+type Consolidator uint8
 
 const (
 	None Consolidator = iota

--- a/metric_tank/cwr.go
+++ b/metric_tank/cwr.go
@@ -13,6 +13,6 @@ type ChunkReadRequest struct {
 type ChunkWriteRequest struct {
 	key       string
 	chunk     *Chunk
-	ttl       uint32
+	ttl       uint16
 	timestamp time.Time
 }

--- a/metric_tank/dataprocessor_test.go
+++ b/metric_tank/dataprocessor_test.go
@@ -183,7 +183,7 @@ func TestConsolidationFunctions(t *testing.T) {
 
 type c struct {
 	numPoints     uint32
-	maxDataPoints uint32
+	maxDataPoints uint16
 	every         uint32
 }
 
@@ -258,13 +258,13 @@ type fixc struct {
 	in       []schema.Point
 	from     uint32
 	to       uint32
-	interval uint32
+	interval uint16
 	out      []schema.Point
 }
 
-func nullPoints(from, to, interval uint32) []schema.Point {
+func nullPoints(from, to uint32, interval uint16) []schema.Point {
 	out := make([]schema.Point, 0)
-	for i := from; i < to; i += interval {
+	for i := from; i < to; i += uint32(interval) {
 		out = append(out, schema.Point{math.NaN(), i})
 	}
 	return out
@@ -398,12 +398,12 @@ type alignCase struct {
 	outErr      error
 }
 
-func reqRaw(key string, from, to, maxPoints uint32, consolidator consolidation.Consolidator, rawInterval uint32) Req {
+func reqRaw(key string, from, to uint32, maxPoints uint16, consolidator consolidation.Consolidator, rawInterval uint16) Req {
 	req := NewReq(key, key, from, to, maxPoints, consolidator)
 	req.rawInterval = rawInterval
 	return req
 }
-func reqOut(key string, from, to, maxPoints uint32, consolidator consolidation.Consolidator, rawInterval uint32, archive int, archInterval, outInterval, aggNum uint32) Req {
+func reqOut(key string, from, to uint32, maxPoints uint16, consolidator consolidation.Consolidator, rawInterval uint16, archive uint8, archInterval, outInterval uint16, aggNum uint32) Req {
 	req := NewReq(key, key, from, to, maxPoints, consolidator)
 	req.rawInterval = rawInterval
 	req.archive = archive

--- a/metric_tank/defcache.go
+++ b/metric_tank/defcache.go
@@ -130,7 +130,7 @@ func (dc *DefCache) UpdateReq(req *Req) error {
 		metricDefCacheMiss.Inc(1)
 		return errMetricNotFound
 	} else {
-		req.rawInterval = uint32(def.Interval)
+		req.rawInterval = uint16(def.Interval)
 		metricDefCacheHit.Inc(1)
 	}
 	return nil

--- a/metric_tank/http.go
+++ b/metric_tank/http.go
@@ -25,7 +25,7 @@ var bufPool = sync.Pool{
 type Series struct {
 	Target     string
 	Datapoints []schema.Point
-	Interval   uint32
+	Interval   uint16
 }
 
 func listJSON(b []byte, defs []*schema.MetricDefinition) ([]byte, error) {
@@ -142,7 +142,7 @@ func Get(w http.ResponseWriter, req *http.Request, store Store, defCache *DefCac
 	pre := time.Now()
 	req.ParseForm()
 
-	maxDataPoints := uint32(800)
+	maxDataPoints := uint16(800)
 	maxDataPointsStr := req.Form.Get("maxDataPoints")
 	var err error
 	if maxDataPointsStr != "" {
@@ -151,7 +151,7 @@ func Get(w http.ResponseWriter, req *http.Request, store Store, defCache *DefCac
 			http.Error(w, err.Error(), http.StatusBadRequest)
 			return
 		}
-		maxDataPoints = uint32(tmp)
+		maxDataPoints = uint16(tmp)
 	}
 
 	targets, ok := req.Form["target"]

--- a/metric_tank/ifaces.go
+++ b/metric_tank/ifaces.go
@@ -10,5 +10,5 @@ type Metrics interface {
 type Metric interface {
 	Add(ts uint32, val float64)
 	Get(from, to uint32) (uint32, []Iter)
-	GetAggregated(consolidator consolidation.Consolidator, aggSpan, from, to uint32) (uint32, []Iter)
+	GetAggregated(consolidator consolidation.Consolidator, aggSpan uint16, from, to uint32) (uint32, []Iter)
 }

--- a/metric_tank/req.go
+++ b/metric_tank/req.go
@@ -11,30 +11,30 @@ type Req struct {
 	target       string // original input string like consolidateBy(key,'sum'). used in output so that graphite doesn't get confused
 	from         uint32
 	to           uint32
-	maxPoints    uint32
 	consolidator consolidation.Consolidator
+	maxPoints    uint16
 
 	// these fields need some more coordination and are typically set later
-	archive      int    // 0 means original data, 1 means first agg level, 2 means 2nd, etc.
-	rawInterval  uint32 // the interval of the raw metric before any consolidation
-	archInterval uint32 // the interval corresponding to the archive we'll fetch
-	outInterval  uint32 // the interval of the output data, after any runtime consolidation
+	archive      uint8  // 0 means original data, 1 means first agg level, 2 means 2nd, etc.
+	rawInterval  uint16 // the interval of the raw metric before any consolidation
+	archInterval uint16 // the interval corresponding to the archive we'll fetch
+	outInterval  uint16 // the interval of the output data, after any runtime consolidation
 	aggNum       uint32 // how many points to consolidate together at runtime, after fetching from the archive
 }
 
-func NewReq(key, target string, from, to, maxPoints uint32, consolidator consolidation.Consolidator) Req {
+func NewReq(key, target string, from, to uint32, maxPoints uint16, consolidator consolidation.Consolidator) Req {
 	return Req{
 		key,
 		target,
 		from,
 		to,
-		maxPoints,
 		consolidator,
-		-1, // this is supposed to be updated still!
-		0,  // this is supposed to be updated still
-		0,  // this is supposed to be updated still
-		0,  // this is supposed to be updated still
-		0,  // this is supposed to be updated still
+		maxPoints,
+		255, // this is supposed to be updated still!
+		0,   // this is supposed to be updated still
+		0,   // this is supposed to be updated still
+		0,   // this is supposed to be updated still
+		0,   // this is supposed to be updated still
 	}
 }
 

--- a/metric_tank/util.go
+++ b/metric_tank/util.go
@@ -1,13 +1,35 @@
 package main
 
-func min(a, b uint32) uint32 {
+import (
+	"errors"
+)
+
+const maxTTL = uint32(65535 * 3600)
+
+var errTTLTooHigh = errors.New("TTL value too high. can be max 2730 days (65535 * 3600 seconds)")
+
+func min32(a, b uint32) uint32 {
 	if a < b {
 		return a
 	}
 	return b
 }
 
-func max(a, b uint32) uint32 {
+func max32(a, b uint32) uint32 {
+	if a > b {
+		return a
+	}
+	return b
+}
+
+func min16(a, b uint16) uint16 {
+	if a < b {
+		return a
+	}
+	return b
+}
+
+func max16(a, b uint16) uint16 {
 	if a > b {
 		return a
 	}
@@ -22,14 +44,14 @@ func maxInt(a, b int) int {
 }
 
 // lcm returns the least common multiple
-func lcm(vals []uint32) uint32 {
+func lcm(vals []uint16) uint16 {
 	out := vals[0]
 	for i := 1; i < len(vals); i++ {
-		a := max(uint32(vals[i]), out)
-		b := min(uint32(vals[i]), out)
+		a := max16(vals[i], out)
+		b := min16(vals[i], out)
 		r := a % b
 		if r != 0 {
-			for j := uint32(2); j <= b; j++ {
+			for j := uint16(2); j <= b; j++ {
 				if (j*a)%b == 0 {
 					out = j * a
 					break
@@ -40,4 +62,15 @@ func lcm(vals []uint32) uint32 {
 		}
 	}
 	return out
+}
+
+func hourlyTTL(secs uint32) (uint16, error) {
+	if secs > maxTTL {
+		return 0, errTTLTooHigh
+	}
+	hours := uint16(secs / 3600)
+	if secs%3600 != 0 {
+		hours += 1
+	}
+	return hours, nil
 }

--- a/metric_tank/util_test.go
+++ b/metric_tank/util_test.go
@@ -6,13 +6,13 @@ import (
 
 func TestLCM(t *testing.T) {
 	cases := []struct {
-		in  []uint32
-		out uint32
+		in  []uint16
+		out uint16
 	}{
-		{[]uint32{10, 60}, 60},
-		{[]uint32{20, 30}, 60},
-		{[]uint32{40, 60}, 120},
-		{[]uint32{1, 3}, 3},
+		{[]uint16{10, 60}, 60},
+		{[]uint16{20, 30}, 60},
+		{[]uint16{40, 60}, 120},
+		{[]uint16{1, 3}, 3},
 	}
 	for i, c := range cases {
 		out := lcm(c.in)


### PR DESCRIPTION
by imposing the reasonable (?) limits explained in the README
we're able to store a lot of the structures using less space.
this should translate in lower memory usage, and possibly lower GC times
structures are also reorganized for better alingment in less space
Note that casting between different uint types seems to be very
efficient and worth the memory gains:
https://gist.github.com/Dieterbe/811e820e83ce05cac0a8
https://gist.github.com/Dieterbe/3f8894bf51daa97b3fc3

this requires more testing, especially for bugs and performance
regressions