### PR TITLE
Remove unnecessary basename error

### DIFF
--- a/scripts/wait_for_endpoint.sh
+++ b/scripts/wait_for_endpoint.sh
@@ -9,14 +9,25 @@ WAIT_TIMEOUT=${WAIT_TIMEOUT:-10}
 CONN_HOLD=${CONN_HOLD:-3}
 
 # test if we're using busybox for timeout
-timeout_exec=$(basename $(readlink $(which timeout)))
-if [ "$timeout_exec" = "busybox" ]
+timeout_path=$(readlink $(which timeout))
+if [ "$timeout_path" = "" ]
+then
+  _using_busybox=0
+else
+  timeout_exec=$(basename $timeout_path)
+  if [ "$timeout_exec" = "busybox" ]
+  then
+    _using_busybox=1
+  else
+    _using_busybox=0
+  fi
+fi
+
+if [ $_using_busybox -eq 1 ]
 then
   log "using busybox"
-  _using_busybox=1
 else
   log "not using busybox"
-  _using_busybox=0
 fi
 
 for endpoint in $(echo $WAIT_HOSTS | tr "," "\n")

--- a/scripts/wait_for_endpoint.sh
+++ b/scripts/wait_for_endpoint.sh
@@ -9,25 +9,14 @@ WAIT_TIMEOUT=${WAIT_TIMEOUT:-10}
 CONN_HOLD=${CONN_HOLD:-3}
 
 # test if we're using busybox for timeout
-timeout_path=$(readlink $(which timeout))
-if [ "$timeout_path" = "" ]
-then
-  _using_busybox=0
-else
-  timeout_exec=$(basename $timeout_path)
-  if [ "$timeout_exec" = "busybox" ]
-  then
-    _using_busybox=1
-  else
-    _using_busybox=0
-  fi
-fi
-
-if [ $_using_busybox -eq 1 ]
+timeout_exec=$(basename "$(readlink $(which timeout))")
+if [ "$timeout_exec" = "busybox" ]
 then
   log "using busybox"
+  _using_busybox=1
 else
   log "not using busybox"
+  _using_busybox=0
 fi
 
 for endpoint in $(echo $WAIT_HOSTS | tr "," "\n")


### PR DESCRIPTION
If `busybox` is not in use the `wait_for_endpoint.sh` script shows an error because `basename` is used on an empty string. This doesn't break the functionality, it's just ugly.

This patch makes the `busybox` checking a little more complex, but it gets rid of that error because it avoids the case where `basename` is called with an empty string.

This is an example how the output looked before the patch:

```
Creating docker_cassandra_1
Creating docker_statsdaemon_1
Creating docker_metrictank_1
Creating docker_graphite-api_1
Creating docker_grafana_1
+ export WAIT_HOSTS=127.0.0.1:2003
+ export WAIT_TIMEOUT=120
+ export METRICS_PER_SECOND=1000
+ scripts/wait_for_endpoint.sh scripts/generate_test_data.sh start
basename: missing operand
Try 'basename --help' for more information.
2016/10/22 21:26:48 not using busybox
2016/10/22 21:26:48 waiting for 127.0.0.1:2003 to become up...
2016/10/22 21:26:51 127.0.0.1:2003 is up. maintained connection for 3 seconds!
+ FAKEMETRICS_REPO=github.com/raintank/fakemetrics
+ FAKEMETRICS_PID=/tmp/fakemetrics.pid
```