### PR TITLE
display request information when it causes a panic.

### DIFF
--- a/metrictank.go
+++ b/metrictank.go
@@ -382,13 +382,13 @@ func main() {
 
 	go func() {
 		http.HandleFunc("/", appStatus)
-		http.HandleFunc("/get", get(store, metricIndex, finalSettings, logMinDur))                        // metrictank native api which deals with ID's, not target strings
-		http.HandleFunc("/get/", get(store, metricIndex, finalSettings, logMinDur))                       // metrictank native api which deals with ID's, not target strings
-		http.HandleFunc("/render", corsHandler(getLegacy(store, metricIndex, finalSettings, logMinDur)))  // traditional graphite api, still lacking a lot of the api
-		http.HandleFunc("/render/", corsHandler(getLegacy(store, metricIndex, finalSettings, logMinDur))) // traditional graphite api, still lacking a lot of the api
-		http.HandleFunc("/metrics/index.json", corsHandler(IndexJson(metricIndex)))
-		http.HandleFunc("/metrics/find", corsHandler(Find(metricIndex)))
-		http.HandleFunc("/metrics/find/", corsHandler(Find(metricIndex)))
+		http.Handle("/get", RecoveryHandler(get(store, metricIndex, finalSettings, logMinDur)))                        // metrictank native api which deals with ID's, not target strings
+		http.Handle("/get/", RecoveryHandler(get(store, metricIndex, finalSettings, logMinDur)))                       // metrictank native api which deals with ID's, not target strings
+		http.Handle("/render", RecoveryHandler(corsHandler(getLegacy(store, metricIndex, finalSettings, logMinDur))))  // traditional graphite api, still lacking a lot of the api
+		http.Handle("/render/", RecoveryHandler(corsHandler(getLegacy(store, metricIndex, finalSettings, logMinDur)))) // traditional graphite api, still lacking a lot of the api
+		http.Handle("/metrics/index.json", RecoveryHandler(corsHandler(IndexJson(metricIndex))))
+		http.Handle("/metrics/find", RecoveryHandler(corsHandler(Find(metricIndex))))
+		http.Handle("/metrics/find/", RecoveryHandler(corsHandler(Find(metricIndex))))
 		http.HandleFunc("/cluster", mdata.CluStatus.HttpHandler)
 		http.HandleFunc("/cluster/", mdata.CluStatus.HttpHandler)
 		log.Info("starting listener for metrics and http/debug on %s", *listenAddr)

--- a/recovery.go
+++ b/recovery.go
@@ -1,0 +1,42 @@
+package main
+
+import (
+	"net/http"
+	"runtime"
+
+	"github.com/raintank/worldping-api/pkg/log"
+)
+
+type recoveryHandler struct {
+	handler http.Handler
+}
+
+// RecoveryHandler is HTTP middleware that recovers from a panic,
+// logs the panic as well as details about the request
+// and writes http.StatusInternalServerError.
+func RecoveryHandler(h http.Handler) http.Handler {
+	return &recoveryHandler{handler: h}
+}
+
+func (h recoveryHandler) ServeHTTP(w http.ResponseWriter, req *http.Request) {
+	defer func() {
+		if err := recover(); err != nil {
+			const size = 64 << 10
+			buf := make([]byte, size)
+			buf = buf[:runtime.Stack(buf, false)]
+			log.Error(1, `panic serving %v: %v
+%sRequest details:
+Method: %s
+URL: %s
+Headers: %q
+Trailer: %q
+Body: not available
+Formdata: %q
+`, req.RemoteAddr, err, buf, req.Method, req.URL, req.Header, req.Trailer, req.Form)
+
+			w.WriteHeader(http.StatusInternalServerError)
+		}
+	}()
+
+	h.handler.ServeHTTP(w, req)
+}


### PR DESCRIPTION
instead of using the built-in net/http panic logger which just logs
remoteAddr and stacktrace, also display request information, so we
can more easily replicate and diagnose when any request triggers
a panic

For example, with the following code change:
```
diff --git a/http.go b/http.go
index 549171a..dceed6a 100644
--- a/http.go
+++ b/http.go
@@ -325,6 +325,11 @@ func Get(w http.ResponseWriter, req *http.Request,
store mdata.Store, metricInde
                }
        }

+       t := time.Now().Unix()
+       if t%10 == 0 {
+               panic("time divides by 10")
+       }
+
        reqs, err = alignRequests(reqs, aggSettings)
        if err != nil {
```

It will log entries like:

```
2016/09/08 19:38:10 [log.go:312 Error()] [E] panic serving 172.19.0.11:56064: time divides by 10
goroutine 539 [running]:
main.recoveryHandler.ServeHTTP.func1(0xc4206793b0, 0xc8a180, 0xc423538b60)
	/home/dieter/go/src/github.com/raintank/metrictank/recovery.go:26 +0xbc
panic(0x91d780, 0xc423653630)
	/home/dieter/code/go/src/runtime/panic.go:458 +0x243
main.Get(0xc8a180, 0xc423538b60, 0xc4206793b0, 0xc89a00, 0xc4201ba580, 0xc8d600, 0xc4201b6180, 0xc4201be190, 0x3, 0x4, ...)
	/home/dieter/go/src/github.com/raintank/metrictank/http.go:330 +0x2686
main.getLegacy.func1(0xc8a180, 0xc423538b60, 0xc4206793b0)
	/home/dieter/go/src/github.com/raintank/metrictank/http.go:180 +0x94
main.corsHandler.func1(0xc8a180, 0xc423538b60, 0xc4206793b0)
	/home/dieter/go/src/github.com/raintank/metrictank/http.go:51 +0xf6
net/http.HandlerFunc.ServeHTTP(0xc421d5edf0, 0xc8a180, 0xc423538b60, 0xc4206793b0)
	/home/dieter/code/go/src/net/http/server.go:1726 +0x44
main.recoveryHandler.ServeHTTP(0xc864c0, 0xc421d5edf0, 0xc8a180, 0xc423538b60, 0xc4206793b0)
	/home/dieter/go/src/github.com/raintank/metrictank/recovery.go:41 +0x8d
main.(*recoveryHandler).ServeHTTP(0xc421d5ee00, 0xc8a180, 0xc423538b60, 0xc4206793b0)
	<autogenerated>:10 +0x79
net/http.(*ServeMux).ServeHTTP(0xcaebe0, 0xc8a180, 0xc423538b60, 0xc4206793b0)
	/home/dieter/code/go/src/net/http/server.go:2022 +0x7f
net/http.serverHandler.ServeHTTP(0xc4201a8a00, 0xc8a180, 0xc423538b60, 0xc4206793b0)
	/home/dieter/code/go/src/net/http/server.go:2202 +0x7d
net/http.(*conn).serve(0xc42364a900, 0xc8abc0, 0xc42353d940)
	/home/dieter/code/go/src/net/http/server.go:1579 +0x4b7
created by net/http.(*Server).Serve
	/home/dieter/code/go/src/net/http/server.go:2293 +0x44d
Request details:
Method: POST
URL: /render
Headers: map["Content-Length":["408"] "Content-Type":["application/x-www-form-urlencoded"] "Connection":["keep-alive"] "Accept-Encoding":["gzip, deflate"] "Accept":["*/*"] "User-Agent":["graphite_raintank"] "X-Org-Id":["1"]]
Trailer: map[]
Body: not available
Formdata: map["to":["1473363490"] "from":["1473363190"] "target":["some.id.of.a.metric.1" "some.id.of.a.metric.10" "some.id.of.a.metric.100" "some.id.of.a.metric.11" "some.id.of.a.metric.12" "some.id.of.a.metric.13" "some.id.of.a.metric.14" "some.id.of.a.metric.15" "some.id.of.a.metric.16" "some.id.of.a.metric.17" "some.id.of.a.metric.18" "some.id.of.a.metric.19"] "maxDataPoints":["1904"]]
```

In particular, this should help us track down #306 much more easily.