### PR TITLE
experimental: add kafka-all plugin for metrics + clustering

### DIFF
--- a/in/kafkaall/kafkaall.go
+++ b/in/kafkaall/kafkaall.go
@@ -1,0 +1,285 @@
+package kafkaall
+
+import (
+	"bytes"
+	"encoding/binary"
+	"encoding/json"
+	"flag"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/Shopify/sarama"
+	"github.com/raintank/worldping-api/pkg/log"
+	"github.com/rakyll/globalconf"
+
+	"github.com/bsm/sarama-cluster"
+	"github.com/raintank/met"
+	"github.com/raintank/metrictank/defcache"
+	"github.com/raintank/metrictank/in"
+	"github.com/raintank/metrictank/mdata"
+	"github.com/raintank/metrictank/usage"
+)
+
+var (
+	messagesPublished met.Count
+	messagesSize      met.Meter
+	sendErrProducer   met.Count
+	sendErrOther      met.Count
+)
+
+// KafkaAll is a consumer for metrics, as well as producer and consumer for cluster messages
+// all using the same topic, this enforces strong ordering between cluster msgs and metric msgs.
+type KafkaAll struct {
+	in.In
+	in       chan mdata.SavedChunk
+	consumer *cluster.Consumer
+	producer sarama.SyncProducer
+	stats    met.Backend
+	buf      []mdata.SavedChunk
+
+	instance string
+	mdata.Cl
+
+	wg sync.WaitGroup
+	// read from this channel to block until consumer is cleanly stopped
+	StopChan chan int
+}
+
+var LogLevel int
+var Enabled bool
+var brokerStr string
+var brokers []string
+var topicStr string
+var topics []string
+var group string
+var cconfig *cluster.Config
+var pconfig *sarama.Config
+var channelBufferSize int
+var consumerFetchMin int
+var consumerFetchDefault int
+var consumerMaxWaitTime string
+var consumerMaxProcessingTime string
+var netMaxOpenRequests int
+
+func ConfigSetup() {
+	fs := flag.NewFlagSet("kafka-all", flag.ExitOnError)
+	fs.BoolVar(&Enabled, "enabled", false, "")
+	fs.StringVar(&brokerStr, "brokers", "kafka:9092", "tcp address for kafka (may be be given multiple times as a comma-separated list)")
+	fs.StringVar(&topicStr, "topics", "mdm", "kafka topic (may be given multiple times as a comma-separated list. first one will be used for cluster production)")
+	fs.StringVar(&group, "group", "group1", "kafka consumer group")
+	fs.IntVar(&channelBufferSize, "channel-buffer-size", 1000000, "The number of metrics to buffer in internal and external channels")
+	fs.IntVar(&consumerFetchMin, "consumer-fetch-min", 1024000, "The minimum number of message bytes to fetch in a request")
+	fs.IntVar(&consumerFetchDefault, "consumer-fetch-default", 4096000, "The default number of message bytes to fetch in a request")
+	fs.StringVar(&consumerMaxWaitTime, "consumer-max-wait-time", "1s", "The maximum amount of time the broker will wait for Consumer.Fetch.Min bytes to become available before it returns fewer than that anyway")
+	fs.StringVar(&consumerMaxProcessingTime, "consumer-max-processing-time", "1s", "The maximum amount of time the consumer expects a message takes to process")
+	fs.IntVar(&netMaxOpenRequests, "net-max-open-requests", 100, "How many outstanding requests a connection is allowed to have before sending on it blocks")
+	globalconf.Register("kafka-all", fs)
+}
+
+func ConfigProcess(instance string) {
+	if !Enabled {
+		return
+	}
+
+	waitTime, err := time.ParseDuration(consumerMaxWaitTime)
+	if err != nil {
+		log.Fatal(4, "kafka-all invalid config, could not parse consumer-max-wait-time: %s", err)
+	}
+	processingTime, err := time.ParseDuration(consumerMaxProcessingTime)
+	if err != nil {
+		log.Fatal(4, "kafka-all invalid config, could not parse consumer-max-processing-time: %s", err)
+	}
+
+	brokers = strings.Split(brokerStr, ",")
+	topics = strings.Split(topicStr, ",")
+
+	cconfig = cluster.NewConfig()
+	// see https://github.com/raintank/metrictank/issues/236
+	cconfig.Consumer.Offsets.Initial = sarama.OffsetNewest
+	cconfig.ClientID = instance + "-all"
+	cconfig.Group.Return.Notifications = true
+	cconfig.ChannelBufferSize = channelBufferSize
+	cconfig.Consumer.Fetch.Min = int32(consumerFetchMin)
+	cconfig.Consumer.Fetch.Default = int32(consumerFetchDefault)
+	cconfig.Consumer.MaxWaitTime = waitTime
+	cconfig.Consumer.MaxProcessingTime = processingTime
+	cconfig.Net.MaxOpenRequests = netMaxOpenRequests
+	cconfig.Config.Version = sarama.V0_10_0_0
+	err = cconfig.Validate()
+	if err != nil {
+		log.Fatal(2, "kafka-all invalid config: %s", err)
+	}
+
+	pconfig = sarama.NewConfig()
+	pconfig.Producer.RequiredAcks = sarama.WaitForAll // Wait for all in-sync replicas to ack the message
+	pconfig.Producer.Retry.Max = 10                   // Retry up to 10 times to produce the message
+	pconfig.Producer.Compression = sarama.CompressionNone
+	pconfig.ClientID = instance + "-cluster"
+	err = pconfig.Validate()
+	if err != nil {
+		log.Fatal(2, "kafka-cluster invalid producer config: %s", err)
+	}
+}
+
+func New(instance string, metrics mdata.Metrics, stats met.Backend) *KafkaAll {
+	consumer, err := cluster.NewConsumer(brokers, group, topics, cconfig)
+	if err != nil {
+		log.Fatal(2, "kafka-all failed to start consumer: %s", err)
+	}
+	log.Info("kafka-all consumer started without error")
+
+	producer, err := sarama.NewSyncProducer(brokers, pconfig)
+	if err != nil {
+		log.Fatal(2, "kafka-all failed to start producer: %s", err)
+	}
+
+	k := KafkaAll{
+		in:       make(chan mdata.SavedChunk),
+		producer: producer,
+		consumer: consumer,
+		stats:    stats,
+		instance: instance,
+		Cl:       mdata.NewCl(instance, metrics),
+		StopChan: make(chan int),
+	}
+
+	messagesPublished = stats.NewCount("cluster.messages-published")
+	messagesSize = stats.NewMeter("cluster.message_size", 0)
+	sendErrProducer = stats.NewCount("cluster.errors.producer")
+	sendErrOther = stats.NewCount("cluster.errors.other")
+
+	return &k
+}
+
+func (k *KafkaAll) Start(metrics mdata.Metrics, defCache *defcache.DefCache, usg *usage.Usage) {
+	k.In = in.New(metrics, defCache, usg, "kafka-all", k.stats)
+	go k.notifications()
+	go k.consume()
+}
+
+func (k *KafkaAll) consume() {
+	k.wg.Add(1)
+	messageChan := k.consumer.Messages()
+	for msg := range messageChan {
+		if LogLevel < 2 {
+			log.Debug("kafka-all received message: Topic %s, Partition: %d, Offset: %d, Key: %x", msg.Topic, msg.Partition, msg.Offset, msg.Key)
+		}
+		// TODO: figure out which it is
+		// persist:
+		k.Cl.Handle(msg.Value)
+		// regular:
+		k.In.Handle(msg.Key, msg.Value)
+
+		k.consumer.MarkOffset(msg, "")
+	}
+	log.Info("kafka-all consumer ended.")
+	k.wg.Done()
+}
+
+func (k *KafkaAll) notifications() {
+	k.wg.Add(1)
+	for msg := range k.consumer.Notifications() {
+		if len(msg.Claimed) > 0 {
+			for topic, partitions := range msg.Claimed {
+				log.Info("kafka-all consumer claimed %d partitions on topic: %s", len(partitions), topic)
+			}
+		}
+		if len(msg.Released) > 0 {
+			for topic, partitions := range msg.Released {
+				log.Info("kafka-all consumer released %d partitions on topic: %s", len(partitions), topic)
+			}
+		}
+
+		if len(msg.Current) == 0 {
+			log.Info("kafka-all consumer is no longer consuming from any partitions.")
+		} else {
+			log.Info("kafka-all Current partitions:")
+			for topic, partitions := range msg.Current {
+				log.Info("kafka-all Current partitions: %s: %v", topic, partitions)
+			}
+		}
+	}
+	log.Info("kafka-all notification processing stopped")
+	k.wg.Done()
+}
+
+// Stop will initiate a graceful stop of the Consumer (permanent)
+//
+// NOTE: receive on StopChan to block until this process completes
+func (k *KafkaAll) Stop() {
+	// closes notifications and messages channels, amongst others
+	k.consumer.Close()
+	k.producer.Close()
+
+	go func() {
+		k.wg.Wait()
+		close(k.StopChan)
+	}()
+}
+
+func (c *KafkaAll) Send(sc mdata.SavedChunk) {
+	c.in <- sc
+}
+
+func (c *KafkaAll) produce() {
+	ticker := time.NewTicker(time.Second)
+	max := 5000
+	for {
+		select {
+		case chunk := <-c.in:
+			c.buf = append(c.buf, chunk)
+			if len(c.buf) == max {
+				c.flush()
+			}
+		case <-ticker.C:
+			if len(c.buf) != 0 {
+				c.flush()
+			}
+		}
+	}
+}
+
+// flush makes sure the batch gets sent, asynchronously.
+func (c *KafkaAll) flush() {
+
+	log.Debug("CLU kafka-all sending %d batch metricPersist messages", len(c.buf))
+
+	payload := make([]*sarama.ProducerMessage, len(c.buf))
+	//pre := time.Now()
+
+	for i, sc := range c.buf {
+		msg := mdata.PersistMessage{Instance: c.instance, Key: sc.Key, T0: sc.T0}
+		data, err := json.Marshal(&msg)
+		if err != nil {
+			log.Fatal(4, "CLU kafka-all failed to marshal persistMessage to json.")
+		}
+
+		buf := new(bytes.Buffer)
+		binary.Write(buf, binary.LittleEndian, uint8(mdata.PersistMessageBatchV1))
+		buf.Write(data)
+		messagesSize.Value(int64(buf.Len()))
+
+		payload[i] = &sarama.ProducerMessage{
+			Key:   sarama.ByteEncoder(sc.PartKey),
+			Topic: topics[0],
+			Value: sarama.ByteEncoder(buf.Bytes()),
+		}
+		messagesSize.Value(int64(len(data)))
+	}
+	c.buf = nil
+	err := c.producer.SendMessages(payload)
+	if err != nil {
+		if errors, ok := err.(sarama.ProducerErrors); ok {
+			sendErrProducer.Inc(int64(len(errors)))
+			for i := 0; i < 10 && i < len(errors); i++ {
+				log.Error(4, "SendMessages ProducerError %d/%d: %s", i, len(errors), errors[i].Error())
+			}
+		} else {
+			sendErrOther.Inc(1)
+			log.Error(4, "SendMessages error: %s", err.Error())
+		}
+		return
+	}
+	messagesPublished.Inc(int64(len(payload)))
+}

