### PR TITLE
Minor improvements to documentation of docker setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ and bugs to fix.  It should be considered an *alpha* project.
 * the datastructures can use performance engineering.   [A Go GC issue may occassionally inflate response times](https://github.com/golang/go/issues/14812).
 * the native input protocol is inefficient.  Should not send all metadata with each point.
 * we use metrics2.0 in native input protocol and indexes, but barely do anything with it yet.
-* For any series you can't write points that are earlier than previously written points. (unless you restart MT)
+* for any series you can't write points that are earlier than previously written points. (unless you restart MT)
 
 ## interesting design characteristics (feature or limitation.. up to you)
 
@@ -40,7 +40,7 @@ Otherwise data loss of current chunks will be incurred.  See [operations guide](
 * 100% open source
 * graphite is a first class citizen (note: currently requires a [fork of graphite-api](https://github.com/raintank/graphite-api/)
   and the [graphite-metrictank](https://github.com/raintank/graphite-metrictank) plugin)
-* Accurate, flexible rollups by storing min/max/sum/count (which also gives us average).
+* accurate, flexible rollups by storing min/max/sum/count (which also gives us average).
 So we can do consolidation (combined runtime+archived) accurately and correctly,
 [unlike most other graphite backends like whisper](https://blog.raintank.io/25-graphite-grafana-and-statsd-gotchas/#runtime.consolidation)
 * metrictank acts as a writeback RAM cache for recent data.

--- a/docs/quick-start-docker.md
+++ b/docs/quick-start-docker.md
@@ -4,7 +4,7 @@
 This tutorial will help you run metrictank, its dependencies, and grafana for dashboarding, with minimal hassle.
 
 [docker installation instructions](https://www.docker.com/products/overview)
-You will also need to install [docker-compose](https://docs.docker.com/compose/)
+You will also need to install version >=1.7 of [docker-compose](https://docs.docker.com/compose/)
 
 ## Getting the repository
 
@@ -37,11 +37,14 @@ The stack will listen on the following ports:
 If you already have something else listen to that port (such as a carbon or grafana server), shut it down, as it will conflict.
 
 
-You can bring up the stack like so:
+Inside your copy of the repository, you can bring up the stack like so:
 
 ```
 cd docker
 docker-compose up
+
+# if this gives you the error: "service 'version' doesn't have any configuration options"
+# your version of `docker-compose` is too old and you need to update to >=1.7.
 ```
 
 A bunch of text will whiz past on your screen, but you should see


### PR DESCRIPTION
I went step by step through the Docker documentation. The only problem I've had was that at first I used `apt-get install` to install `docker-compose`, which in Ubuntu `16.04` gave me version `1.5.2`. 

The `docker-compose.yml` file requires a version of `>=1.7`. Assuming that other people might make the same mistake I added a special note pointing out that the returned error means the version of `docker-compose` needs to be updated.