### PR TITLE
make nc sleep after connect

### DIFF
--- a/scripts/wait_for_endpoint.sh
+++ b/scripts/wait_for_endpoint.sh
@@ -43,11 +43,11 @@ do
     # connection stays up for $CONN_HOLD seconds.
     if [ $_using_busybox -eq 1 ]
     then
-      timeout -t $CONN_HOLD busybox nc $host $port
+      timeout -t $CONN_HOLD busybox nc $host $port -e busybox sleep $(( $CONN_HOLD + 1 ))
       retval=$?
 
       # busybox-timeout on alpine returns 0 on timeout
-      expected=0
+      expected=143
     else
       timeout $CONN_HOLD nc $host $port
       retval=$?


### PR DESCRIPTION
There are two parts to this story. First one is why we need to append `-e busybox sleep <int>` and the second one why the expected return status changed:

1) We need that sleep statement because when `busybox-nc`'s `stdin` is closed it does not wait for input after connecting. Instead of waiting it just directly returns `0` [here](https://lxr.missinglinkelectronics.com/#busybox+1_24_0/networking/nc_bloaty.c#L740), which will then be returned as exit status by `main` [here](https://lxr.missinglinkelectronics.com/busybox+1_24_0/networking/nc_bloaty.c#L921)

2) As shown in the above referenced code, if `stdin` is closed and nothing happens on the network `busybox-nc` will exit with `0` which will be returned by `busybox-timeout`, that's why previously the expected exit status was `0`. After this change `busybox-nc` sleeps until it gets a `TERM` from `busybox-timeout`, in this case `busybox-nc` will exit with `143`, which will then also be forwarded by `busybox-timeout`.