### PR TITLE
allow adding points to the latest, but already saved chunk

### DIFF
--- a/docs/instrumentation.md
+++ b/docs/instrumentation.md
@@ -1,2 +1,5 @@
 metrics
 grafana dashboard
+
+ alert on:
+add_to_saved_chunk for primary nodes

--- a/docs/instrumentation.md
+++ b/docs/instrumentation.md
@@ -1,5 +1,14 @@
 metrics
 grafana dashboard
 
- alert on:
-add_to_saved_chunk for primary nodes
+# useful metrics to monitor/alert on
+
+ * `add_to_saving_chunk`: points received - by the primary node - for the most recent chunk
+   when that chunk is already being saved (or has been saved).  
+   this indicates that your GC is actively sealing chunks and saving them before you have the chance to send
+   your (infrequent) updates.  The primary won't add them to its in-memory chunks, but secondaries will
+   (because they are never in "saving" state for them), see below.
+ * `add_to_saved_chunk`: points received - by a secondary node - for the most recent chunk when that chunk
+   has already been saved by a primary.  A secondary can add this data to its chunks.
+ * `metrics_too_old`: points that go back in time.  E.g. for any given series, when a point has a timestamp
+   that is not higher than the timestamp of the last written timestamp for that series.

--- a/mdata/aggmetric.go
+++ b/mdata/aggmetric.go
@@ -492,8 +492,8 @@ func (a *AggMetric) GC(chunkMinTs, metricMinTs uint32) bool {
 			if currentChunk.LastWrite < metricMinTs {
 				return true
 			}
-		} else {
-			// chunk has not been written to in a while. Lets persist it.
+		} else if !currentChunk.Saving {
+			// chunk hasn't been written to in a while, and is not yet queued to persist. Let's persist it
 			log.Info("Found stale Chunk, persisting it to Cassandra. key: %s T0: %d", a.Key, currentChunk.T0)
 			a.persist(a.CurrentChunkPos)
 		}

--- a/mdata/init.go
+++ b/mdata/init.go
@@ -11,7 +11,8 @@ var (
 	chunkCreate met.Count
 	chunkClear  met.Count
 
-	metricsTooOld met.Count
+	metricsTooOld   met.Count
+	addToSavedChunk met.Count
 
 	memToIterDuration met.Timer
 	persistDuration   met.Timer
@@ -25,6 +26,7 @@ func InitMetrics(stats met.Backend) {
 	chunkClear = stats.NewCount("chunks.clear")
 
 	metricsTooOld = stats.NewCount("metrics_too_old")
+	addToSavedChunk = stats.NewCount("add_to_saved_chunk")
 
 	memToIterDuration = stats.NewTimer("mem.to_iter_duration", 0)
 	persistDuration = stats.NewTimer("persist_duration", 0)

--- a/mdata/init.go
+++ b/mdata/init.go
@@ -11,8 +11,9 @@ var (
 	chunkCreate met.Count
 	chunkClear  met.Count
 
-	metricsTooOld   met.Count
-	addToSavedChunk met.Count
+	metricsTooOld    met.Count
+	addToSavingChunk met.Count
+	addToSavedChunk  met.Count
 
 	memToIterDuration met.Timer
 	persistDuration   met.Timer
@@ -26,6 +27,7 @@ func InitMetrics(stats met.Backend) {
 	chunkClear = stats.NewCount("chunks.clear")
 
 	metricsTooOld = stats.NewCount("metrics_too_old")
+	addToSavingChunk = stats.NewCount("add_to_saving_chunk")
 	addToSavedChunk = stats.NewCount("add_to_saved_chunk")
 
 	memToIterDuration = stats.NewTimer("mem.to_iter_duration", 0)


### PR DESCRIPTION
for primary nodes, this is undesirable, so monitor the metric
for non primaries, this alleviates scenarios where metrics processing falls behind
metricpersist processing

note that we still don't allow adding to any chunks but the latest,
because if we've created a newer chunk, that means data has existed for more recent data,
so this scenario indicates out of order messages, which is different than the out of sync
scenario.
