### PR TITLE
implement "offset fencing" between kafka cluster and metric messages

### DIFF
--- a/mdata/clkafka.go
+++ b/mdata/clkafka.go
@@ -5,6 +5,7 @@ import (
 	"encoding/binary"
 	"encoding/json"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/Shopify/sarama"
@@ -137,6 +138,9 @@ func (c *ClKafka) flush() {
 	}
 
 	msg := PersistMessageBatch{Instance: c.instance, SavedChunks: c.buf}
+	if OffsetFence != nil {
+		msg.OffsetFence = atomic.LoadInt64(OffsetFence)
+	}
 	c.buf = nil
 
 	go func() {

--- a/mdata/init.go
+++ b/mdata/init.go
@@ -18,6 +18,8 @@ var (
 
 	metricsActive met.Gauge
 	gcMetric      met.Count // metrics GC
+
+	OffsetFence *int64 // when using kafka for metrics and clustering, points to the offset of a kafka metrics stream to guarantee some synchronisation between cluster and metrics feeds
 )
 
 func InitMetrics(stats met.Backend) {

--- a/metrictank.go
+++ b/metrictank.go
@@ -320,6 +320,11 @@ func main() {
 	if clKafka.Enabled {
 		clKafkaInst = mdata.NewKafka(*instance, metrics, stats)
 		handlers = append(handlers, clKafkaInst)
+
+		// if we use kafka for clustering and the kafka-mdm, then synchronize them
+		if inKafkaMdm.Enabled {
+			mdata.OffsetFence = new(int64)
+		}
 	}
 
 	mdata.InitCluster(stats, handlers...)


### PR DESCRIPTION
so that we can guarantee that when processing metricpersist messages,
the required metrics messages have been processed.

see #263 
based on the idea in https://github.com/raintank/metrictank/pull/74#discussion_r47485075
I think I like this a lot more then #264 