### PR TITLE
fix: don't try to add first point of new series twice

### DIFF
--- a/metric_tank/mdata/aggmetric.go
+++ b/metric_tank/mdata/aggmetric.go
@@ -421,6 +421,8 @@ func (a *AggMetric) Add(ts uint32, val float64) {
 		}
 
 		log.Debug("AM %s Add(): created first chunk with first point: %v", a.Key, a.Chunks[0])
+		a.addAggregators(ts, val)
+		return
 	}
 
 	currentChunk := a.getChunk(a.CurrentChunkPos)


### PR DESCRIPTION
I spotted this problem when trying to add points through the new carbon plugin
```
2016/07/10 20:28:14 [D] AM 1.1cef6a333a35fa3eab1748815cf39167 Add(): created first chunk with first point: <chunk T0=1468182000, LastTs=1468182345, NumPoints=1, Saved=false>
2016/07/10 20:28:14 [D] AM failed to add metric to chunk for 1.1cef6a333a35fa3eab1748815cf39167. Point must be newer than already added points. t:1468182345 lastTs: 1468182345
```