### PR TITLE
merge series when multiple metricDefs for a single target

### DIFF
--- a/dataprocessor_test.go
+++ b/dataprocessor_test.go
@@ -885,7 +885,7 @@ func TestMergeSeries(t *testing.T) {
 
 	merged := mergeSeries(out)
 	if len(merged) != 5 {
-		t.Errorf("Expected data to be merged down to 5 series. got %s instead", len(merged))
+		t.Errorf("Expected data to be merged down to 5 series. got %d instead", len(merged))
 	}
 	for _, serie := range merged {
 		if serie.Target == "some.series.foo1" {

--- a/http.go
+++ b/http.go
@@ -274,9 +274,6 @@ func Get(w http.ResponseWriter, req *http.Request, store mdata.Store, defCache *
 		}
 
 		if legacy {
-			// querying for a graphite pattern
-			// for now we just pick random defs if we have multiple defs (e.g. multiple intervals) for the same key
-			// in the future we'll do something smarter.
 			_, defs := defCache.Find(org, id)
 			if len(defs) == 0 {
 				http.Error(w, errMetricNotFound.Error(), http.StatusBadRequest)
@@ -341,6 +338,8 @@ func Get(w http.ResponseWriter, req *http.Request, store mdata.Store, defCache *
 		sort.Sort(SeriesByTarget(merged))
 		js, err = graphiteJSON(js, merged)
 	} else {
+		// we dont merge here as graphite is expecting all metric.Ids it reqested.
+		// graphite will then handle the merging itself.
 		js, err = graphiteRaintankJSON(js, out)
 	}
 	for _, serie := range out {

--- a/http.go
+++ b/http.go
@@ -337,37 +337,7 @@ func Get(w http.ResponseWriter, req *http.Request, store mdata.Store, defCache *
 
 	js := bufPool.Get().([]byte)
 	if legacy {
-		//check for duplicate series names. If found merge the results.
-		seriesByTarget := make(map[string][]Series)
-		for _, series := range out {
-			if _, ok := seriesByTarget[series.Target]; !ok {
-				seriesByTarget[series.Target] = make([]Series, 0)
-			}
-			seriesByTarget[series.Target] = append(seriesByTarget[series.Target], series)
-		}
-		merged := make([]Series, len(seriesByTarget))
-		count := 0
-		for _, series := range seriesByTarget {
-			if len(series) == 1 {
-				merged[count] = series[0]
-			} else {
-				//we use the first series in the list as our result.  We check over every
-				// point and if it is null, we then check the other series for a non null
-				// value to use instead.
-				for i, pt := range series[0].Datapoints {
-					if pt.Val == math.NaN() {
-						for j := 1; j < len(series); j++ {
-							if series[j].Datapoints[i].Val != math.NaN() {
-								pt.Val = series[j].Datapoints[i].Val
-								break
-							}
-						}
-					}
-				}
-				merged[count] = series[0]
-			}
-			count++
-		}
+		merged := mergeSeries(out)
 		sort.Sort(SeriesByTarget(merged))
 		js, err = graphiteJSON(js, merged)
 	} else {


### PR DESCRIPTION
Metrics can change over time while still maintaining the same
metric.Name. This can happen when tags are changed or when the
interval of a metric changes.  When this happens we need to merge
the multiple sets of metric points into a single set.

Though there can be more then one metricDef for a series, only
one of the metricDefs should be receiving data at any point in time.
So the approach for merging is to use the first non-null value
found for each timestamp in the result.