### PR TITLE
config fixes

### DIFF
--- a/docs/config.md
+++ b/docs/config.md
@@ -171,13 +171,13 @@ data-dir =
 # The minimum number of message bytes to fetch in a request
 consumer-fetch-min = 1
 # The default number of message bytes to fetch in a request
-consumer-fetch-default = 4096000
+consumer-fetch-default = 32768
 # The maximum amount of time the broker will wait for Consumer.Fetch.Min bytes to become available before it
 consumer-max-wait-time = 1s
 #The maximum amount of time the consumer expects a message takes to process
 consumer-max-processing-time = 1s
 # How many outstanding requests a connection is allowed to have before sending on it blocks
-consumer-fetch-default = 100
+net-max-open-requests = 100
 ```
 
 ### kafka-mdam input (optional, discouraged)

--- a/in/kafkamdm/kafkamdm.go
+++ b/in/kafkamdm/kafkamdm.go
@@ -61,7 +61,7 @@ func ConfigSetup() {
 	inKafkaMdm.StringVar(&dataDir, "data-dir", "", "Directory to store partition offsets index")
 	inKafkaMdm.IntVar(&channelBufferSize, "channel-buffer-size", 1000000, "The number of metrics to buffer in internal and external channels")
 	inKafkaMdm.IntVar(&consumerFetchMin, "consumer-fetch-min", 1, "The minimum number of message bytes to fetch in a request")
-	inKafkaMdm.IntVar(&consumerFetchDefault, "consumer-fetch-default", 4096000, "The default number of message bytes to fetch in a request")
+	inKafkaMdm.IntVar(&consumerFetchDefault, "consumer-fetch-default", 32768, "The default number of message bytes to fetch in a request")
 	inKafkaMdm.DurationVar(&consumerMaxWaitTime, "consumer-max-wait-time", time.Second, "The maximum amount of time the broker will wait for Consumer.Fetch.Min bytes to become available before it returns fewer than that anyway")
 	inKafkaMdm.DurationVar(&consumerMaxProcessingTime, "consumer-max-processing-time", time.Second, "The maximum amount of time the consumer expects a message takes to process")
 	inKafkaMdm.IntVar(&netMaxOpenRequests, "net-max-open-requests", 100, "How many outstanding requests a connection is allowed to have before sending on it blocks")

--- a/metrictank-sample.ini
+++ b/metrictank-sample.ini
@@ -149,17 +149,16 @@ offset-commit-interval = 5s
 # directory to store partition offsets index. supports relative or absolute paths. empty means working dir.
 # it will be created (incl parent dirs) if not existing.
 data-dir =
-
 # The minimum number of message bytes to fetch in a request
 consumer-fetch-min = 1
 # The default number of message bytes to fetch in a request
-consumer-fetch-default = 4096000
+consumer-fetch-default = 32768
 # The maximum amount of time the broker will wait for Consumer.Fetch.Min bytes to become available before it
 consumer-max-wait-time = 1s
 #The maximum amount of time the consumer expects a message takes to process
 consumer-max-processing-time = 1s
 # How many outstanding requests a connection is allowed to have before sending on it blocks
-consumer-fetch-default = 100
+net-max-open-requests = 100
 
 ### kafka-mdam input (optional, discouraged)
 [kafka-mdam-in]

--- a/scripts/config/metrictank-docker.ini
+++ b/scripts/config/metrictank-docker.ini
@@ -146,17 +146,16 @@ offset-commit-interval = 5s
 # directory to store partition offsets index. supports relative or absolute paths. empty means working dir.
 # it will be created (incl parent dirs) if not existing.
 data-dir = /var/lib/metrictank
-
 # The minimum number of message bytes to fetch in a request
 consumer-fetch-min = 1
 # The default number of message bytes to fetch in a request
-consumer-fetch-default = 4096000
+consumer-fetch-default = 32768
 # The maximum amount of time the broker will wait for Consumer.Fetch.Min bytes to become available before it
 consumer-max-wait-time = 1s
 #The maximum amount of time the consumer expects a message takes to process
 consumer-max-processing-time = 1s
 # How many outstanding requests a connection is allowed to have before sending on it blocks
-consumer-fetch-default = 100
+net-max-open-requests = 100
 
 ### kafka-mdam input (optional, discouraged)
 [kafka-mdam-in]

--- a/scripts/config/metrictank-package.ini
+++ b/scripts/config/metrictank-package.ini
@@ -146,17 +146,16 @@ offset-commit-interval = 5s
 # directory to store partition offsets index. supports relative or absolute paths. empty means working dir.
 # it will be created (incl parent dirs) if not existing.
 data-dir = /var/lib/metrictank
-
 # The minimum number of message bytes to fetch in a request
 consumer-fetch-min = 1
 # The default number of message bytes to fetch in a request
-consumer-fetch-default = 4096000
+consumer-fetch-default = 32768
 # The maximum amount of time the broker will wait for Consumer.Fetch.Min bytes to become available before it
 consumer-max-wait-time = 1s
 #The maximum amount of time the consumer expects a message takes to process
 consumer-max-processing-time = 1s
 # How many outstanding requests a connection is allowed to have before sending on it blocks
-consumer-fetch-default = 100
+net-max-open-requests = 100
 
 ### kafka-mdam input (optional, discouraged)
 [kafka-mdam-in]


### PR DESCRIPTION
* set consumer-fetch-default to sarama default of 32768, our messages
  should really fit in that anyway.
* fix bug that was resetting consumer-fetch-default to 100