### PR TITLE
Filter search by from ts

### DIFF
--- a/http.go
+++ b/http.go
@@ -273,7 +273,7 @@ func Get(w http.ResponseWriter, req *http.Request, store mdata.Store, metricInde
 		}
 
 		if legacy {
-			nodes, err := metricIndex.Find(org, id)
+			nodes, err := metricIndex.Find(org, id, int64(fromUnix))
 			if err != nil {
 				http.Error(w, err.Error(), http.StatusBadRequest)
 				return
@@ -385,6 +385,8 @@ func Find(metricIndex idx.MetricIndex) http.HandlerFunc {
 		format := r.FormValue("format")
 		jsonp := r.FormValue("jsonp")
 		query := r.FormValue("query")
+		from, _ := strconv.ParseInt(r.FormValue("from"), 10, 64)
+
 		org, err := getOrg(r)
 		if err != nil {
 			http.Error(w, err.Error(), http.StatusBadRequest)
@@ -401,7 +403,7 @@ func Find(metricIndex idx.MetricIndex) http.HandlerFunc {
 			return
 		}
 
-		nodes, err := metricIndex.Find(org, query)
+		nodes, err := metricIndex.Find(org, query, from)
 		if err != nil {
 			http.Error(w, err.Error(), http.StatusBadRequest)
 			return

--- a/idx/cassandra/cassandra_test.go
+++ b/idx/cassandra/cassandra_test.go
@@ -129,7 +129,7 @@ func TestFind(t *testing.T) {
 
 	Convey("When listing root nodes", t, func() {
 		Convey("root nodes for orgId 1", func() {
-			nodes, err := ix.Find(1, "*")
+			nodes, err := ix.Find(1, "*", 0)
 			So(err, ShouldBeNil)
 			So(nodes, ShouldHaveLength, 2)
 			So(nodes[0].Path, ShouldBeIn, "metric", "foo")
@@ -137,7 +137,7 @@ func TestFind(t *testing.T) {
 			So(nodes[0].Leaf, ShouldBeFalse)
 		})
 		Convey("root nodes for orgId 2", func() {
-			nodes, err := ix.Find(2, "*")
+			nodes, err := ix.Find(2, "*", 0)
 			So(err, ShouldBeNil)
 			So(nodes, ShouldHaveLength, 1)
 			So(nodes[0].Path, ShouldEqual, "metric")
@@ -146,7 +146,7 @@ func TestFind(t *testing.T) {
 	})
 
 	Convey("When searching with GLOB", t, func() {
-		nodes, err := ix.Find(2, "metric.{f*,demo}.*")
+		nodes, err := ix.Find(2, "metric.{f*,demo}.*", 0)
 		So(err, ShouldBeNil)
 		So(nodes, ShouldHaveLength, 10)
 		for _, n := range nodes {
@@ -155,7 +155,7 @@ func TestFind(t *testing.T) {
 	})
 
 	Convey("When searching with multiple wildcards", t, func() {
-		nodes, err := ix.Find(1, "*.*")
+		nodes, err := ix.Find(1, "*.*", 0)
 		So(err, ShouldBeNil)
 		So(nodes, ShouldHaveLength, 2)
 		for _, n := range nodes {
@@ -164,24 +164,24 @@ func TestFind(t *testing.T) {
 	})
 
 	Convey("When searching nodes not in public series", t, func() {
-		nodes, err := ix.Find(1, "foo.demo.*")
+		nodes, err := ix.Find(1, "foo.demo.*", 0)
 		So(err, ShouldBeNil)
 		So(nodes, ShouldHaveLength, 5)
 		Convey("When searching for specific series", func() {
-			found, err := ix.Find(1, nodes[0].Path)
+			found, err := ix.Find(1, nodes[0].Path, 0)
 			So(err, ShouldBeNil)
 			So(found, ShouldHaveLength, 1)
 			So(found[0].Path, ShouldEqual, nodes[0].Path)
 		})
 		Convey("When searching nodes that are children of a leaf", func() {
-			found, err := ix.Find(1, nodes[0].Path+".*")
+			found, err := ix.Find(1, nodes[0].Path+".*", 0)
 			So(err, ShouldBeNil)
 			So(found, ShouldHaveLength, 0)
 		})
 	})
 
 	Convey("When searching with multiple wildcards mixed leaf/branch", t, func() {
-		nodes, err := ix.Find(1, "*.demo.*")
+		nodes, err := ix.Find(1, "*.demo.*", 0)
 		So(err, ShouldBeNil)
 		So(nodes, ShouldHaveLength, 15)
 		for _, n := range nodes {
@@ -194,13 +194,13 @@ func TestFind(t *testing.T) {
 		}
 	})
 	Convey("When searching nodes for unkown orgId", t, func() {
-		nodes, err := ix.Find(4, "foo.demo.*")
+		nodes, err := ix.Find(4, "foo.demo.*", 0)
 		So(err, ShouldBeNil)
 		So(nodes, ShouldHaveLength, 0)
 	})
 
 	Convey("When searching nodes that dont exist", t, func() {
-		nodes, err := ix.Find(1, "foo.demo.blah.*")
+		nodes, err := ix.Find(1, "foo.demo.blah.*", 0)
 		So(err, ShouldBeNil)
 		So(nodes, ShouldHaveLength, 0)
 	})

--- a/idx/elasticsearch/elasticsearch_test.go
+++ b/idx/elasticsearch/elasticsearch_test.go
@@ -222,7 +222,7 @@ func TestFind(t *testing.T) {
 
 	Convey("When listing root nodes", t, func() {
 		Convey("root nodes for orgId 1", func() {
-			nodes, err := ix.Find(1, "*")
+			nodes, err := ix.Find(1, "*", 0)
 			So(err, ShouldBeNil)
 			So(nodes, ShouldHaveLength, 2)
 			So(nodes[0].Path, ShouldBeIn, "metric", "foo")
@@ -230,7 +230,7 @@ func TestFind(t *testing.T) {
 			So(nodes[0].Leaf, ShouldBeFalse)
 		})
 		Convey("root nodes for orgId 2", func() {
-			nodes, err := ix.Find(2, "*")
+			nodes, err := ix.Find(2, "*", 0)
 			So(err, ShouldBeNil)
 			So(nodes, ShouldHaveLength, 1)
 			So(nodes[0].Path, ShouldEqual, "metric")
@@ -239,7 +239,7 @@ func TestFind(t *testing.T) {
 	})
 
 	Convey("When searching with GLOB", t, func() {
-		nodes, err := ix.Find(2, "metric.{f*,demo}.*")
+		nodes, err := ix.Find(2, "metric.{f*,demo}.*", 0)
 		So(err, ShouldBeNil)
 		So(nodes, ShouldHaveLength, 10)
 		for _, n := range nodes {
@@ -248,7 +248,7 @@ func TestFind(t *testing.T) {
 	})
 
 	Convey("When searching with multiple wildcards", t, func() {
-		nodes, err := ix.Find(1, "*.*")
+		nodes, err := ix.Find(1, "*.*", 0)
 		So(err, ShouldBeNil)
 		So(nodes, ShouldHaveLength, 2)
 		for _, n := range nodes {
@@ -257,24 +257,24 @@ func TestFind(t *testing.T) {
 	})
 
 	Convey("When searching nodes not in public series", t, func() {
-		nodes, err := ix.Find(1, "foo.demo.*")
+		nodes, err := ix.Find(1, "foo.demo.*", 0)
 		So(err, ShouldBeNil)
 		So(nodes, ShouldHaveLength, 5)
 		Convey("When searching for specific series", func() {
-			found, err := ix.Find(1, nodes[0].Path)
+			found, err := ix.Find(1, nodes[0].Path, 0)
 			So(err, ShouldBeNil)
 			So(found, ShouldHaveLength, 1)
 			So(found[0].Path, ShouldEqual, nodes[0].Path)
 		})
 		Convey("When searching nodes that are children of a leaf", func() {
-			found, err := ix.Find(1, nodes[0].Path+".*")
+			found, err := ix.Find(1, nodes[0].Path+".*", 0)
 			So(err, ShouldBeNil)
 			So(found, ShouldHaveLength, 0)
 		})
 	})
 
 	Convey("When searching with multiple wildcards mixed leaf/branch", t, func() {
-		nodes, err := ix.Find(1, "*.demo.*")
+		nodes, err := ix.Find(1, "*.demo.*", 0)
 		So(err, ShouldBeNil)
 		So(nodes, ShouldHaveLength, 15)
 		for _, n := range nodes {
@@ -287,13 +287,13 @@ func TestFind(t *testing.T) {
 		}
 	})
 	Convey("When searching nodes for unkown orgId", t, func() {
-		nodes, err := ix.Find(4, "foo.demo.*")
+		nodes, err := ix.Find(4, "foo.demo.*", 0)
 		So(err, ShouldBeNil)
 		So(nodes, ShouldHaveLength, 0)
 	})
 
 	Convey("When searching nodes that dont exist", t, func() {
-		nodes, err := ix.Find(1, "foo.demo.blah.*")
+		nodes, err := ix.Find(1, "foo.demo.blah.*", 0)
 		So(err, ShouldBeNil)
 		So(nodes, ShouldHaveLength, 0)
 	})
@@ -341,7 +341,7 @@ func TestDelete(t *testing.T) {
 			Convey("series should not be present in searchs", func() {
 				nodes := strings.Split(org1Series[0].Name, ".")
 				branch := strings.Join(nodes[0:len(nodes)-2], ".")
-				found, err := ix.Find(1, branch+".*.*")
+				found, err := ix.Find(1, branch+".*.*", 0)
 				So(err, ShouldBeNil)
 				So(found, ShouldHaveLength, 4)
 				for _, n := range found {
@@ -365,11 +365,11 @@ func TestDelete(t *testing.T) {
 				for _, def := range org1Series {
 					nodes := strings.Split(def.Name, ".")
 					branch := strings.Join(nodes[0:len(nodes)-1], ".")
-					found, err := ix.Find(1, branch+".*")
+					found, err := ix.Find(1, branch+".*", 0)
 					So(err, ShouldBeNil)
 					So(found, ShouldHaveLength, 0)
 				}
-				found, err := ix.Find(1, "metric.*")
+				found, err := ix.Find(1, "metric.*", 0)
 				So(err, ShouldBeNil)
 				So(found, ShouldHaveLength, 1)
 				So(found[0].Path, ShouldEqual, "metric.public")

--- a/idx/idx.go
+++ b/idx/idx.go
@@ -58,11 +58,13 @@ Interface
   passed OrgId is "-1", then all metricDefinitions across all organisations
   should be returned.
 
-* Find(int, string) ([]Node, error):
-  This method provides searches.  The method is passed an OrgId and a query
-  pattern. Searches should return all nodes that match for the given OrgId and
-  OrgId -1.  The pattern should be handled in the same way Graphite would. see
-  https://graphite.readthedocs.io/en/latest/render_api.html#paths-and-wildcards
+* Find(int, string, int64) ([]Node, error):
+  This method provides searches.  The method is passed an OrgId, a query
+  pattern and a unix timestamp. Searches should return all nodes that match for
+  the given OrgId and OrgId -1.  The pattern should be handled in the same way
+  Graphite would. see https://graphite.readthedocs.io/en/latest/render_api.html#paths-and-wildcards
+  And the unix stimestamp is used to ignore series that have been stale since
+  the timestmap.
 
 * Delete(int, string) ([]schema.MetricDefinition, error):
   This method is used for deleting items from the index. The method is passed
@@ -84,7 +86,7 @@ type MetricIndex interface {
 	Add(*schema.MetricData)
 	Get(string) (schema.MetricDefinition, error)
 	Delete(int, string) ([]schema.MetricDefinition, error)
-	Find(int, string) ([]Node, error)
+	Find(int, string, int64) ([]Node, error)
 	List(int) []schema.MetricDefinition
 	Prune(int, time.Time) ([]schema.MetricDefinition, error)
 }

--- a/idx/memory/memory_find_test.go
+++ b/idx/memory/memory_find_test.go
@@ -137,7 +137,7 @@ func Init() {
 }
 
 func ixFind(org, q int) {
-	nodes, err := ix.Find(org, queries[q].Pattern)
+	nodes, err := ix.Find(org, queries[q].Pattern, 0)
 	if err != nil {
 		panic(err)
 	}


### PR DESCRIPTION
- update the metricIdx.Find() method to take a third parameter
that is a timestmap that the series should have been updated since.
- If a series has not been seen for a long time, then it will be
excluded from search results. This is separate to the index pruning
that deletes series from the index.
- if a series has multiple metricDefs, ie due to a interval change,
this new feature will ensure that only the relevant metricDef is used
and the old stale one is excluded from the search result. If the query
is for a time range from when the old metricDef was still being received,
then it will still be included.