--- a/in/kafkamdm/kafkamdm.go
+++ b/in/kafkamdm/kafkamdm.go
@@ -121,7 +121,7 @@ func (k *KafkaMdm) consume() {
 		if LogLevel < 2 {
 			log.Debug("kafka-mdm received message: Topic %s, Partition: %d, Offset: %d, Key: %x", msg.Topic, msg.Partition, msg.Offset, msg.Key)
 		}
-		k.In.Handle(msg.Value)
+		k.In.Handle(msg.Key, msg.Value)
 		k.consumer.MarkOffset(msg, "")
 	}
 	log.Info("kafka-mdm consumer ended.")

--- a/mdata/aggmetric.go
+++ b/mdata/aggmetric.go
@@ -30,11 +30,12 @@ type AggMetric struct {
 	aggregators     []*Aggregator
 	firstChunkT0    uint32
 	ttl             uint32
+	partKey         []byte // used with kafkaall, to route persist messages with same key as the metric came in with
 }
 
 // NewAggMetric creates a metric with given key, it retains the given number of chunks each chunkSpan seconds long
 // it optionally also creates aggregations with the given settings
-func NewAggMetric(store Store, key string, chunkSpan, numChunks uint32, ttl uint32, aggsetting ...AggSetting) *AggMetric {
+func NewAggMetric(store Store, key string, chunkSpan, numChunks uint32, ttl uint32, partKey []byte, aggsetting ...AggSetting) *AggMetric {
 	m := AggMetric{
 		store:     store,
 		Key:       key,
@@ -42,9 +43,10 @@ func NewAggMetric(store Store, key string, chunkSpan, numChunks uint32, ttl uint
 		NumChunks: numChunks,
 		Chunks:    make([]*chunk.Chunk, 0, numChunks),
 		ttl:       ttl,
+		partKey:   partKey,
 	}
 	for _, as := range aggsetting {
-		m.aggregators = append(m.aggregators, NewAggregator(store, key, as.Span, as.ChunkSpan, as.NumChunks, as.Ttl))
+		m.aggregators = append(m.aggregators, NewAggregator(store, key, partKey, as.Span, as.ChunkSpan, as.NumChunks, as.Ttl))
 	}
 
 	return &m
@@ -348,6 +350,7 @@ func (a *AggMetric) persist(pos int) {
 		chunk:     chunk,
 		ttl:       a.ttl,
 		timestamp: time.Now(),
+		partKey:   a.partKey,
 	}
 
 	// if we recently became the primary, there may be older chunks
@@ -367,6 +370,7 @@ func (a *AggMetric) persist(pos int) {
 			chunk:     previousChunk,
 			ttl:       a.ttl,
 			timestamp: time.Now(),
+			partKey:   a.partKey,
 		})
 		previousPos--
 		if previousPos < 0 {

--- a/mdata/aggmetrics.go
+++ b/mdata/aggmetrics.go
@@ -95,11 +95,11 @@ func (ms *AggMetrics) Get(key string) (Metric, bool) {
 	return m, ok
 }
 
-func (ms *AggMetrics) GetOrCreate(key string) Metric {
+func (ms *AggMetrics) GetOrCreate(key string, partKey []byte) Metric {
 	ms.Lock()
 	m, ok := ms.Metrics[key]
 	if !ok {
-		m = NewAggMetric(ms.store, key, ms.chunkSpan, ms.numChunks, ms.ttl, ms.aggSettings...)
+		m = NewAggMetric(ms.store, key, ms.chunkSpan, ms.numChunks, ms.ttl, partKey, ms.aggSettings...)
 		ms.Metrics[key] = m
 	}
 	ms.Unlock()

--- a/mdata/aggregator.go
+++ b/mdata/aggregator.go
@@ -45,15 +45,15 @@ type Aggregator struct {
 	cntMetric       *AggMetric
 }
 
-func NewAggregator(store Store, key string, aggSpan, aggChunkSpan, aggNumChunks uint32, ttl uint32) *Aggregator {
+func NewAggregator(store Store, key string, partKey []byte, aggSpan, aggChunkSpan, aggNumChunks uint32, ttl uint32) *Aggregator {
 	return &Aggregator{
 		key:       key,
 		span:      aggSpan,
 		agg:       NewAggregation(),
-		minMetric: NewAggMetric(store, fmt.Sprintf("%s_min_%d", key, aggSpan), aggChunkSpan, aggNumChunks, ttl),
-		maxMetric: NewAggMetric(store, fmt.Sprintf("%s_max_%d", key, aggSpan), aggChunkSpan, aggNumChunks, ttl),
-		sumMetric: NewAggMetric(store, fmt.Sprintf("%s_sum_%d", key, aggSpan), aggChunkSpan, aggNumChunks, ttl),
-		cntMetric: NewAggMetric(store, fmt.Sprintf("%s_cnt_%d", key, aggSpan), aggChunkSpan, aggNumChunks, ttl),
+		minMetric: NewAggMetric(store, fmt.Sprintf("%s_min_%d", key, aggSpan), aggChunkSpan, aggNumChunks, ttl, partKey),
+		maxMetric: NewAggMetric(store, fmt.Sprintf("%s_max_%d", key, aggSpan), aggChunkSpan, aggNumChunks, ttl, partKey),
+		sumMetric: NewAggMetric(store, fmt.Sprintf("%s_sum_%d", key, aggSpan), aggChunkSpan, aggNumChunks, ttl, partKey),
+		cntMetric: NewAggMetric(store, fmt.Sprintf("%s_cnt_%d", key, aggSpan), aggChunkSpan, aggNumChunks, ttl, partKey),
 	}
 }
 func (agg *Aggregator) flush() {

--- a/mdata/cwr.go
+++ b/mdata/cwr.go
@@ -19,4 +19,5 @@ type ChunkWriteRequest struct {
 	chunk     *chunk.Chunk
 	ttl       uint32
 	timestamp time.Time
+	partKey   []byte
 }

--- a/mdata/ifaces.go
+++ b/mdata/ifaces.go
@@ -5,7 +5,7 @@ import "github.com/raintank/metrictank/iter"
 
 type Metrics interface {
 	Get(key string) (Metric, bool)
-	GetOrCreate(key string) Metric
+	GetOrCreate(key string, partKey []byte) Metric
 }
 
 type Metric interface {

--- a/mdata/store_cassandra.go
+++ b/mdata/store_cassandra.go
@@ -164,7 +164,7 @@ func (c *cassandraStore) processWriteQueue(queue chan *ChunkWriteRequest, meter 
 				if err == nil {
 					success = true
 					cwr.chunk.Saved = true
-					SendPersistMessage(cwr.key, cwr.chunk.T0)
+					SendPersistMessage(cwr.key, cwr.chunk.T0, cwr.partKey)
 					log.Debug("CS: save complete. %s:%d %v", cwr.key, cwr.chunk.T0, cwr.chunk)
 					chunkSaveOk.Inc(1)
 				} else {

--- a/metrictank-sample.ini
+++ b/metrictank-sample.ini
@@ -131,7 +131,28 @@ addr = :2003
 # needed to know your raw resolution for your metrics. see http://graphite.readthedocs.io/en/latest/config-carbon.html#storage-schemas-conf
 schemas-file = /path/to/your/schemas-file
 
-## kafka-mdm input (optional, recommended)
+## kafka-all input (optional, recommended)
+## it's like mdm but also cluster msgs in same topic
+[kafka-all]
+enabled = false
+# tcp address (may be given multiple times as a comma-separated list)
+brokers = kafka:9092
+# kafka topic (may be given multiple times as a comma-separated list)
+topics = mdm
+# consumer group name
+group = group1
+# The minimum number of message bytes to fetch in a request
+consumer-fetch-min = 1024000
+# The default number of message bytes to fetch in a request
+consumer-fetch-default = 4096000
+# The maximum amount of time the broker will wait for Consumer.Fetch.Min bytes to become available before it
+consumer-max-wait-time = 1s
+#The maximum amount of time the consumer expects a message takes to process
+consumer-max-processing-time = 1s
+# How many outstanding requests a connection is allowed to have before sending on it blocks
+consumer-fetch-default = 100
+
+## kafka-mdm input (optional)
 [kafka-mdm-in]
 enabled = false
 # tcp address (may be given multiple times as a comma-separated list)

--- a/usage/usage.go
+++ b/usage/usage.go
@@ -101,7 +101,7 @@ func (u *Usage) Report() {
 		met.Value = val
 		met.SetId()
 
-		m := metrics.GetOrCreate(met.Id)
+		m := metrics.GetOrCreate(met.Id, nil) // TODO: usage metrics should have an appropriate partition key so they end up with their org
 		m.Add(uint32(met.Time), met.Value)
 		defCache.Add(met)
 	}


### PR DESCRIPTION
see https://github.com/raintank/metrictank/pull/263#issuecomment-236657454

I'm actually not a big fan anymore of this approach, maybe we can do something simpler. especially since we now have a new prod environment that's up and running, and migrating to different clustering messages with different header etc is going to be messy.
I like @woodsaj's idea at https://github.com/raintank/metrictank/pull/74#discussion_r47485075

tasks left todo if we want to persue this method:
* test this
* fix broken unit tests
* partKey for usage metrics?
* add metadata blocks to messages to differentiate between metrics and metricpersist messages.
  integrating this into existing stack is going to be messy.