### PR TITLE
Clustering

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,8 +18,7 @@ and bugs to fix.  It should be considered an *alpha* project.
 ## limitations
 
 * no performance/availability isolation between tenants per instance. (only data isolation)
-* no sharding/partitioning mechanism in metrictank itself yet.  (Cassandra does it for storage) ([work in progress](https://github.com/raintank/metrictank/issues/315))
-* runtime master promotions (for clusters) are a manual process.
+* clustering is basic: statically defined peers, master promotions are manual, etc. See [clustering](https://github.com/raintank/metrictank/blob/master/docs/clustering.md) for more.
 * no computation locality: we move the data from storage to processing code, which is both metrictank and graphite-api.
 * the datastructures can use performance engineering.   [A Go GC issue may occassionally inflate response times](https://github.com/golang/go/issues/14812).
 * the native input protocol is inefficient.  Should not send all metadata with each point.

--- a/api/cluster.go
+++ b/api/cluster.go
@@ -92,3 +92,16 @@ func (s *Server) getData(ctx *middleware.Context, request models.GetData) {
 	}
 	response.Write(ctx, response.NewMsgp(200, &models.GetDataResp{Series: series}))
 }
+
+func (s *Server) indexDelete(ctx *middleware.Context, req models.IndexDelete) {
+	defs, err := s.MetricIndex.Delete(req.OrgId, req.Query)
+	if err != nil {
+		response.Write(ctx, response.NewError(http.StatusBadRequest, err))
+		return
+	}
+
+	resp := models.MetricsDeleteResp{
+		DeletedDefs: len(defs),
+	}
+	response.Write(ctx, response.NewMsgp(200, &resp))
+}

--- a/api/cluster.go
+++ b/api/cluster.go
@@ -8,7 +8,11 @@ import (
 	"github.com/raintank/metrictank/api/models"
 	"github.com/raintank/metrictank/api/response"
 	"github.com/raintank/metrictank/cluster"
+	"github.com/raintank/worldping-api/pkg/log"
+	"github.com/tinylib/msgp/msgp"
 )
+
+var NotFoundErr = errors.New("not found")
 
 func (s *Server) getNodeStatus(ctx *middleware.Context) {
 	response.Write(ctx, response.NewJson(200, cluster.ThisNode, ""))
@@ -26,4 +30,65 @@ func (s *Server) appStatus(ctx *middleware.Context) {
 	}
 
 	response.Write(ctx, response.NewError(http.StatusServiceUnavailable, errors.New("node not ready")))
+}
+
+func (s *Server) getClusterStatus(ctx *middleware.Context) {
+	status := models.ClusterStatus{
+		Node:  cluster.ThisNode,
+		Peers: cluster.GetPeers(),
+	}
+	response.Write(ctx, response.NewJson(200, status, ""))
+}
+
+// IndexFind returns a sequence of msgp encoded idx.Node's
+func (s *Server) indexFind(ctx *middleware.Context, req models.IndexFind) {
+	// metricDefs only get updated periodically (when using CassandraIdx), so we add a 1day (86400seconds) buffer when
+	// filtering by our From timestamp.  This should be moved to a configuration option
+	if req.From != 0 {
+		req.From -= 86400
+	}
+	resp := models.NewIndexFindResp()
+
+	for _, pattern := range req.Patterns {
+		nodes, err := s.MetricIndex.Find(req.OrgId, pattern, req.From)
+		if err != nil {
+			response.Write(ctx, response.NewError(http.StatusBadRequest, err))
+			return
+		}
+		resp.Nodes[pattern] = nodes
+	}
+	response.Write(ctx, response.NewMsgp(200, resp))
+}
+
+// IndexGet returns a msgp encoded schema.MetricDefinition
+func (s *Server) indexGet(ctx *middleware.Context, req models.IndexGet) {
+	def, err := s.MetricIndex.Get(req.Id)
+	if err != nil {
+	} else { // currently this can only be notFound
+		response.Write(ctx, response.NewError(http.StatusNotFound, NotFoundErr))
+		return
+	}
+
+	response.Write(ctx, response.NewMsgp(200, &def))
+}
+
+// IndexList returns msgp encoded schema.MetricDefinition's
+func (s *Server) indexList(ctx *middleware.Context, req models.IndexList) {
+	defs := s.MetricIndex.List(req.OrgId)
+	resp := make([]msgp.Marshaler, len(defs))
+	for i, _ := range defs {
+		d := defs[i]
+		resp[i] = &d
+	}
+	response.Write(ctx, response.NewMsgpArray(200, resp))
+}
+
+func (s *Server) getData(ctx *middleware.Context, request models.GetData) {
+	series, err := s.getTargetsLocal(request.Requests)
+	if err != nil {
+		log.Error(3, "HTTP getData() %s", err.Error())
+		response.Write(ctx, response.NewError(http.StatusInternalServerError, err))
+		return
+	}
+	response.Write(ctx, response.NewMsgp(200, &models.GetDataResp{Series: series}))
 }

--- a/api/dataprocessor.go
+++ b/api/dataprocessor.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/raintank/metrictank/api/models"
+	"github.com/raintank/metrictank/cluster"
 	"github.com/raintank/metrictank/consolidation"
 	"github.com/raintank/metrictank/iter"
 	"github.com/raintank/metrictank/util"
@@ -166,8 +167,108 @@ func aggEvery(numPoints, maxPoints uint32) uint32 {
 	return (numPoints + maxPoints - 1) / maxPoints
 }
 
-// error is the error of the first failing target request
 func (s *Server) getTargets(reqs []models.Req) ([]models.Series, error) {
+	// split reqs into local and remote.
+	localReqs := make([]models.Req, 0)
+	remoteReqs := make(map[*cluster.Node][]models.Req)
+	for _, req := range reqs {
+		if req.Node == cluster.ThisNode {
+			localReqs = append(localReqs, req)
+		} else {
+			remoteReqs[req.Node] = append(remoteReqs[req.Node], req)
+		}
+	}
+
+	var mu sync.Mutex
+	var wg sync.WaitGroup
+
+	out := make([]models.Series, 0)
+	errs := make([]error, 0)
+
+	if len(localReqs) > 0 {
+		wg.Add(1)
+		go func() {
+			series, err := s.getTargetsLocal(localReqs)
+			mu.Lock()
+			if err != nil {
+				errs = append(errs, err)
+			}
+			if len(series) > 0 {
+				out = append(out, series...)
+			}
+			mu.Unlock()
+			wg.Done()
+		}()
+	}
+	if len(remoteReqs) > 0 {
+		wg.Add(1)
+		go func() {
+			series, err := s.getTargetsRemote(remoteReqs)
+			mu.Lock()
+			if err != nil {
+				errs = append(errs, err)
+			}
+			if len(series) > 0 {
+				out = append(out, series...)
+			}
+			mu.Unlock()
+			wg.Done()
+		}()
+	}
+	wg.Wait()
+	var err error
+	if len(errs) > 0 {
+		err = errs[0]
+	}
+	log.Debug("HTTP getTargets: %d series found on cluster", len(out))
+	return out, err
+}
+
+func (s *Server) getTargetsRemote(remoteReqs map[*cluster.Node][]models.Req) ([]models.Series, error) {
+	seriesChan := make(chan []models.Series, len(remoteReqs))
+	errorsChan := make(chan error, len(remoteReqs))
+	wg := sync.WaitGroup{}
+	wg.Add(len(remoteReqs))
+	for node, nodeReqs := range remoteReqs {
+		log.Debug("HTTP getTargets: handling %d reqs from %s", len(nodeReqs), node.GetName())
+		go func(reqs []models.Req, node *cluster.Node) {
+			defer wg.Done()
+			buf, err := node.Post("/cluster/getdata", models.GetData{Requests: reqs})
+			if err != nil {
+				errorsChan <- err
+				return
+			}
+			var resp models.GetDataResp
+			buf, err = resp.UnmarshalMsg(buf)
+			if err != nil {
+				errorsChan <- errors.New(fmt.Sprintf("HTTP error unmarshaling body from %s/cluster/getdata: %q", node.GetName(), err))
+				return
+			}
+			log.Debug("HTTP getTargets: %s returned %d series", node.GetName(), len(resp.Series))
+			seriesChan <- resp.Series
+		}(nodeReqs, node)
+	}
+	go func() {
+		wg.Wait()
+		close(seriesChan)
+		close(errorsChan)
+	}()
+	out := make([]models.Series, 0)
+	var err error
+	for series := range seriesChan {
+		out = append(out, series...)
+	}
+	log.Debug("HTTP getTargets: total of %d series found on peers", len(out))
+	for e := range errorsChan {
+		err = e
+		break
+	}
+	return out, err
+}
+
+// error is the error of the first failing target request
+func (s *Server) getTargetsLocal(reqs []models.Req) ([]models.Series, error) {
+	log.Debug("HTTP getTargets: handling %d reqs locally", len(reqs))
 	seriesChan := make(chan models.Series, len(reqs))
 	errorsChan := make(chan error, len(reqs))
 	// TODO: abort pending requests on error, maybe use context, maybe timeouts too
@@ -200,6 +301,7 @@ func (s *Server) getTargets(reqs []models.Req) ([]models.Series, error) {
 	for series := range seriesChan {
 		out = append(out, series)
 	}
+	log.Debug("HTTP getTargets: %d series found locally", len(out))
 	for e := range errorsChan {
 		err = e
 		break

--- a/api/dataprocessor.go
+++ b/api/dataprocessor.go
@@ -236,7 +236,7 @@ func (s *Server) getTargetsRemote(remoteReqs map[*cluster.Node][]models.Req) ([]
 		log.Debug("DP getTargetsRemote: handling %d reqs from %s", len(nodeReqs), node.GetName())
 		go func(reqs []models.Req, node *cluster.Node) {
 			defer wg.Done()
-			buf, err := node.Post("/cluster/getdata", models.GetData{Requests: reqs})
+			buf, err := node.Post("/getdata", models.GetData{Requests: reqs})
 			if err != nil {
 				errorsChan <- err
 				return
@@ -244,7 +244,7 @@ func (s *Server) getTargetsRemote(remoteReqs map[*cluster.Node][]models.Req) ([]
 			var resp models.GetDataResp
 			buf, err = resp.UnmarshalMsg(buf)
 			if err != nil {
-				log.Error(3, "DP getTargetsRemote: error unmarshaling body from %s/cluster/getdata: %q", node.GetName(), err)
+				log.Error(3, "DP getTargetsRemote: error unmarshaling body from %s/getdata: %q", node.GetName(), err)
 				errorsChan <- err
 				return
 			}

--- a/api/dataprocessor_test.go
+++ b/api/dataprocessor_test.go
@@ -23,7 +23,7 @@ type testCase struct {
 }
 
 func init() {
-	cluster.Init("default", "test", false, time.Now())
+	cluster.Init("default", "test", time.Now())
 }
 
 func validate(cases []testCase, t *testing.T) {
@@ -541,7 +541,7 @@ func TestPrevBoundary(t *testing.T) {
 
 // TestGetSeries assures that series data is returned in proper form.
 func TestGetSeries(t *testing.T) {
-	cluster.Init("default", "test", false, time.Now())
+	cluster.Init("default", "test", time.Now())
 	stats, _ := helper.New(false, "", "standard", "metrictank", "")
 	store := mdata.NewDevnullStore()
 	metrics := mdata.NewAggMetrics(store, 600, 10, 0, 0, 0, 0, []mdata.AggSetting{})
@@ -575,7 +575,7 @@ func TestGetSeries(t *testing.T) {
 				metric.Add(20+offset, 30) // this point will always be quantized to 30, so it should be selected
 				metric.Add(30+offset, 40) // this point will always be quantized to 40
 				metric.Add(40+offset, 50) // this point will always be quantized to 50
-				req := models.NewReq(name, name, from, to, 1000, 10, consolidation.Avg)
+				req := models.NewReq(name, name, from, to, 1000, 10, consolidation.Avg, cluster.ThisNode)
 				req.ArchInterval = 10
 				points := srv.getSeries(req, consolidation.None)
 				if !reflect.DeepEqual(expected, points) {
@@ -594,11 +594,11 @@ type alignCase struct {
 }
 
 func reqRaw(key string, from, to, maxPoints, rawInterval uint32, consolidator consolidation.Consolidator) models.Req {
-	req := models.NewReq(key, key, from, to, maxPoints, rawInterval, consolidator)
+	req := models.NewReq(key, key, from, to, maxPoints, rawInterval, consolidator, cluster.ThisNode)
 	return req
 }
 func reqOut(key string, from, to, maxPoints, rawInterval uint32, consolidator consolidation.Consolidator, archive int, archInterval, outInterval, aggNum uint32) models.Req {
-	req := models.NewReq(key, key, from, to, maxPoints, rawInterval, consolidator)
+	req := models.NewReq(key, key, from, to, maxPoints, rawInterval, consolidator, cluster.ThisNode)
 	req.Archive = archive
 	req.ArchInterval = archInterval
 	req.OutInterval = outInterval

--- a/api/graphite.go
+++ b/api/graphite.go
@@ -397,7 +397,7 @@ func (s *Server) metricsIndex(ctx *middleware.Context) {
 				wg.Done()
 			}()
 		} else {
-			go func() {
+			go func(peer *cluster.Node) {
 				result, err := s.listRemote(ctx.OrgId, peer)
 				mu.Lock()
 				if err != nil {
@@ -411,7 +411,7 @@ func (s *Server) metricsIndex(ctx *middleware.Context) {
 				}
 				mu.Unlock()
 				wg.Done()
-			}()
+			}(peer)
 		}
 	}
 	wg.Wait()

--- a/api/graphite.go
+++ b/api/graphite.go
@@ -2,9 +2,11 @@ package api
 
 import (
 	"errors"
+	"fmt"
 	"net/http"
 	"sort"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/raintank/dur"
@@ -24,6 +26,12 @@ var InvalidFormatErr = errors.New("invalid format specified")
 var MaxPointsPerReqErr = errors.New("request exceeds max-points-per-req limit. Reduce the number of series and or maxDataPoints requested or ask your admin to increase the limit.")
 var MaxDaysPerReqErr = errors.New("request exceeds max-days-per-req limit. Reduce the number of series and or time range requested or ask your admin to increase the limit.")
 var InvalidTimeRangeErr = errors.New("invalid time range requested")
+
+type Series struct {
+	Pattern string
+	Series  []idx.Node
+	Node    *cluster.Node
+}
 
 func parseTarget(target string) (string, string, error) {
 	var consolidateBy string
@@ -51,6 +59,106 @@ func parseTarget(target string) (string, string, error) {
 		target = t[strings.Index(t, "(")+1 : strings.LastIndex(t, ",")]
 	}
 	return target, consolidateBy, nil
+}
+
+func (s *Server) findSeries(orgId int, patterns []string, seenAfter int64) ([]Series, error) {
+	peers := cluster.PeersForQuery()
+	log.Debug("HTTP findSeries for %v across %d instances", patterns, len(peers))
+	errors := make([]error, 0)
+	series := make([]Series, 0)
+	var mu sync.Mutex
+	var wg sync.WaitGroup
+	for _, peer := range peers {
+		log.Debug("HTTP findSeries getting results from %s", peer.GetName())
+		wg.Add(1)
+		if peer == cluster.ThisNode {
+			go func() {
+				result, err := s.findSeriesLocal(orgId, patterns, seenAfter)
+				mu.Lock()
+				if err != nil {
+					errors = append(errors, err)
+				}
+				series = append(series, result...)
+				mu.Unlock()
+				wg.Done()
+			}()
+		} else {
+			go func(peer *cluster.Node) {
+				result, err := s.findSeriesRemote(orgId, patterns, seenAfter, peer)
+				mu.Lock()
+				if err != nil {
+					errors = append(errors, err)
+				}
+				series = append(series, result...)
+				mu.Unlock()
+				wg.Done()
+			}(peer)
+		}
+	}
+	wg.Wait()
+	var err error
+	if len(errors) > 0 {
+		if len(errors) == 1 {
+			err = errors[0]
+		} else {
+			msg := fmt.Sprintf("%d errors: ", len(errors))
+			for _, e := range errors {
+				msg += e.Error() + ", "
+			}
+			err = fmt.Errorf(msg)
+		}
+	}
+
+	return series, err
+}
+
+func (s *Server) findSeriesLocal(orgId int, patterns []string, seenAfter int64) ([]Series, error) {
+	// metricDefs only get updated periodically, so we add a 1day (86400seconds) buffer when
+	// filtering by our From timestamp.  This should be moved to a configuration option,
+	// but that will require significant refactoring to expose the updateInterval used
+	// in the MetricIdx.
+	if seenAfter != 0 {
+		seenAfter -= 86400
+	}
+	result := make([]Series, 0)
+	for _, pattern := range patterns {
+		nodes, err := s.MetricIndex.Find(orgId, pattern, seenAfter)
+		if err != nil {
+			return nil, err
+		}
+		result = append(result, Series{
+			Pattern: pattern,
+			Node:    cluster.ThisNode,
+			Series:  nodes,
+		})
+		log.Debug("HTTP findSeries %d matches for %s found locally", len(nodes), pattern)
+	}
+	return result, nil
+}
+
+func (s *Server) findSeriesRemote(orgId int, patterns []string, seenAfter int64, peer *cluster.Node) ([]Series, error) {
+	log.Debug("HTTP Render querying %s/cluster/index/find for %d:%q", peer.GetName(), orgId, patterns)
+	buf, err := peer.Post("/cluster/index/find", models.IndexFind{Patterns: patterns, OrgId: orgId})
+	if err != nil {
+		log.Error(4, "HTTP Render error querying %s/cluster/index/find: %q", peer.GetName(), err)
+		return nil, err
+	}
+	resp := models.NewIndexFindResp()
+	buf, err = resp.UnmarshalMsg(buf)
+	if err != nil {
+		log.Error(4, "HTTP Find() error unmarshaling body from %s/cluster/index/find: %q", peer.GetName(), err)
+		return nil, err
+	}
+	result := make([]Series, 0)
+	for pattern, nodes := range resp.Nodes {
+		result = append(result, Series{
+			Pattern: pattern,
+			Node:    peer,
+			Series:  nodes,
+		})
+		log.Debug("HTTP findSeries %d matches for %s found on %s", len(nodes), pattern, peer.GetName())
+	}
+	return result, nil
 }
 
 func (s *Server) renderMetrics(ctx *middleware.Context, request models.GraphiteRender) {
@@ -101,63 +209,62 @@ func (s *Server) renderMetrics(ctx *middleware.Context, request models.GraphiteR
 	}
 
 	reqs := make([]models.Req, 0)
-	parsedTargets := make(map[string]string)
+
+	// consolidatorForPattern[<pattern>]<consolidateBy>
+	consolidatorForPattern := make(map[string]string)
 	patterns := make([]string, 0)
 	type locatedDef struct {
 		def  schema.MetricDefinition
 		node *cluster.Node
 	}
 
+	//locatedDefs[<pattern>][<def.id>]locatedDef
 	locatedDefs := make(map[string]map[string]locatedDef)
-	queryForTarget := make(map[string]string)
-	for _, query := range targets {
-		target, consolidateBy, err := parseTarget(query)
+	//targetForPattern[<pattern>]<target>
+	targetForPattern := make(map[string]string)
+	for _, target := range targets {
+		pattern, consolidateBy, err := parseTarget(target)
 		if err != nil {
 			ctx.Error(http.StatusBadRequest, err.Error())
 			return
 		}
-		parsedTargets[target] = consolidateBy
-		patterns = append(patterns, target)
-		queryForTarget[target] = query
-		locatedDefs[target] = make(map[string]locatedDef)
+		consolidatorForPattern[pattern] = consolidateBy
+		patterns = append(patterns, pattern)
+		targetForPattern[pattern] = target
+		locatedDefs[pattern] = make(map[string]locatedDef)
 
-		// metricDefs only get updated periodically, so we add a 1day (86400seconds) buffer when
-		// filtering by our From timestamp.  This should be moved to a configuration option,
-		// but that will require significant refactoring to expose the updateInterval used
-		// in the MetricIdx.
-		seenAfter := int64(fromUnix)
-		if seenAfter != 0 {
-			seenAfter -= 86400
-		}
-		nodes, err := s.MetricIndex.Find(ctx.OrgId, target, seenAfter)
-		if err != nil {
-			response.Write(ctx, response.NewError(http.StatusBadRequest, err))
-			return
-		}
-		for _, node := range nodes {
-			for _, def := range node.Defs {
-				locatedDefs[target][def.Id] = locatedDef{def, cluster.ThisNode}
+	}
+
+	series, err := s.findSeries(ctx.OrgId, patterns, int64(fromUnix))
+	if err != nil {
+		response.Write(ctx, response.NewError(http.StatusInternalServerError, err))
+	}
+
+	for _, s := range series {
+		for _, metric := range s.Series {
+			for _, def := range metric.Defs {
+				locatedDefs[s.Pattern][def.Id] = locatedDef{def, s.Node}
 			}
 		}
 	}
 
-	for target, ldefs := range locatedDefs {
+	for pattern, ldefs := range locatedDefs {
 		for _, locdef := range ldefs {
 			def := locdef.def
-			consolidator, err := consolidation.GetConsolidator(&def, parsedTargets[target])
+			consolidator, err := consolidation.GetConsolidator(&def, consolidatorForPattern[pattern])
 			if err != nil {
 				response.Write(ctx, response.NewError(http.StatusBadRequest, err))
 				return
 			}
-			// query is like foo.bar or foo.* or consolidateBy(foo.*,'sum')
-			// target is like foo.bar or foo.*
+			// target is like foo.bar or foo.* or consolidateBy(foo.*,'sum')
+			// pattern is like foo.bar or foo.*
 			// def.Name is like foo.concretebar
-			// so we want query to contain the concrete graphite name, potentially wrapped with consolidateBy().
-
-			query := strings.Replace(queryForTarget[target], target, def.Name, -1)
-			reqs = append(reqs, models.NewReq(def.Id, query, fromUnix, toUnix, request.MaxDataPoints, uint32(def.Interval), consolidator))
+			// so we want target to contain the concrete graphite name, potentially wrapped with consolidateBy().
+			target := strings.Replace(targetForPattern[pattern], pattern, def.Name, -1)
+			reqs = append(reqs, models.NewReq(def.Id, target, fromUnix, toUnix, request.MaxDataPoints, uint32(def.Interval), consolidator, locdef.node))
 		}
 	}
+
 	if len(reqs) == 0 {
 		response.Write(ctx, response.NewJson(200, []string{}, ""))
 		return
@@ -177,7 +284,7 @@ func (s *Server) renderMetrics(ctx *middleware.Context, request models.GraphiteR
 
 	if LogLevel < 2 {
 		for _, req := range reqs {
-			log.Debug("HTTP Render %s - arch:%d archI:%d outI:%d aggN: %d", req, req.Archive, req.ArchInterval, req.OutInterval, req.AggNum)
+			log.Debug("HTTP Render %s - arch:%d archI:%d outI:%d aggN: %d from %s", req, req.Archive, req.ArchInterval, req.OutInterval, req.AggNum, req.Node.GetName())
 		}
 	}
 
@@ -208,10 +315,24 @@ func (s *Server) metricsFind(ctx *middleware.Context, request models.GraphiteFin
 	if request.From != 0 {
 		request.From -= 86400
 	}
-	nodes, err := s.MetricIndex.Find(ctx.OrgId, request.Query, request.From)
+	nodes := make([]idx.Node, 0)
+	series, err := s.findSeries(ctx.OrgId, []string{request.Query}, request.From)
 	if err != nil {
-		response.Write(ctx, response.NewError(http.StatusBadRequest, err))
-		return
+		response.Write(ctx, response.NewError(http.StatusInternalServerError, err))
+	}
+	seenPaths := make(map[string]struct{})
+	// different nodes may have overlapping data in their index.
+	// maybe because they used to receive a certain shard but now dont. or because they host metrics under branches
+	// that other nodes also host metrics under. It may even happen that a node has a leaf that for another
+	// node is a branch, if the org has been sending improper data.  in this case there's no elegant way
+	// to nicely handle this so we'll just ignore one of them like we ignore other paths we've already seen.
+	for _, s := range series {
+		for _, n := range s.Series {
+			if _, ok := seenPaths[n.Path]; !ok {
+				nodes = append(nodes, n)
+				seenPaths[n.Path] = struct{}{}
+			}
+		}
 	}
 
 	var b interface{}
@@ -229,9 +350,87 @@ func (s *Server) metricsFind(ctx *middleware.Context, request models.GraphiteFin
 	response.Write(ctx, response.NewJson(200, b, request.Jsonp))
 }
 
+func (s *Server) listLocal(orgId int) []schema.MetricDefinition {
+	return s.MetricIndex.List(orgId)
+}
+
+func (s *Server) listRemote(orgId int, peer *cluster.Node) ([]schema.MetricDefinition, error) {
+	log.Debug("HTTP IndexJson() querying %s/cluster/index/list for %d", peer.GetName(), orgId)
+	buf, err := peer.Post("/cluster/index/list", models.IndexList{OrgId: orgId})
+	if err != nil {
+		log.Error(4, "HTTP IndexJson() error querying %s/cluster/index/list: %q", peer.GetName(), err)
+		return nil, err
+	}
+	result := make([]schema.MetricDefinition, 0)
+	for len(buf) != 0 {
+		var def schema.MetricDefinition
+		buf, err = def.UnmarshalMsg(buf)
+		if err != nil {
+			log.Error(3, "HTTP IndexJson() error unmarshaling body from %s/cluster/index/list: %q", peer.GetName(), err)
+			return nil, err
+		}
+		result = append(result, def)
+	}
+	return result, nil
+}
+
 func (s *Server) metricsIndex(ctx *middleware.Context) {
-	list := s.MetricIndex.List(ctx.OrgId)
-	response.Write(ctx, response.NewFastJson(200, models.MetricNames(list)))
+	peers := cluster.PeersForQuery()
+	errors := make([]error, 0)
+	series := make([]schema.MetricDefinition, 0)
+	seenDefs := make(map[string]struct{})
+	var mu sync.Mutex
+	var wg sync.WaitGroup
+	for _, peer := range peers {
+		wg.Add(1)
+		if peer == cluster.ThisNode {
+			go func() {
+				result := s.listLocal(ctx.OrgId)
+				mu.Lock()
+				for _, def := range result {
+					if _, ok := seenDefs[def.Id]; !ok {
+						series = append(series, def)
+						seenDefs[def.Id] = struct{}{}
+					}
+				}
+				mu.Unlock()
+				wg.Done()
+			}()
+		} else {
+			go func() {
+				result, err := s.listRemote(ctx.OrgId, peer)
+				mu.Lock()
+				if err != nil {
+					errors = append(errors, err)
+				}
+				for _, def := range result {
+					if _, ok := seenDefs[def.Id]; !ok {
+						series = append(series, def)
+						seenDefs[def.Id] = struct{}{}
+					}
+				}
+				mu.Unlock()
+				wg.Done()
+			}()
+		}
+	}
+	wg.Wait()
+	var err error
+	if len(errors) > 0 {
+		if len(errors) == 1 {
+			err = errors[0]
+		} else {
+			err = fmt.Errorf("%d errors: %q", len(errors), errors)
+		}
+	}
+
+	if err != nil {
+		log.Error(3, "HTTP IndexJson() %s", err.Error())
+		response.Write(ctx, response.NewError(http.StatusInternalServerError, err))
+		return
+	}
+
+	response.Write(ctx, response.NewFastJson(200, models.MetricNames(series)))
 }
 
 func findCompleter(nodes []idx.Node) (models.SeriesCompleter, error) {
@@ -299,16 +498,6 @@ func findTreejson(query string, nodes []idx.Node) (models.SeriesTree, error) {
 }
 
 func (s *Server) metricsDelete(ctx *middleware.Context, req models.MetricsDelete) {
-	if ctx.OrgId == 0 {
-		response.Write(ctx, response.NewError(http.StatusBadRequest, MissingOrgHeaderErr))
-		return
-	}
-
-	if req.Query == "" {
-		response.Write(ctx, response.NewError(http.StatusBadRequest, MissingQueryErr))
-		return
-	}
-
 	defs, err := s.MetricIndex.Delete(ctx.OrgId, req.Query)
 	if err != nil {
 		response.Write(ctx, response.NewError(http.StatusBadRequest, err))

--- a/api/graphite.go
+++ b/api/graphite.go
@@ -128,16 +128,16 @@ func (s *Server) findSeriesLocal(orgId int, patterns []string, seenAfter int64) 
 }
 
 func (s *Server) findSeriesRemote(orgId int, patterns []string, seenAfter int64, peer *cluster.Node) ([]Series, error) {
-	log.Debug("HTTP Render querying %s/cluster/index/find for %d:%q", peer.GetName(), orgId, patterns)
-	buf, err := peer.Post("/cluster/index/find", models.IndexFind{Patterns: patterns, OrgId: orgId})
+	log.Debug("HTTP Render querying %s/index/find for %d:%q", peer.GetName(), orgId, patterns)
+	buf, err := peer.Post("/index/find", models.IndexFind{Patterns: patterns, OrgId: orgId})
 	if err != nil {
-		log.Error(4, "HTTP Render error querying %s/cluster/index/find: %q", peer.GetName(), err)
+		log.Error(4, "HTTP Render error querying %s/index/find: %q", peer.GetName(), err)
 		return nil, err
 	}
 	resp := models.NewIndexFindResp()
 	buf, err = resp.UnmarshalMsg(buf)
 	if err != nil {
-		log.Error(4, "HTTP Find() error unmarshaling body from %s/cluster/index/find: %q", peer.GetName(), err)
+		log.Error(4, "HTTP Find() error unmarshaling body from %s/index/find: %q", peer.GetName(), err)
 		return nil, err
 	}
 	result := make([]Series, 0)
@@ -347,10 +347,10 @@ func (s *Server) listLocal(orgId int) []schema.MetricDefinition {
 }
 
 func (s *Server) listRemote(orgId int, peer *cluster.Node) ([]schema.MetricDefinition, error) {
-	log.Debug("HTTP IndexJson() querying %s/cluster/index/list for %d", peer.GetName(), orgId)
-	buf, err := peer.Post("/cluster/index/list", models.IndexList{OrgId: orgId})
+	log.Debug("HTTP IndexJson() querying %s/index/list for %d", peer.GetName(), orgId)
+	buf, err := peer.Post("/index/list", models.IndexList{OrgId: orgId})
 	if err != nil {
-		log.Error(4, "HTTP IndexJson() error querying %s/cluster/index/list: %q", peer.GetName(), err)
+		log.Error(4, "HTTP IndexJson() error querying %s/index/list: %q", peer.GetName(), err)
 		return nil, err
 	}
 	result := make([]schema.MetricDefinition, 0)
@@ -358,7 +358,7 @@ func (s *Server) listRemote(orgId int, peer *cluster.Node) ([]schema.MetricDefin
 		var def schema.MetricDefinition
 		buf, err = def.UnmarshalMsg(buf)
 		if err != nil {
-			log.Error(3, "HTTP IndexJson() error unmarshaling body from %s/cluster/index/list: %q", peer.GetName(), err)
+			log.Error(3, "HTTP IndexJson() error unmarshaling body from %s/index/list: %q", peer.GetName(), err)
 			return nil, err
 		}
 		result = append(result, def)
@@ -544,16 +544,16 @@ func (s *Server) metricsDeleteLocal(orgId int, query string) (int, error) {
 }
 
 func (s *Server) metricsDeleteRemote(orgId int, query string, peer *cluster.Node) (int, error) {
-	log.Debug("HTTP metricDelete calling %s/cluster/index/delete for %d:%q", peer.GetName(), orgId, query)
-	buf, err := peer.Post("/cluster/index/delete", models.IndexDelete{Query: query, OrgId: orgId})
+	log.Debug("HTTP metricDelete calling %s/index/delete for %d:%q", peer.GetName(), orgId, query)
+	buf, err := peer.Post("/index/delete", models.IndexDelete{Query: query, OrgId: orgId})
 	if err != nil {
-		log.Error(4, "HTTP metricDelete error querying %s/cluster/index/delete: %q", peer.GetName(), err)
+		log.Error(4, "HTTP metricDelete error querying %s/index/delete: %q", peer.GetName(), err)
 		return 0, err
 	}
 	resp := models.MetricsDeleteResp{}
 	buf, err = resp.UnmarshalMsg(buf)
 	if err != nil {
-		log.Error(4, "HTTP metricDelete error unmarshaling body from %s/cluster/index/delete: %q", peer.GetName(), err)
+		log.Error(4, "HTTP metricDelete error unmarshaling body from %s/index/delete: %q", peer.GetName(), err)
 		return 0, err
 	}
 

--- a/api/models/cluster.go
+++ b/api/models/cluster.go
@@ -20,3 +20,7 @@ func NewIndexFindResp() *IndexFindResp {
 type GetDataResp struct {
 	Series []Series
 }
+
+type MetricsDeleteResp struct {
+	DeletedDefs int `json:"deletedDefs"`
+}

--- a/api/models/cluster.go
+++ b/api/models/cluster.go
@@ -1,5 +1,22 @@
 package models
 
-type NodeStatus struct {
-	Primary bool `json:"primary" form:"primary" binding:"Required"`
+import (
+	"github.com/raintank/metrictank/idx"
+)
+
+//go:generate msgp
+type IndexFindResp struct {
+	Nodes map[string][]idx.Node
+}
+
+//go:generate msgp
+func NewIndexFindResp() *IndexFindResp {
+	return &IndexFindResp{
+		Nodes: make(map[string][]idx.Node),
+	}
+}
+
+//go:generate msgp
+type GetDataResp struct {
+	Series []Series
 }

--- a/api/models/cluster_gen.go
+++ b/api/models/cluster_gen.go
@@ -1,0 +1,340 @@
+package models
+
+// NOTE: THIS FILE WAS PRODUCED BY THE
+// MSGP CODE GENERATION TOOL (github.com/tinylib/msgp)
+// DO NOT EDIT
+
+import (
+	"github.com/raintank/metrictank/idx"
+	"github.com/tinylib/msgp/msgp"
+)
+
+// DecodeMsg implements msgp.Decodable
+func (z *GetDataResp) DecodeMsg(dc *msgp.Reader) (err error) {
+	var field []byte
+	_ = field
+	var zbzg uint32
+	zbzg, err = dc.ReadMapHeader()
+	if err != nil {
+		return
+	}
+	for zbzg > 0 {
+		zbzg--
+		field, err = dc.ReadMapKeyPtr()
+		if err != nil {
+			return
+		}
+		switch msgp.UnsafeString(field) {
+		case "Series":
+			var zbai uint32
+			zbai, err = dc.ReadArrayHeader()
+			if err != nil {
+				return
+			}
+			if cap(z.Series) >= int(zbai) {
+				z.Series = (z.Series)[:zbai]
+			} else {
+				z.Series = make([]Series, zbai)
+			}
+			for zxvk := range z.Series {
+				err = z.Series[zxvk].DecodeMsg(dc)
+				if err != nil {
+					return
+				}
+			}
+		default:
+			err = dc.Skip()
+			if err != nil {
+				return
+			}
+		}
+	}
+	return
+}
+
+// EncodeMsg implements msgp.Encodable
+func (z *GetDataResp) EncodeMsg(en *msgp.Writer) (err error) {
+	// map header, size 1
+	// write "Series"
+	err = en.Append(0x81, 0xa6, 0x53, 0x65, 0x72, 0x69, 0x65, 0x73)
+	if err != nil {
+		return err
+	}
+	err = en.WriteArrayHeader(uint32(len(z.Series)))
+	if err != nil {
+		return
+	}
+	for zxvk := range z.Series {
+		err = z.Series[zxvk].EncodeMsg(en)
+		if err != nil {
+			return
+		}
+	}
+	return
+}
+
+// MarshalMsg implements msgp.Marshaler
+func (z *GetDataResp) MarshalMsg(b []byte) (o []byte, err error) {
+	o = msgp.Require(b, z.Msgsize())
+	// map header, size 1
+	// string "Series"
+	o = append(o, 0x81, 0xa6, 0x53, 0x65, 0x72, 0x69, 0x65, 0x73)
+	o = msgp.AppendArrayHeader(o, uint32(len(z.Series)))
+	for zxvk := range z.Series {
+		o, err = z.Series[zxvk].MarshalMsg(o)
+		if err != nil {
+			return
+		}
+	}
+	return
+}
+
+// UnmarshalMsg implements msgp.Unmarshaler
+func (z *GetDataResp) UnmarshalMsg(bts []byte) (o []byte, err error) {
+	var field []byte
+	_ = field
+	var zcmr uint32
+	zcmr, bts, err = msgp.ReadMapHeaderBytes(bts)
+	if err != nil {
+		return
+	}
+	for zcmr > 0 {
+		zcmr--
+		field, bts, err = msgp.ReadMapKeyZC(bts)
+		if err != nil {
+			return
+		}
+		switch msgp.UnsafeString(field) {
+		case "Series":
+			var zajw uint32
+			zajw, bts, err = msgp.ReadArrayHeaderBytes(bts)
+			if err != nil {
+				return
+			}
+			if cap(z.Series) >= int(zajw) {
+				z.Series = (z.Series)[:zajw]
+			} else {
+				z.Series = make([]Series, zajw)
+			}
+			for zxvk := range z.Series {
+				bts, err = z.Series[zxvk].UnmarshalMsg(bts)
+				if err != nil {
+					return
+				}
+			}
+		default:
+			bts, err = msgp.Skip(bts)
+			if err != nil {
+				return
+			}
+		}
+	}
+	o = bts
+	return
+}
+
+// Msgsize returns an upper bound estimate of the number of bytes occupied by the serialized message
+func (z *GetDataResp) Msgsize() (s int) {
+	s = 1 + 7 + msgp.ArrayHeaderSize
+	for zxvk := range z.Series {
+		s += z.Series[zxvk].Msgsize()
+	}
+	return
+}
+
+// DecodeMsg implements msgp.Decodable
+func (z *IndexFindResp) DecodeMsg(dc *msgp.Reader) (err error) {
+	var field []byte
+	_ = field
+	var zxhx uint32
+	zxhx, err = dc.ReadMapHeader()
+	if err != nil {
+		return
+	}
+	for zxhx > 0 {
+		zxhx--
+		field, err = dc.ReadMapKeyPtr()
+		if err != nil {
+			return
+		}
+		switch msgp.UnsafeString(field) {
+		case "Nodes":
+			var zlqf uint32
+			zlqf, err = dc.ReadMapHeader()
+			if err != nil {
+				return
+			}
+			if z.Nodes == nil && zlqf > 0 {
+				z.Nodes = make(map[string][]idx.Node, zlqf)
+			} else if len(z.Nodes) > 0 {
+				for key, _ := range z.Nodes {
+					delete(z.Nodes, key)
+				}
+			}
+			for zlqf > 0 {
+				zlqf--
+				var zwht string
+				var zhct []idx.Node
+				zwht, err = dc.ReadString()
+				if err != nil {
+					return
+				}
+				var zdaf uint32
+				zdaf, err = dc.ReadArrayHeader()
+				if err != nil {
+					return
+				}
+				if cap(zhct) >= int(zdaf) {
+					zhct = (zhct)[:zdaf]
+				} else {
+					zhct = make([]idx.Node, zdaf)
+				}
+				for zcua := range zhct {
+					err = zhct[zcua].DecodeMsg(dc)
+					if err != nil {
+						return
+					}
+				}
+				z.Nodes[zwht] = zhct
+			}
+		default:
+			err = dc.Skip()
+			if err != nil {
+				return
+			}
+		}
+	}
+	return
+}
+
+// EncodeMsg implements msgp.Encodable
+func (z *IndexFindResp) EncodeMsg(en *msgp.Writer) (err error) {
+	// map header, size 1
+	// write "Nodes"
+	err = en.Append(0x81, 0xa5, 0x4e, 0x6f, 0x64, 0x65, 0x73)
+	if err != nil {
+		return err
+	}
+	err = en.WriteMapHeader(uint32(len(z.Nodes)))
+	if err != nil {
+		return
+	}
+	for zwht, zhct := range z.Nodes {
+		err = en.WriteString(zwht)
+		if err != nil {
+			return
+		}
+		err = en.WriteArrayHeader(uint32(len(zhct)))
+		if err != nil {
+			return
+		}
+		for zcua := range zhct {
+			err = zhct[zcua].EncodeMsg(en)
+			if err != nil {
+				return
+			}
+		}
+	}
+	return
+}
+
+// MarshalMsg implements msgp.Marshaler
+func (z *IndexFindResp) MarshalMsg(b []byte) (o []byte, err error) {
+	o = msgp.Require(b, z.Msgsize())
+	// map header, size 1
+	// string "Nodes"
+	o = append(o, 0x81, 0xa5, 0x4e, 0x6f, 0x64, 0x65, 0x73)
+	o = msgp.AppendMapHeader(o, uint32(len(z.Nodes)))
+	for zwht, zhct := range z.Nodes {
+		o = msgp.AppendString(o, zwht)
+		o = msgp.AppendArrayHeader(o, uint32(len(zhct)))
+		for zcua := range zhct {
+			o, err = zhct[zcua].MarshalMsg(o)
+			if err != nil {
+				return
+			}
+		}
+	}
+	return
+}
+
+// UnmarshalMsg implements msgp.Unmarshaler
+func (z *IndexFindResp) UnmarshalMsg(bts []byte) (o []byte, err error) {
+	var field []byte
+	_ = field
+	var zpks uint32
+	zpks, bts, err = msgp.ReadMapHeaderBytes(bts)
+	if err != nil {
+		return
+	}
+	for zpks > 0 {
+		zpks--
+		field, bts, err = msgp.ReadMapKeyZC(bts)
+		if err != nil {
+			return
+		}
+		switch msgp.UnsafeString(field) {
+		case "Nodes":
+			var zjfb uint32
+			zjfb, bts, err = msgp.ReadMapHeaderBytes(bts)
+			if err != nil {
+				return
+			}
+			if z.Nodes == nil && zjfb > 0 {
+				z.Nodes = make(map[string][]idx.Node, zjfb)
+			} else if len(z.Nodes) > 0 {
+				for key, _ := range z.Nodes {
+					delete(z.Nodes, key)
+				}
+			}
+			for zjfb > 0 {
+				var zwht string
+				var zhct []idx.Node
+				zjfb--
+				zwht, bts, err = msgp.ReadStringBytes(bts)
+				if err != nil {
+					return
+				}
+				var zcxo uint32
+				zcxo, bts, err = msgp.ReadArrayHeaderBytes(bts)
+				if err != nil {
+					return
+				}
+				if cap(zhct) >= int(zcxo) {
+					zhct = (zhct)[:zcxo]
+				} else {
+					zhct = make([]idx.Node, zcxo)
+				}
+				for zcua := range zhct {
+					bts, err = zhct[zcua].UnmarshalMsg(bts)
+					if err != nil {
+						return
+					}
+				}
+				z.Nodes[zwht] = zhct
+			}
+		default:
+			bts, err = msgp.Skip(bts)
+			if err != nil {
+				return
+			}
+		}
+	}
+	o = bts
+	return
+}
+
+// Msgsize returns an upper bound estimate of the number of bytes occupied by the serialized message
+func (z *IndexFindResp) Msgsize() (s int) {
+	s = 1 + 6 + msgp.MapHeaderSize
+	if z.Nodes != nil {
+		for zwht, zhct := range z.Nodes {
+			_ = zhct
+			s += msgp.StringPrefixSize + len(zwht) + msgp.ArrayHeaderSize
+			for zcua := range zhct {
+				s += zhct[zcua].Msgsize()
+			}
+		}
+	}
+	return
+}

--- a/api/models/cluster_gen.go
+++ b/api/models/cluster_gen.go
@@ -13,31 +13,31 @@ import (
 func (z *GetDataResp) DecodeMsg(dc *msgp.Reader) (err error) {
 	var field []byte
 	_ = field
-	var zbzg uint32
-	zbzg, err = dc.ReadMapHeader()
+	var isz uint32
+	isz, err = dc.ReadMapHeader()
 	if err != nil {
 		return
 	}
-	for zbzg > 0 {
-		zbzg--
+	for isz > 0 {
+		isz--
 		field, err = dc.ReadMapKeyPtr()
 		if err != nil {
 			return
 		}
 		switch msgp.UnsafeString(field) {
 		case "Series":
-			var zbai uint32
-			zbai, err = dc.ReadArrayHeader()
+			var xsz uint32
+			xsz, err = dc.ReadArrayHeader()
 			if err != nil {
 				return
 			}
-			if cap(z.Series) >= int(zbai) {
-				z.Series = (z.Series)[:zbai]
+			if cap(z.Series) >= int(xsz) {
+				z.Series = z.Series[:xsz]
 			} else {
-				z.Series = make([]Series, zbai)
+				z.Series = make([]Series, xsz)
 			}
-			for zxvk := range z.Series {
-				err = z.Series[zxvk].DecodeMsg(dc)
+			for xvk := range z.Series {
+				err = z.Series[xvk].DecodeMsg(dc)
 				if err != nil {
 					return
 				}
@@ -64,8 +64,8 @@ func (z *GetDataResp) EncodeMsg(en *msgp.Writer) (err error) {
 	if err != nil {
 		return
 	}
-	for zxvk := range z.Series {
-		err = z.Series[zxvk].EncodeMsg(en)
+	for xvk := range z.Series {
+		err = z.Series[xvk].EncodeMsg(en)
 		if err != nil {
 			return
 		}
@@ -80,8 +80,8 @@ func (z *GetDataResp) MarshalMsg(b []byte) (o []byte, err error) {
 	// string "Series"
 	o = append(o, 0x81, 0xa6, 0x53, 0x65, 0x72, 0x69, 0x65, 0x73)
 	o = msgp.AppendArrayHeader(o, uint32(len(z.Series)))
-	for zxvk := range z.Series {
-		o, err = z.Series[zxvk].MarshalMsg(o)
+	for xvk := range z.Series {
+		o, err = z.Series[xvk].MarshalMsg(o)
 		if err != nil {
 			return
 		}
@@ -93,31 +93,31 @@ func (z *GetDataResp) MarshalMsg(b []byte) (o []byte, err error) {
 func (z *GetDataResp) UnmarshalMsg(bts []byte) (o []byte, err error) {
 	var field []byte
 	_ = field
-	var zcmr uint32
-	zcmr, bts, err = msgp.ReadMapHeaderBytes(bts)
+	var isz uint32
+	isz, bts, err = msgp.ReadMapHeaderBytes(bts)
 	if err != nil {
 		return
 	}
-	for zcmr > 0 {
-		zcmr--
+	for isz > 0 {
+		isz--
 		field, bts, err = msgp.ReadMapKeyZC(bts)
 		if err != nil {
 			return
 		}
 		switch msgp.UnsafeString(field) {
 		case "Series":
-			var zajw uint32
-			zajw, bts, err = msgp.ReadArrayHeaderBytes(bts)
+			var xsz uint32
+			xsz, bts, err = msgp.ReadArrayHeaderBytes(bts)
 			if err != nil {
 				return
 			}
-			if cap(z.Series) >= int(zajw) {
-				z.Series = (z.Series)[:zajw]
+			if cap(z.Series) >= int(xsz) {
+				z.Series = z.Series[:xsz]
 			} else {
-				z.Series = make([]Series, zajw)
+				z.Series = make([]Series, xsz)
 			}
-			for zxvk := range z.Series {
-				bts, err = z.Series[zxvk].UnmarshalMsg(bts)
+			for xvk := range z.Series {
+				bts, err = z.Series[xvk].UnmarshalMsg(bts)
 				if err != nil {
 					return
 				}
@@ -133,11 +133,10 @@ func (z *GetDataResp) UnmarshalMsg(bts []byte) (o []byte, err error) {
 	return
 }
 
-// Msgsize returns an upper bound estimate of the number of bytes occupied by the serialized message
 func (z *GetDataResp) Msgsize() (s int) {
 	s = 1 + 7 + msgp.ArrayHeaderSize
-	for zxvk := range z.Series {
-		s += z.Series[zxvk].Msgsize()
+	for xvk := range z.Series {
+		s += z.Series[xvk].Msgsize()
 	}
 	return
 }
@@ -146,56 +145,56 @@ func (z *GetDataResp) Msgsize() (s int) {
 func (z *IndexFindResp) DecodeMsg(dc *msgp.Reader) (err error) {
 	var field []byte
 	_ = field
-	var zxhx uint32
-	zxhx, err = dc.ReadMapHeader()
+	var isz uint32
+	isz, err = dc.ReadMapHeader()
 	if err != nil {
 		return
 	}
-	for zxhx > 0 {
-		zxhx--
+	for isz > 0 {
+		isz--
 		field, err = dc.ReadMapKeyPtr()
 		if err != nil {
 			return
 		}
 		switch msgp.UnsafeString(field) {
 		case "Nodes":
-			var zlqf uint32
-			zlqf, err = dc.ReadMapHeader()
+			var msz uint32
+			msz, err = dc.ReadMapHeader()
 			if err != nil {
 				return
 			}
-			if z.Nodes == nil && zlqf > 0 {
-				z.Nodes = make(map[string][]idx.Node, zlqf)
+			if z.Nodes == nil && msz > 0 {
+				z.Nodes = make(map[string][]idx.Node, msz)
 			} else if len(z.Nodes) > 0 {
 				for key, _ := range z.Nodes {
 					delete(z.Nodes, key)
 				}
 			}
-			for zlqf > 0 {
-				zlqf--
-				var zwht string
-				var zhct []idx.Node
-				zwht, err = dc.ReadString()
+			for msz > 0 {
+				msz--
+				var bzg string
+				var bai []idx.Node
+				bzg, err = dc.ReadString()
 				if err != nil {
 					return
 				}
-				var zdaf uint32
-				zdaf, err = dc.ReadArrayHeader()
+				var xsz uint32
+				xsz, err = dc.ReadArrayHeader()
 				if err != nil {
 					return
 				}
-				if cap(zhct) >= int(zdaf) {
-					zhct = (zhct)[:zdaf]
+				if cap(bai) >= int(xsz) {
+					bai = bai[:xsz]
 				} else {
-					zhct = make([]idx.Node, zdaf)
+					bai = make([]idx.Node, xsz)
 				}
-				for zcua := range zhct {
-					err = zhct[zcua].DecodeMsg(dc)
+				for cmr := range bai {
+					err = bai[cmr].DecodeMsg(dc)
 					if err != nil {
 						return
 					}
 				}
-				z.Nodes[zwht] = zhct
+				z.Nodes[bzg] = bai
 			}
 		default:
 			err = dc.Skip()
@@ -219,17 +218,17 @@ func (z *IndexFindResp) EncodeMsg(en *msgp.Writer) (err error) {
 	if err != nil {
 		return
 	}
-	for zwht, zhct := range z.Nodes {
-		err = en.WriteString(zwht)
+	for bzg, bai := range z.Nodes {
+		err = en.WriteString(bzg)
 		if err != nil {
 			return
 		}
-		err = en.WriteArrayHeader(uint32(len(zhct)))
+		err = en.WriteArrayHeader(uint32(len(bai)))
 		if err != nil {
 			return
 		}
-		for zcua := range zhct {
-			err = zhct[zcua].EncodeMsg(en)
+		for cmr := range bai {
+			err = bai[cmr].EncodeMsg(en)
 			if err != nil {
 				return
 			}
@@ -245,11 +244,11 @@ func (z *IndexFindResp) MarshalMsg(b []byte) (o []byte, err error) {
 	// string "Nodes"
 	o = append(o, 0x81, 0xa5, 0x4e, 0x6f, 0x64, 0x65, 0x73)
 	o = msgp.AppendMapHeader(o, uint32(len(z.Nodes)))
-	for zwht, zhct := range z.Nodes {
-		o = msgp.AppendString(o, zwht)
-		o = msgp.AppendArrayHeader(o, uint32(len(zhct)))
-		for zcua := range zhct {
-			o, err = zhct[zcua].MarshalMsg(o)
+	for bzg, bai := range z.Nodes {
+		o = msgp.AppendString(o, bzg)
+		o = msgp.AppendArrayHeader(o, uint32(len(bai)))
+		for cmr := range bai {
+			o, err = bai[cmr].MarshalMsg(o)
 			if err != nil {
 				return
 			}
@@ -262,56 +261,56 @@ func (z *IndexFindResp) MarshalMsg(b []byte) (o []byte, err error) {
 func (z *IndexFindResp) UnmarshalMsg(bts []byte) (o []byte, err error) {
 	var field []byte
 	_ = field
-	var zpks uint32
-	zpks, bts, err = msgp.ReadMapHeaderBytes(bts)
+	var isz uint32
+	isz, bts, err = msgp.ReadMapHeaderBytes(bts)
 	if err != nil {
 		return
 	}
-	for zpks > 0 {
-		zpks--
+	for isz > 0 {
+		isz--
 		field, bts, err = msgp.ReadMapKeyZC(bts)
 		if err != nil {
 			return
 		}
 		switch msgp.UnsafeString(field) {
 		case "Nodes":
-			var zjfb uint32
-			zjfb, bts, err = msgp.ReadMapHeaderBytes(bts)
+			var msz uint32
+			msz, bts, err = msgp.ReadMapHeaderBytes(bts)
 			if err != nil {
 				return
 			}
-			if z.Nodes == nil && zjfb > 0 {
-				z.Nodes = make(map[string][]idx.Node, zjfb)
+			if z.Nodes == nil && msz > 0 {
+				z.Nodes = make(map[string][]idx.Node, msz)
 			} else if len(z.Nodes) > 0 {
 				for key, _ := range z.Nodes {
 					delete(z.Nodes, key)
 				}
 			}
-			for zjfb > 0 {
-				var zwht string
-				var zhct []idx.Node
-				zjfb--
-				zwht, bts, err = msgp.ReadStringBytes(bts)
+			for msz > 0 {
+				var bzg string
+				var bai []idx.Node
+				msz--
+				bzg, bts, err = msgp.ReadStringBytes(bts)
 				if err != nil {
 					return
 				}
-				var zcxo uint32
-				zcxo, bts, err = msgp.ReadArrayHeaderBytes(bts)
+				var xsz uint32
+				xsz, bts, err = msgp.ReadArrayHeaderBytes(bts)
 				if err != nil {
 					return
 				}
-				if cap(zhct) >= int(zcxo) {
-					zhct = (zhct)[:zcxo]
+				if cap(bai) >= int(xsz) {
+					bai = bai[:xsz]
 				} else {
-					zhct = make([]idx.Node, zcxo)
+					bai = make([]idx.Node, xsz)
 				}
-				for zcua := range zhct {
-					bts, err = zhct[zcua].UnmarshalMsg(bts)
+				for cmr := range bai {
+					bts, err = bai[cmr].UnmarshalMsg(bts)
 					if err != nil {
 						return
 					}
 				}
-				z.Nodes[zwht] = zhct
+				z.Nodes[bzg] = bai
 			}
 		default:
 			bts, err = msgp.Skip(bts)
@@ -324,17 +323,109 @@ func (z *IndexFindResp) UnmarshalMsg(bts []byte) (o []byte, err error) {
 	return
 }
 
-// Msgsize returns an upper bound estimate of the number of bytes occupied by the serialized message
 func (z *IndexFindResp) Msgsize() (s int) {
 	s = 1 + 6 + msgp.MapHeaderSize
 	if z.Nodes != nil {
-		for zwht, zhct := range z.Nodes {
-			_ = zhct
-			s += msgp.StringPrefixSize + len(zwht) + msgp.ArrayHeaderSize
-			for zcua := range zhct {
-				s += zhct[zcua].Msgsize()
+		for bzg, bai := range z.Nodes {
+			_ = bai
+			s += msgp.StringPrefixSize + len(bzg) + msgp.ArrayHeaderSize
+			for cmr := range bai {
+				s += bai[cmr].Msgsize()
 			}
 		}
 	}
+	return
+}
+
+// DecodeMsg implements msgp.Decodable
+func (z *MetricsDeleteResp) DecodeMsg(dc *msgp.Reader) (err error) {
+	var field []byte
+	_ = field
+	var isz uint32
+	isz, err = dc.ReadMapHeader()
+	if err != nil {
+		return
+	}
+	for isz > 0 {
+		isz--
+		field, err = dc.ReadMapKeyPtr()
+		if err != nil {
+			return
+		}
+		switch msgp.UnsafeString(field) {
+		case "DeletedDefs":
+			z.DeletedDefs, err = dc.ReadInt()
+			if err != nil {
+				return
+			}
+		default:
+			err = dc.Skip()
+			if err != nil {
+				return
+			}
+		}
+	}
+	return
+}
+
+// EncodeMsg implements msgp.Encodable
+func (z MetricsDeleteResp) EncodeMsg(en *msgp.Writer) (err error) {
+	// map header, size 1
+	// write "DeletedDefs"
+	err = en.Append(0x81, 0xab, 0x44, 0x65, 0x6c, 0x65, 0x74, 0x65, 0x64, 0x44, 0x65, 0x66, 0x73)
+	if err != nil {
+		return err
+	}
+	err = en.WriteInt(z.DeletedDefs)
+	if err != nil {
+		return
+	}
+	return
+}
+
+// MarshalMsg implements msgp.Marshaler
+func (z MetricsDeleteResp) MarshalMsg(b []byte) (o []byte, err error) {
+	o = msgp.Require(b, z.Msgsize())
+	// map header, size 1
+	// string "DeletedDefs"
+	o = append(o, 0x81, 0xab, 0x44, 0x65, 0x6c, 0x65, 0x74, 0x65, 0x64, 0x44, 0x65, 0x66, 0x73)
+	o = msgp.AppendInt(o, z.DeletedDefs)
+	return
+}
+
+// UnmarshalMsg implements msgp.Unmarshaler
+func (z *MetricsDeleteResp) UnmarshalMsg(bts []byte) (o []byte, err error) {
+	var field []byte
+	_ = field
+	var isz uint32
+	isz, bts, err = msgp.ReadMapHeaderBytes(bts)
+	if err != nil {
+		return
+	}
+	for isz > 0 {
+		isz--
+		field, bts, err = msgp.ReadMapKeyZC(bts)
+		if err != nil {
+			return
+		}
+		switch msgp.UnsafeString(field) {
+		case "DeletedDefs":
+			z.DeletedDefs, bts, err = msgp.ReadIntBytes(bts)
+			if err != nil {
+				return
+			}
+		default:
+			bts, err = msgp.Skip(bts)
+			if err != nil {
+				return
+			}
+		}
+	}
+	o = bts
+	return
+}
+
+func (z MetricsDeleteResp) Msgsize() (s int) {
+	s = 1 + 12 + msgp.IntSize
 	return
 }

--- a/api/models/cluster_gen_test.go
+++ b/api/models/cluster_gen_test.go
@@ -236,3 +236,116 @@ func BenchmarkDecodeIndexFindResp(b *testing.B) {
 		}
 	}
 }
+
+func TestMarshalUnmarshalMetricsDeleteResp(t *testing.T) {
+	v := MetricsDeleteResp{}
+	bts, err := v.MarshalMsg(nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	left, err := v.UnmarshalMsg(bts)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(left) > 0 {
+		t.Errorf("%d bytes left over after UnmarshalMsg(): %q", len(left), left)
+	}
+
+	left, err = msgp.Skip(bts)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(left) > 0 {
+		t.Errorf("%d bytes left over after Skip(): %q", len(left), left)
+	}
+}
+
+func BenchmarkMarshalMsgMetricsDeleteResp(b *testing.B) {
+	v := MetricsDeleteResp{}
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		v.MarshalMsg(nil)
+	}
+}
+
+func BenchmarkAppendMsgMetricsDeleteResp(b *testing.B) {
+	v := MetricsDeleteResp{}
+	bts := make([]byte, 0, v.Msgsize())
+	bts, _ = v.MarshalMsg(bts[0:0])
+	b.SetBytes(int64(len(bts)))
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		bts, _ = v.MarshalMsg(bts[0:0])
+	}
+}
+
+func BenchmarkUnmarshalMetricsDeleteResp(b *testing.B) {
+	v := MetricsDeleteResp{}
+	bts, _ := v.MarshalMsg(nil)
+	b.ReportAllocs()
+	b.SetBytes(int64(len(bts)))
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_, err := v.UnmarshalMsg(bts)
+		if err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func TestEncodeDecodeMetricsDeleteResp(t *testing.T) {
+	v := MetricsDeleteResp{}
+	var buf bytes.Buffer
+	msgp.Encode(&buf, &v)
+
+	m := v.Msgsize()
+	if buf.Len() > m {
+		t.Logf("WARNING: Msgsize() for %v is inaccurate", v)
+	}
+
+	vn := MetricsDeleteResp{}
+	err := msgp.Decode(&buf, &vn)
+	if err != nil {
+		t.Error(err)
+	}
+
+	buf.Reset()
+	msgp.Encode(&buf, &v)
+	err = msgp.NewReader(&buf).Skip()
+	if err != nil {
+		t.Error(err)
+	}
+}
+
+func BenchmarkEncodeMetricsDeleteResp(b *testing.B) {
+	v := MetricsDeleteResp{}
+	var buf bytes.Buffer
+	msgp.Encode(&buf, &v)
+	b.SetBytes(int64(buf.Len()))
+	en := msgp.NewWriter(msgp.Nowhere)
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		v.EncodeMsg(en)
+	}
+	en.Flush()
+}
+
+func BenchmarkDecodeMetricsDeleteResp(b *testing.B) {
+	v := MetricsDeleteResp{}
+	var buf bytes.Buffer
+	msgp.Encode(&buf, &v)
+	b.SetBytes(int64(buf.Len()))
+	rd := msgp.NewEndlessReader(buf.Bytes(), b)
+	dc := msgp.NewReader(rd)
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		err := v.DecodeMsg(dc)
+		if err != nil {
+			b.Fatal(err)
+		}
+	}
+}

--- a/api/models/cluster_gen_test.go
+++ b/api/models/cluster_gen_test.go
@@ -1,0 +1,238 @@
+package models
+
+// NOTE: THIS FILE WAS PRODUCED BY THE
+// MSGP CODE GENERATION TOOL (github.com/tinylib/msgp)
+// DO NOT EDIT
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/tinylib/msgp/msgp"
+)
+
+func TestMarshalUnmarshalGetDataResp(t *testing.T) {
+	v := GetDataResp{}
+	bts, err := v.MarshalMsg(nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	left, err := v.UnmarshalMsg(bts)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(left) > 0 {
+		t.Errorf("%d bytes left over after UnmarshalMsg(): %q", len(left), left)
+	}
+
+	left, err = msgp.Skip(bts)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(left) > 0 {
+		t.Errorf("%d bytes left over after Skip(): %q", len(left), left)
+	}
+}
+
+func BenchmarkMarshalMsgGetDataResp(b *testing.B) {
+	v := GetDataResp{}
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		v.MarshalMsg(nil)
+	}
+}
+
+func BenchmarkAppendMsgGetDataResp(b *testing.B) {
+	v := GetDataResp{}
+	bts := make([]byte, 0, v.Msgsize())
+	bts, _ = v.MarshalMsg(bts[0:0])
+	b.SetBytes(int64(len(bts)))
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		bts, _ = v.MarshalMsg(bts[0:0])
+	}
+}
+
+func BenchmarkUnmarshalGetDataResp(b *testing.B) {
+	v := GetDataResp{}
+	bts, _ := v.MarshalMsg(nil)
+	b.ReportAllocs()
+	b.SetBytes(int64(len(bts)))
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_, err := v.UnmarshalMsg(bts)
+		if err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func TestEncodeDecodeGetDataResp(t *testing.T) {
+	v := GetDataResp{}
+	var buf bytes.Buffer
+	msgp.Encode(&buf, &v)
+
+	m := v.Msgsize()
+	if buf.Len() > m {
+		t.Logf("WARNING: Msgsize() for %v is inaccurate", v)
+	}
+
+	vn := GetDataResp{}
+	err := msgp.Decode(&buf, &vn)
+	if err != nil {
+		t.Error(err)
+	}
+
+	buf.Reset()
+	msgp.Encode(&buf, &v)
+	err = msgp.NewReader(&buf).Skip()
+	if err != nil {
+		t.Error(err)
+	}
+}
+
+func BenchmarkEncodeGetDataResp(b *testing.B) {
+	v := GetDataResp{}
+	var buf bytes.Buffer
+	msgp.Encode(&buf, &v)
+	b.SetBytes(int64(buf.Len()))
+	en := msgp.NewWriter(msgp.Nowhere)
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		v.EncodeMsg(en)
+	}
+	en.Flush()
+}
+
+func BenchmarkDecodeGetDataResp(b *testing.B) {
+	v := GetDataResp{}
+	var buf bytes.Buffer
+	msgp.Encode(&buf, &v)
+	b.SetBytes(int64(buf.Len()))
+	rd := msgp.NewEndlessReader(buf.Bytes(), b)
+	dc := msgp.NewReader(rd)
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		err := v.DecodeMsg(dc)
+		if err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func TestMarshalUnmarshalIndexFindResp(t *testing.T) {
+	v := IndexFindResp{}
+	bts, err := v.MarshalMsg(nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	left, err := v.UnmarshalMsg(bts)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(left) > 0 {
+		t.Errorf("%d bytes left over after UnmarshalMsg(): %q", len(left), left)
+	}
+
+	left, err = msgp.Skip(bts)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(left) > 0 {
+		t.Errorf("%d bytes left over after Skip(): %q", len(left), left)
+	}
+}
+
+func BenchmarkMarshalMsgIndexFindResp(b *testing.B) {
+	v := IndexFindResp{}
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		v.MarshalMsg(nil)
+	}
+}
+
+func BenchmarkAppendMsgIndexFindResp(b *testing.B) {
+	v := IndexFindResp{}
+	bts := make([]byte, 0, v.Msgsize())
+	bts, _ = v.MarshalMsg(bts[0:0])
+	b.SetBytes(int64(len(bts)))
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		bts, _ = v.MarshalMsg(bts[0:0])
+	}
+}
+
+func BenchmarkUnmarshalIndexFindResp(b *testing.B) {
+	v := IndexFindResp{}
+	bts, _ := v.MarshalMsg(nil)
+	b.ReportAllocs()
+	b.SetBytes(int64(len(bts)))
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_, err := v.UnmarshalMsg(bts)
+		if err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func TestEncodeDecodeIndexFindResp(t *testing.T) {
+	v := IndexFindResp{}
+	var buf bytes.Buffer
+	msgp.Encode(&buf, &v)
+
+	m := v.Msgsize()
+	if buf.Len() > m {
+		t.Logf("WARNING: Msgsize() for %v is inaccurate", v)
+	}
+
+	vn := IndexFindResp{}
+	err := msgp.Decode(&buf, &vn)
+	if err != nil {
+		t.Error(err)
+	}
+
+	buf.Reset()
+	msgp.Encode(&buf, &v)
+	err = msgp.NewReader(&buf).Skip()
+	if err != nil {
+		t.Error(err)
+	}
+}
+
+func BenchmarkEncodeIndexFindResp(b *testing.B) {
+	v := IndexFindResp{}
+	var buf bytes.Buffer
+	msgp.Encode(&buf, &v)
+	b.SetBytes(int64(buf.Len()))
+	en := msgp.NewWriter(msgp.Nowhere)
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		v.EncodeMsg(en)
+	}
+	en.Flush()
+}
+
+func BenchmarkDecodeIndexFindResp(b *testing.B) {
+	v := IndexFindResp{}
+	var buf bytes.Buffer
+	msgp.Encode(&buf, &v)
+	b.SetBytes(int64(buf.Len()))
+	rd := msgp.NewEndlessReader(buf.Bytes(), b)
+	dc := msgp.NewReader(rd)
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		err := v.DecodeMsg(dc)
+		if err != nil {
+			b.Fatal(err)
+		}
+	}
+}

--- a/api/models/node.go
+++ b/api/models/node.go
@@ -32,6 +32,6 @@ type GetData struct {
 }
 
 type IndexDelete struct {
-	Query string `json:"patterns" form:"query" binding:"Required"`
+	Query string `json:"query" form:"query" binding:"Required"`
 	OrgId int    `json:"orgId" form:"orgId" binding:"Required"`
 }

--- a/api/models/node.go
+++ b/api/models/node.go
@@ -30,3 +30,8 @@ type IndexFind struct {
 type GetData struct {
 	Requests []Req `json:"requests" binding:"Required"`
 }
+
+type IndexDelete struct {
+	Query string `json:"patterns" form:"query" binding:"Required"`
+	OrgId int    `json:"orgId" form:"orgId" binding:"Required"`
+}

--- a/api/models/node.go
+++ b/api/models/node.go
@@ -1,0 +1,32 @@
+package models
+
+import (
+	"github.com/raintank/metrictank/cluster"
+)
+
+type NodeStatus struct {
+	Primary bool `json:"primary" form:"primary" binding:"Required"`
+}
+
+type ClusterStatus struct {
+	Node  *cluster.Node   `json:"node"`
+	Peers []*cluster.Node `json:"peers"`
+}
+
+type IndexList struct {
+	OrgId int `json:"orgId" form:"orgId" binding:"Required"`
+}
+
+type IndexGet struct {
+	Id string `json:"id" form:"id" binding:"Required"`
+}
+
+type IndexFind struct {
+	Patterns []string `json:"patterns" form:"patterns" binding:"Required"`
+	OrgId    int      `json:"orgId" form:"orgId" binding:"Required"`
+	From     int64    `json:"from" form:"from"`
+}
+
+type GetData struct {
+	Requests []Req `json:"requests" binding:"Required"`
+}

--- a/api/models/request.go
+++ b/api/models/request.go
@@ -2,6 +2,7 @@ package models
 
 import (
 	"fmt"
+	"github.com/raintank/metrictank/cluster"
 	"github.com/raintank/metrictank/consolidation"
 	"github.com/raintank/metrictank/util"
 )
@@ -15,6 +16,7 @@ type Req struct {
 	MaxPoints    uint32                     `json:"maxPoints"`
 	RawInterval  uint32                     `json:"rawInterval"` // the interval of the raw metric before any consolidation
 	Consolidator consolidation.Consolidator `json:"consolidator"`
+	Node         *cluster.Node              `json:"-"`
 
 	// these fields need some more coordination and are typically set later
 	Archive      int    `json:"archive"`      // 0 means original data, 1 means first agg level, 2 means 2nd, etc.
@@ -23,7 +25,7 @@ type Req struct {
 	AggNum       uint32 `json:"aggNum"`       // how many points to consolidate together at runtime, after fetching from the archive
 }
 
-func NewReq(key, target string, from, to, maxPoints, rawInterval uint32, consolidator consolidation.Consolidator) Req {
+func NewReq(key, target string, from, to, maxPoints, rawInterval uint32, consolidator consolidation.Consolidator, node *cluster.Node) Req {
 	return Req{
 		key,
 		target,
@@ -32,6 +34,7 @@ func NewReq(key, target string, from, to, maxPoints, rawInterval uint32, consoli
 		maxPoints,
 		rawInterval,
 		consolidator,
+		node,
 		-1, // this is supposed to be updated still!
 		0,  // this is supposed to be updated still
 		0,  // this is supposed to be updated still

--- a/api/models/series.go
+++ b/api/models/series.go
@@ -7,6 +7,7 @@ import (
 	"gopkg.in/raintank/schema.v1"
 )
 
+//go:generate msgp
 type Series struct {
 	Target     string // will be set to the target attribute of the given request
 	Datapoints []schema.Point

--- a/api/models/series_gen.go
+++ b/api/models/series_gen.go
@@ -13,13 +13,13 @@ import (
 func (z *Series) DecodeMsg(dc *msgp.Reader) (err error) {
 	var field []byte
 	_ = field
-	var zbzg uint32
-	zbzg, err = dc.ReadMapHeader()
+	var isz uint32
+	isz, err = dc.ReadMapHeader()
 	if err != nil {
 		return
 	}
-	for zbzg > 0 {
-		zbzg--
+	for isz > 0 {
+		isz--
 		field, err = dc.ReadMapKeyPtr()
 		if err != nil {
 			return
@@ -31,18 +31,18 @@ func (z *Series) DecodeMsg(dc *msgp.Reader) (err error) {
 				return
 			}
 		case "Datapoints":
-			var zbai uint32
-			zbai, err = dc.ReadArrayHeader()
+			var xsz uint32
+			xsz, err = dc.ReadArrayHeader()
 			if err != nil {
 				return
 			}
-			if cap(z.Datapoints) >= int(zbai) {
-				z.Datapoints = (z.Datapoints)[:zbai]
+			if cap(z.Datapoints) >= int(xsz) {
+				z.Datapoints = z.Datapoints[:xsz]
 			} else {
-				z.Datapoints = make([]schema.Point, zbai)
+				z.Datapoints = make([]schema.Point, xsz)
 			}
-			for zxvk := range z.Datapoints {
-				err = z.Datapoints[zxvk].DecodeMsg(dc)
+			for xvk := range z.Datapoints {
+				err = z.Datapoints[xvk].DecodeMsg(dc)
 				if err != nil {
 					return
 				}
@@ -83,8 +83,8 @@ func (z *Series) EncodeMsg(en *msgp.Writer) (err error) {
 	if err != nil {
 		return
 	}
-	for zxvk := range z.Datapoints {
-		err = z.Datapoints[zxvk].EncodeMsg(en)
+	for xvk := range z.Datapoints {
+		err = z.Datapoints[xvk].EncodeMsg(en)
 		if err != nil {
 			return
 		}
@@ -111,8 +111,8 @@ func (z *Series) MarshalMsg(b []byte) (o []byte, err error) {
 	// string "Datapoints"
 	o = append(o, 0xaa, 0x44, 0x61, 0x74, 0x61, 0x70, 0x6f, 0x69, 0x6e, 0x74, 0x73)
 	o = msgp.AppendArrayHeader(o, uint32(len(z.Datapoints)))
-	for zxvk := range z.Datapoints {
-		o, err = z.Datapoints[zxvk].MarshalMsg(o)
+	for xvk := range z.Datapoints {
+		o, err = z.Datapoints[xvk].MarshalMsg(o)
 		if err != nil {
 			return
 		}
@@ -127,13 +127,13 @@ func (z *Series) MarshalMsg(b []byte) (o []byte, err error) {
 func (z *Series) UnmarshalMsg(bts []byte) (o []byte, err error) {
 	var field []byte
 	_ = field
-	var zcmr uint32
-	zcmr, bts, err = msgp.ReadMapHeaderBytes(bts)
+	var isz uint32
+	isz, bts, err = msgp.ReadMapHeaderBytes(bts)
 	if err != nil {
 		return
 	}
-	for zcmr > 0 {
-		zcmr--
+	for isz > 0 {
+		isz--
 		field, bts, err = msgp.ReadMapKeyZC(bts)
 		if err != nil {
 			return
@@ -145,18 +145,18 @@ func (z *Series) UnmarshalMsg(bts []byte) (o []byte, err error) {
 				return
 			}
 		case "Datapoints":
-			var zajw uint32
-			zajw, bts, err = msgp.ReadArrayHeaderBytes(bts)
+			var xsz uint32
+			xsz, bts, err = msgp.ReadArrayHeaderBytes(bts)
 			if err != nil {
 				return
 			}
-			if cap(z.Datapoints) >= int(zajw) {
-				z.Datapoints = (z.Datapoints)[:zajw]
+			if cap(z.Datapoints) >= int(xsz) {
+				z.Datapoints = z.Datapoints[:xsz]
 			} else {
-				z.Datapoints = make([]schema.Point, zajw)
+				z.Datapoints = make([]schema.Point, xsz)
 			}
-			for zxvk := range z.Datapoints {
-				bts, err = z.Datapoints[zxvk].UnmarshalMsg(bts)
+			for xvk := range z.Datapoints {
+				bts, err = z.Datapoints[xvk].UnmarshalMsg(bts)
 				if err != nil {
 					return
 				}
@@ -177,11 +177,10 @@ func (z *Series) UnmarshalMsg(bts []byte) (o []byte, err error) {
 	return
 }
 
-// Msgsize returns an upper bound estimate of the number of bytes occupied by the serialized message
 func (z *Series) Msgsize() (s int) {
 	s = 1 + 7 + msgp.StringPrefixSize + len(z.Target) + 11 + msgp.ArrayHeaderSize
-	for zxvk := range z.Datapoints {
-		s += z.Datapoints[zxvk].Msgsize()
+	for xvk := range z.Datapoints {
+		s += z.Datapoints[xvk].Msgsize()
 	}
 	s += 9 + msgp.Uint32Size
 	return
@@ -189,18 +188,18 @@ func (z *Series) Msgsize() (s int) {
 
 // DecodeMsg implements msgp.Decodable
 func (z *SeriesByTarget) DecodeMsg(dc *msgp.Reader) (err error) {
-	var zcua uint32
-	zcua, err = dc.ReadArrayHeader()
+	var xsz uint32
+	xsz, err = dc.ReadArrayHeader()
 	if err != nil {
 		return
 	}
-	if cap((*z)) >= int(zcua) {
-		(*z) = (*z)[:zcua]
+	if cap((*z)) >= int(xsz) {
+		(*z) = (*z)[:xsz]
 	} else {
-		(*z) = make(SeriesByTarget, zcua)
+		(*z) = make(SeriesByTarget, xsz)
 	}
-	for zhct := range *z {
-		err = (*z)[zhct].DecodeMsg(dc)
+	for bai := range *z {
+		err = (*z)[bai].DecodeMsg(dc)
 		if err != nil {
 			return
 		}
@@ -214,8 +213,8 @@ func (z SeriesByTarget) EncodeMsg(en *msgp.Writer) (err error) {
 	if err != nil {
 		return
 	}
-	for zxhx := range z {
-		err = z[zxhx].EncodeMsg(en)
+	for cmr := range z {
+		err = z[cmr].EncodeMsg(en)
 		if err != nil {
 			return
 		}
@@ -227,8 +226,8 @@ func (z SeriesByTarget) EncodeMsg(en *msgp.Writer) (err error) {
 func (z SeriesByTarget) MarshalMsg(b []byte) (o []byte, err error) {
 	o = msgp.Require(b, z.Msgsize())
 	o = msgp.AppendArrayHeader(o, uint32(len(z)))
-	for zxhx := range z {
-		o, err = z[zxhx].MarshalMsg(o)
+	for cmr := range z {
+		o, err = z[cmr].MarshalMsg(o)
 		if err != nil {
 			return
 		}
@@ -238,18 +237,18 @@ func (z SeriesByTarget) MarshalMsg(b []byte) (o []byte, err error) {
 
 // UnmarshalMsg implements msgp.Unmarshaler
 func (z *SeriesByTarget) UnmarshalMsg(bts []byte) (o []byte, err error) {
-	var zdaf uint32
-	zdaf, bts, err = msgp.ReadArrayHeaderBytes(bts)
+	var xsz uint32
+	xsz, bts, err = msgp.ReadArrayHeaderBytes(bts)
 	if err != nil {
 		return
 	}
-	if cap((*z)) >= int(zdaf) {
-		(*z) = (*z)[:zdaf]
+	if cap((*z)) >= int(xsz) {
+		(*z) = (*z)[:xsz]
 	} else {
-		(*z) = make(SeriesByTarget, zdaf)
+		(*z) = make(SeriesByTarget, xsz)
 	}
-	for zlqf := range *z {
-		bts, err = (*z)[zlqf].UnmarshalMsg(bts)
+	for ajw := range *z {
+		bts, err = (*z)[ajw].UnmarshalMsg(bts)
 		if err != nil {
 			return
 		}
@@ -258,11 +257,10 @@ func (z *SeriesByTarget) UnmarshalMsg(bts []byte) (o []byte, err error) {
 	return
 }
 
-// Msgsize returns an upper bound estimate of the number of bytes occupied by the serialized message
 func (z SeriesByTarget) Msgsize() (s int) {
 	s = msgp.ArrayHeaderSize
-	for zpks := range z {
-		s += z[zpks].Msgsize()
+	for wht := range z {
+		s += z[wht].Msgsize()
 	}
 	return
 }

--- a/api/models/series_gen.go
+++ b/api/models/series_gen.go
@@ -1,0 +1,268 @@
+package models
+
+// NOTE: THIS FILE WAS PRODUCED BY THE
+// MSGP CODE GENERATION TOOL (github.com/tinylib/msgp)
+// DO NOT EDIT
+
+import (
+	"github.com/tinylib/msgp/msgp"
+	"gopkg.in/raintank/schema.v1"
+)
+
+// DecodeMsg implements msgp.Decodable
+func (z *Series) DecodeMsg(dc *msgp.Reader) (err error) {
+	var field []byte
+	_ = field
+	var zbzg uint32
+	zbzg, err = dc.ReadMapHeader()
+	if err != nil {
+		return
+	}
+	for zbzg > 0 {
+		zbzg--
+		field, err = dc.ReadMapKeyPtr()
+		if err != nil {
+			return
+		}
+		switch msgp.UnsafeString(field) {
+		case "Target":
+			z.Target, err = dc.ReadString()
+			if err != nil {
+				return
+			}
+		case "Datapoints":
+			var zbai uint32
+			zbai, err = dc.ReadArrayHeader()
+			if err != nil {
+				return
+			}
+			if cap(z.Datapoints) >= int(zbai) {
+				z.Datapoints = (z.Datapoints)[:zbai]
+			} else {
+				z.Datapoints = make([]schema.Point, zbai)
+			}
+			for zxvk := range z.Datapoints {
+				err = z.Datapoints[zxvk].DecodeMsg(dc)
+				if err != nil {
+					return
+				}
+			}
+		case "Interval":
+			z.Interval, err = dc.ReadUint32()
+			if err != nil {
+				return
+			}
+		default:
+			err = dc.Skip()
+			if err != nil {
+				return
+			}
+		}
+	}
+	return
+}
+
+// EncodeMsg implements msgp.Encodable
+func (z *Series) EncodeMsg(en *msgp.Writer) (err error) {
+	// map header, size 3
+	// write "Target"
+	err = en.Append(0x83, 0xa6, 0x54, 0x61, 0x72, 0x67, 0x65, 0x74)
+	if err != nil {
+		return err
+	}
+	err = en.WriteString(z.Target)
+	if err != nil {
+		return
+	}
+	// write "Datapoints"
+	err = en.Append(0xaa, 0x44, 0x61, 0x74, 0x61, 0x70, 0x6f, 0x69, 0x6e, 0x74, 0x73)
+	if err != nil {
+		return err
+	}
+	err = en.WriteArrayHeader(uint32(len(z.Datapoints)))
+	if err != nil {
+		return
+	}
+	for zxvk := range z.Datapoints {
+		err = z.Datapoints[zxvk].EncodeMsg(en)
+		if err != nil {
+			return
+		}
+	}
+	// write "Interval"
+	err = en.Append(0xa8, 0x49, 0x6e, 0x74, 0x65, 0x72, 0x76, 0x61, 0x6c)
+	if err != nil {
+		return err
+	}
+	err = en.WriteUint32(z.Interval)
+	if err != nil {
+		return
+	}
+	return
+}
+
+// MarshalMsg implements msgp.Marshaler
+func (z *Series) MarshalMsg(b []byte) (o []byte, err error) {
+	o = msgp.Require(b, z.Msgsize())
+	// map header, size 3
+	// string "Target"
+	o = append(o, 0x83, 0xa6, 0x54, 0x61, 0x72, 0x67, 0x65, 0x74)
+	o = msgp.AppendString(o, z.Target)
+	// string "Datapoints"
+	o = append(o, 0xaa, 0x44, 0x61, 0x74, 0x61, 0x70, 0x6f, 0x69, 0x6e, 0x74, 0x73)
+	o = msgp.AppendArrayHeader(o, uint32(len(z.Datapoints)))
+	for zxvk := range z.Datapoints {
+		o, err = z.Datapoints[zxvk].MarshalMsg(o)
+		if err != nil {
+			return
+		}
+	}
+	// string "Interval"
+	o = append(o, 0xa8, 0x49, 0x6e, 0x74, 0x65, 0x72, 0x76, 0x61, 0x6c)
+	o = msgp.AppendUint32(o, z.Interval)
+	return
+}
+
+// UnmarshalMsg implements msgp.Unmarshaler
+func (z *Series) UnmarshalMsg(bts []byte) (o []byte, err error) {
+	var field []byte
+	_ = field
+	var zcmr uint32
+	zcmr, bts, err = msgp.ReadMapHeaderBytes(bts)
+	if err != nil {
+		return
+	}
+	for zcmr > 0 {
+		zcmr--
+		field, bts, err = msgp.ReadMapKeyZC(bts)
+		if err != nil {
+			return
+		}
+		switch msgp.UnsafeString(field) {
+		case "Target":
+			z.Target, bts, err = msgp.ReadStringBytes(bts)
+			if err != nil {
+				return
+			}
+		case "Datapoints":
+			var zajw uint32
+			zajw, bts, err = msgp.ReadArrayHeaderBytes(bts)
+			if err != nil {
+				return
+			}
+			if cap(z.Datapoints) >= int(zajw) {
+				z.Datapoints = (z.Datapoints)[:zajw]
+			} else {
+				z.Datapoints = make([]schema.Point, zajw)
+			}
+			for zxvk := range z.Datapoints {
+				bts, err = z.Datapoints[zxvk].UnmarshalMsg(bts)
+				if err != nil {
+					return
+				}
+			}
+		case "Interval":
+			z.Interval, bts, err = msgp.ReadUint32Bytes(bts)
+			if err != nil {
+				return
+			}
+		default:
+			bts, err = msgp.Skip(bts)
+			if err != nil {
+				return
+			}
+		}
+	}
+	o = bts
+	return
+}
+
+// Msgsize returns an upper bound estimate of the number of bytes occupied by the serialized message
+func (z *Series) Msgsize() (s int) {
+	s = 1 + 7 + msgp.StringPrefixSize + len(z.Target) + 11 + msgp.ArrayHeaderSize
+	for zxvk := range z.Datapoints {
+		s += z.Datapoints[zxvk].Msgsize()
+	}
+	s += 9 + msgp.Uint32Size
+	return
+}
+
+// DecodeMsg implements msgp.Decodable
+func (z *SeriesByTarget) DecodeMsg(dc *msgp.Reader) (err error) {
+	var zcua uint32
+	zcua, err = dc.ReadArrayHeader()
+	if err != nil {
+		return
+	}
+	if cap((*z)) >= int(zcua) {
+		(*z) = (*z)[:zcua]
+	} else {
+		(*z) = make(SeriesByTarget, zcua)
+	}
+	for zhct := range *z {
+		err = (*z)[zhct].DecodeMsg(dc)
+		if err != nil {
+			return
+		}
+	}
+	return
+}
+
+// EncodeMsg implements msgp.Encodable
+func (z SeriesByTarget) EncodeMsg(en *msgp.Writer) (err error) {
+	err = en.WriteArrayHeader(uint32(len(z)))
+	if err != nil {
+		return
+	}
+	for zxhx := range z {
+		err = z[zxhx].EncodeMsg(en)
+		if err != nil {
+			return
+		}
+	}
+	return
+}
+
+// MarshalMsg implements msgp.Marshaler
+func (z SeriesByTarget) MarshalMsg(b []byte) (o []byte, err error) {
+	o = msgp.Require(b, z.Msgsize())
+	o = msgp.AppendArrayHeader(o, uint32(len(z)))
+	for zxhx := range z {
+		o, err = z[zxhx].MarshalMsg(o)
+		if err != nil {
+			return
+		}
+	}
+	return
+}
+
+// UnmarshalMsg implements msgp.Unmarshaler
+func (z *SeriesByTarget) UnmarshalMsg(bts []byte) (o []byte, err error) {
+	var zdaf uint32
+	zdaf, bts, err = msgp.ReadArrayHeaderBytes(bts)
+	if err != nil {
+		return
+	}
+	if cap((*z)) >= int(zdaf) {
+		(*z) = (*z)[:zdaf]
+	} else {
+		(*z) = make(SeriesByTarget, zdaf)
+	}
+	for zlqf := range *z {
+		bts, err = (*z)[zlqf].UnmarshalMsg(bts)
+		if err != nil {
+			return
+		}
+	}
+	o = bts
+	return
+}
+
+// Msgsize returns an upper bound estimate of the number of bytes occupied by the serialized message
+func (z SeriesByTarget) Msgsize() (s int) {
+	s = msgp.ArrayHeaderSize
+	for zpks := range z {
+		s += z[zpks].Msgsize()
+	}
+	return
+}

--- a/api/models/series_gen_test.go
+++ b/api/models/series_gen_test.go
@@ -1,0 +1,238 @@
+package models
+
+// NOTE: THIS FILE WAS PRODUCED BY THE
+// MSGP CODE GENERATION TOOL (github.com/tinylib/msgp)
+// DO NOT EDIT
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/tinylib/msgp/msgp"
+)
+
+func TestMarshalUnmarshalSeries(t *testing.T) {
+	v := Series{}
+	bts, err := v.MarshalMsg(nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	left, err := v.UnmarshalMsg(bts)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(left) > 0 {
+		t.Errorf("%d bytes left over after UnmarshalMsg(): %q", len(left), left)
+	}
+
+	left, err = msgp.Skip(bts)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(left) > 0 {
+		t.Errorf("%d bytes left over after Skip(): %q", len(left), left)
+	}
+}
+
+func BenchmarkMarshalMsgSeries(b *testing.B) {
+	v := Series{}
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		v.MarshalMsg(nil)
+	}
+}
+
+func BenchmarkAppendMsgSeries(b *testing.B) {
+	v := Series{}
+	bts := make([]byte, 0, v.Msgsize())
+	bts, _ = v.MarshalMsg(bts[0:0])
+	b.SetBytes(int64(len(bts)))
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		bts, _ = v.MarshalMsg(bts[0:0])
+	}
+}
+
+func BenchmarkUnmarshalSeries(b *testing.B) {
+	v := Series{}
+	bts, _ := v.MarshalMsg(nil)
+	b.ReportAllocs()
+	b.SetBytes(int64(len(bts)))
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_, err := v.UnmarshalMsg(bts)
+		if err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func TestEncodeDecodeSeries(t *testing.T) {
+	v := Series{}
+	var buf bytes.Buffer
+	msgp.Encode(&buf, &v)
+
+	m := v.Msgsize()
+	if buf.Len() > m {
+		t.Logf("WARNING: Msgsize() for %v is inaccurate", v)
+	}
+
+	vn := Series{}
+	err := msgp.Decode(&buf, &vn)
+	if err != nil {
+		t.Error(err)
+	}
+
+	buf.Reset()
+	msgp.Encode(&buf, &v)
+	err = msgp.NewReader(&buf).Skip()
+	if err != nil {
+		t.Error(err)
+	}
+}
+
+func BenchmarkEncodeSeries(b *testing.B) {
+	v := Series{}
+	var buf bytes.Buffer
+	msgp.Encode(&buf, &v)
+	b.SetBytes(int64(buf.Len()))
+	en := msgp.NewWriter(msgp.Nowhere)
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		v.EncodeMsg(en)
+	}
+	en.Flush()
+}
+
+func BenchmarkDecodeSeries(b *testing.B) {
+	v := Series{}
+	var buf bytes.Buffer
+	msgp.Encode(&buf, &v)
+	b.SetBytes(int64(buf.Len()))
+	rd := msgp.NewEndlessReader(buf.Bytes(), b)
+	dc := msgp.NewReader(rd)
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		err := v.DecodeMsg(dc)
+		if err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func TestMarshalUnmarshalSeriesByTarget(t *testing.T) {
+	v := SeriesByTarget{}
+	bts, err := v.MarshalMsg(nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	left, err := v.UnmarshalMsg(bts)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(left) > 0 {
+		t.Errorf("%d bytes left over after UnmarshalMsg(): %q", len(left), left)
+	}
+
+	left, err = msgp.Skip(bts)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(left) > 0 {
+		t.Errorf("%d bytes left over after Skip(): %q", len(left), left)
+	}
+}
+
+func BenchmarkMarshalMsgSeriesByTarget(b *testing.B) {
+	v := SeriesByTarget{}
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		v.MarshalMsg(nil)
+	}
+}
+
+func BenchmarkAppendMsgSeriesByTarget(b *testing.B) {
+	v := SeriesByTarget{}
+	bts := make([]byte, 0, v.Msgsize())
+	bts, _ = v.MarshalMsg(bts[0:0])
+	b.SetBytes(int64(len(bts)))
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		bts, _ = v.MarshalMsg(bts[0:0])
+	}
+}
+
+func BenchmarkUnmarshalSeriesByTarget(b *testing.B) {
+	v := SeriesByTarget{}
+	bts, _ := v.MarshalMsg(nil)
+	b.ReportAllocs()
+	b.SetBytes(int64(len(bts)))
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_, err := v.UnmarshalMsg(bts)
+		if err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func TestEncodeDecodeSeriesByTarget(t *testing.T) {
+	v := SeriesByTarget{}
+	var buf bytes.Buffer
+	msgp.Encode(&buf, &v)
+
+	m := v.Msgsize()
+	if buf.Len() > m {
+		t.Logf("WARNING: Msgsize() for %v is inaccurate", v)
+	}
+
+	vn := SeriesByTarget{}
+	err := msgp.Decode(&buf, &vn)
+	if err != nil {
+		t.Error(err)
+	}
+
+	buf.Reset()
+	msgp.Encode(&buf, &v)
+	err = msgp.NewReader(&buf).Skip()
+	if err != nil {
+		t.Error(err)
+	}
+}
+
+func BenchmarkEncodeSeriesByTarget(b *testing.B) {
+	v := SeriesByTarget{}
+	var buf bytes.Buffer
+	msgp.Encode(&buf, &v)
+	b.SetBytes(int64(buf.Len()))
+	en := msgp.NewWriter(msgp.Nowhere)
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		v.EncodeMsg(en)
+	}
+	en.Flush()
+}
+
+func BenchmarkDecodeSeriesByTarget(b *testing.B) {
+	v := SeriesByTarget{}
+	var buf bytes.Buffer
+	msgp.Encode(&buf, &v)
+	b.SetBytes(int64(buf.Len()))
+	rd := msgp.NewEndlessReader(buf.Bytes(), b)
+	dc := msgp.NewReader(rd)
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		err := v.DecodeMsg(dc)
+		if err != nil {
+			b.Fatal(err)
+		}
+	}
+}

--- a/api/response/error.go
+++ b/api/response/error.go
@@ -1,30 +1,53 @@
 package response
 
-type Error struct {
-	code int
-	err  error
+type Error interface {
+	Code() int
+	Error() string
 }
 
-func NewError(code int, err error) *Error {
-	return &Error{
+type ErrorResp struct {
+	code int
+	err  string
+}
+
+func WrapError(e error) *ErrorResp {
+	if _, ok := e.(*ErrorResp); ok {
+		return e.(*ErrorResp)
+	}
+	resp := &ErrorResp{
+		err:  e.Error(),
+		code: 500,
+	}
+	if _, ok := e.(Error); ok {
+		resp.code = e.(Error).Code()
+	}
+	return resp
+}
+
+func NewError(code int, err string) *ErrorResp {
+	return &ErrorResp{
 		code: code,
 		err:  err,
 	}
 }
 
-func (r *Error) Code() int {
+func (r *ErrorResp) Error() string {
+	return r.err
+}
+
+func (r *ErrorResp) Code() int {
 	return r.code
 }
 
-func (r *Error) Close() {
+func (r *ErrorResp) Close() {
 	return
 }
 
-func (r *Error) Body() ([]byte, error) {
-	return []byte(r.err.Error()), nil
+func (r *ErrorResp) Body() ([]byte, error) {
+	return []byte(r.err), nil
 }
 
-func (r *Error) Headers() (headers map[string]string) {
+func (r *ErrorResp) Headers() (headers map[string]string) {
 	headers = map[string]string{"content-type": "text/plain"}
 	return headers
 }

--- a/api/routes.go
+++ b/api/routes.go
@@ -19,6 +19,14 @@ func (s *Server) RegisterRoutes() {
 	r.Get("/", s.appStatus)
 	r.Get("/node", s.getNodeStatus)
 	r.Post("/node", bind(models.NodeStatus{}), s.setNodeStatus)
+	// Internal api endpoints used for inter cluster communication
+	r.Group("/cluster", func() {
+		r.Get("/", s.getClusterStatus)
+		r.Combo("/getdata", bind(models.GetData{})).Get(s.getData).Post(s.getData)
+		r.Combo("/index/find", bind(models.IndexFind{})).Get(s.indexFind).Post(s.indexFind)
+		r.Combo("/index/get", bind(models.IndexGet{})).Get(s.indexGet).Post(s.indexGet)
+		r.Combo("/index/list", bind(models.IndexList{})).Get(s.indexList).Post(s.indexList)
+	})
 
 	r.Options("/*", func(ctx *macaron.Context) {
 		ctx.Write(nil)

--- a/api/routes.go
+++ b/api/routes.go
@@ -26,6 +26,7 @@ func (s *Server) RegisterRoutes() {
 		r.Combo("/index/find", bind(models.IndexFind{})).Get(s.indexFind).Post(s.indexFind)
 		r.Combo("/index/get", bind(models.IndexGet{})).Get(s.indexGet).Post(s.indexGet)
 		r.Combo("/index/list", bind(models.IndexList{})).Get(s.indexList).Post(s.indexList)
+		r.Combo("/index/delete", bind(models.IndexDelete{})).Get(s.indexDelete).Post(s.indexDelete)
 	})
 
 	r.Options("/*", func(ctx *macaron.Context) {

--- a/api/routes.go
+++ b/api/routes.go
@@ -19,15 +19,15 @@ func (s *Server) RegisterRoutes() {
 	r.Get("/", s.appStatus)
 	r.Get("/node", s.getNodeStatus)
 	r.Post("/node", bind(models.NodeStatus{}), s.setNodeStatus)
-	// Internal api endpoints used for inter cluster communication
-	r.Group("/cluster", func() {
-		r.Get("/", s.getClusterStatus)
-		r.Combo("/getdata", bind(models.GetData{})).Get(s.getData).Post(s.getData)
-		r.Combo("/index/find", bind(models.IndexFind{})).Get(s.indexFind).Post(s.indexFind)
-		r.Combo("/index/get", bind(models.IndexGet{})).Get(s.indexGet).Post(s.indexGet)
-		r.Combo("/index/list", bind(models.IndexList{})).Get(s.indexList).Post(s.indexList)
-		r.Combo("/index/delete", bind(models.IndexDelete{})).Get(s.indexDelete).Post(s.indexDelete)
-	})
+
+	r.Get("/cluster", s.getClusterStatus)
+
+	r.Combo("/getdata", bind(models.GetData{})).Get(s.getData).Post(s.getData)
+
+	r.Combo("/index/find", bind(models.IndexFind{})).Get(s.indexFind).Post(s.indexFind)
+	r.Combo("/index/list", bind(models.IndexList{})).Get(s.indexList).Post(s.indexList)
+	r.Combo("/index/delete", bind(models.IndexDelete{})).Get(s.indexDelete).Post(s.indexDelete)
+	r.Combo("/index/get", bind(models.IndexGet{})).Get(s.indexGet).Post(s.indexGet)
 
 	r.Options("/*", func(ctx *macaron.Context) {
 		ctx.Write(nil)

--- a/cluster/cluster.go
+++ b/cluster/cluster.go
@@ -1,18 +1,146 @@
 package cluster
 
 import (
+	"math/rand"
+	"net/url"
+	"sync"
 	"time"
 )
 
-var ThisNode *Node
+type ModeType string
 
-func Init(name, version string, primary bool, started time.Time) {
+const (
+	ModeSingle = "single"
+	ModeMulti  = "multi"
+)
+
+func validMode(m string) bool {
+	if ModeType(m) == ModeSingle || ModeType(m) == ModeMulti {
+		return true
+	}
+	return false
+}
+
+var (
+	ThisNode *Node
+	Mode     ModeType
+	shutdown = make(chan struct{})
+
+	mu    sync.Mutex
+	peers = make([]*Node, 0)
+)
+
+func Init(name, version string, started time.Time) {
 	ThisNode = &Node{
 		name:          name,
 		started:       started,
 		version:       version,
-		primary:       primary,
+		primary:       false,
 		primaryChange: time.Now(),
 		stateChange:   time.Now(),
 	}
+}
+
+func Stop() {
+	close(shutdown)
+}
+
+func Start() {
+	go probePeers(probeInterval)
+}
+
+func AddPeer(remoteAddr *url.URL) {
+	mu.Lock()
+	peer := &Node{
+		remoteAddr:  remoteAddr,
+		stateChange: time.Now(),
+	}
+	peers = append(peers, peer)
+	go peer.Probe()
+	mu.Unlock()
+}
+
+func GetPeers() []*Node {
+	mu.Lock()
+	p := make([]*Node, len(peers))
+	copy(p, peers)
+	mu.Unlock()
+	return p
+}
+
+func probePeers(interval time.Duration) {
+	ticker := time.NewTicker(interval)
+	for {
+		select {
+		case <-shutdown:
+			ticker.Stop()
+			return
+		case <-ticker.C:
+			mu.Lock()
+			for _, peer := range peers {
+				go peer.Probe()
+			}
+			mu.Unlock()
+		}
+	}
+}
+
+// return the list of nodes to broadcast requests to
+// Only 1 peer per partition is returned. This list includes
+// ThisNode if it is capable of handling queries.
+func PeersForQuery() []*Node {
+	// If we are running in single mode, just return thisNode
+	if Mode == ModeSingle {
+		return []*Node{ThisNode}
+	}
+
+	peersMap := make(map[int32][]*Node)
+	if ThisNode.IsReady() {
+		for _, part := range ThisNode.GetPartitions() {
+			peersMap[part] = []*Node{ThisNode}
+		}
+	}
+	mu.Lock()
+	for _, peer := range peers {
+		if !peer.IsReady() {
+			continue
+		}
+		for _, part := range peer.GetPartitions() {
+			peersMap[part] = append(peersMap[part], peer)
+		}
+	}
+	mu.Unlock()
+	selectedPeers := make(map[*Node]struct{})
+	answer := make([]*Node, 0)
+	// we want to get the minimum number of nodes
+	// needed to cover all partitions
+	for _, nodes := range peersMap {
+		selected := nodes[0]
+		// always prefer the local node which will be nodes[0]
+		// if it has this partition
+		if selected != ThisNode {
+			// check if we are already going to use one of the
+			// available nodes and re-use it
+			reusePeer := false
+			for _, n := range nodes {
+				if _, ok := selectedPeers[n]; ok {
+					selected = n
+					reusePeer = true
+					break
+				}
+			}
+			// if no nodes have been selected yet then grab a
+			// random node from the set of available nodes
+			if !reusePeer {
+				selected = nodes[rand.Intn(len(nodes))]
+			}
+		}
+
+		if _, ok := selectedPeers[selected]; !ok {
+			selectedPeers[selected] = struct{}{}
+			answer = append(answer, selected)
+		}
+	}
+
+	return answer
 }

--- a/cluster/cluster_test.go
+++ b/cluster/cluster_test.go
@@ -40,7 +40,7 @@ func TestPeersForQuery(t *testing.T) {
 	Convey("when cluster in multi mode", t, func() {
 		selected := PeersForQuery()
 		So(selected, ShouldHaveLength, 2)
-		So(selected[0], ShouldEqual, ThisNode)
+		So(selected, ShouldContain, ThisNode)
 		Convey("peers should be selected randomly with even distribution", func() {
 			peerCount := make(map[string]int)
 			for i := 0; i < 1000; i++ {

--- a/cluster/cluster_test.go
+++ b/cluster/cluster_test.go
@@ -1,0 +1,62 @@
+package cluster
+
+import (
+	. "github.com/smartystreets/goconvey/convey"
+	"testing"
+	"time"
+)
+
+func TestPeersForQuery(t *testing.T) {
+	Init("node1", "test", time.Now())
+	ThisNode.SetPrimary(true)
+	ThisNode.SetPartitions([]int32{1, 2})
+	ThisNode.SetReady()
+	Convey("when cluster in single mode", t, func() {
+		selected := PeersForQuery()
+		So(selected, ShouldHaveLength, 1)
+		So(selected[0], ShouldEqual, ThisNode)
+	})
+	mu.Lock()
+	Mode = ModeMulti
+	peers = append(peers, &Node{
+		name:       "node2",
+		primary:    true,
+		partitions: []int32{1, 2},
+		state:      NodeReady,
+	})
+	peers = append(peers, &Node{
+		name:       "node3",
+		primary:    true,
+		partitions: []int32{3, 4},
+		state:      NodeReady,
+	})
+	peers = append(peers, &Node{
+		name:       "node4",
+		primary:    true,
+		partitions: []int32{3, 4},
+		state:      NodeReady,
+	})
+	mu.Unlock()
+	Convey("when cluster in multi mode", t, func() {
+		selected := PeersForQuery()
+		So(selected, ShouldHaveLength, 2)
+		So(selected[0], ShouldEqual, ThisNode)
+		Convey("peers should be selected randomly with even distribution", func() {
+			peerCount := make(map[string]int)
+			for i := 0; i < 1000; i++ {
+				selected = PeersForQuery()
+				for _, p := range selected {
+					peerCount[p.GetName()]++
+				}
+			}
+			So(peerCount["node1"], ShouldEqual, 1000)
+			So(peerCount["node2"], ShouldEqual, 0)
+			So(peerCount["node3"], ShouldNotAlmostEqual, 500)
+			So(peerCount["node4"], ShouldNotAlmostEqual, 500)
+			for p, count := range peerCount {
+				t.Logf("%s: %d", p, count)
+			}
+		})
+	})
+
+}

--- a/cluster/config.go
+++ b/cluster/config.go
@@ -1,0 +1,59 @@
+package cluster
+
+import (
+	"flag"
+	"fmt"
+	"net/url"
+	"strings"
+	"time"
+
+	"github.com/raintank/worldping-api/pkg/log"
+	"github.com/rakyll/globalconf"
+)
+
+var (
+	primary          bool
+	peersStr         string
+	probeIntervalStr string
+	probeInterval    time.Duration
+	mode             string
+)
+
+func ConfigSetup() {
+	clusterCfg := flag.NewFlagSet("cluster", flag.ExitOnError)
+	clusterCfg.BoolVar(&primary, "primary-node", false, "the primary node writes data to cassandra. There should only be 1 primary node per cluster of nodes.")
+	clusterCfg.StringVar(&peersStr, "peers", "", "http/s addresses of other nodes, comma separated. use this if you shard your data and want to query other instances")
+	clusterCfg.StringVar(&probeIntervalStr, "probe-interval", "2s", "Interval to probe peer nodes")
+	clusterCfg.StringVar(&mode, "mode", "single", "Operating mode of cluster. (single|multi)")
+	globalconf.Register("cluster", clusterCfg)
+}
+
+func ConfigProcess() {
+	var err error
+	probeInterval, err = time.ParseDuration(probeIntervalStr)
+	if err != nil {
+		log.Fatal(4, "probe-interval could not be parsed. %s", err)
+	}
+
+	if !validMode(mode) {
+		log.Fatal(4, "invalid cluster operating mode")
+	}
+
+	Mode = ModeType(mode)
+
+	if peersStr != "" {
+		for _, peer := range strings.Split(peersStr, ",") {
+			// if peers are listed as "host:port" then assume they are using http
+			if !strings.HasPrefix(peer, "http://") && !strings.HasPrefix(peer, "https://") {
+				peer = fmt.Sprintf("http://%s", peer)
+			}
+			peer = strings.TrimSuffix(peer, "/")
+			addr, err := url.Parse(peer)
+			if err != nil {
+				log.Fatal(4, "Unable to parse Peer address %s: %s", peer, err)
+			}
+			AddPeer(addr)
+		}
+	}
+	ThisNode.SetPrimary(primary)
+}

--- a/cluster/config.go
+++ b/cluster/config.go
@@ -21,7 +21,7 @@ var (
 
 func ConfigSetup() {
 	clusterCfg := flag.NewFlagSet("cluster", flag.ExitOnError)
-	clusterCfg.BoolVar(&primary, "primary-node", false, "the primary node writes data to cassandra. There should only be 1 primary node per cluster of nodes.")
+	clusterCfg.BoolVar(&primary, "primary-node", false, "the primary node writes data to cassandra. There should only be 1 primary node per shardGroup.")
 	clusterCfg.StringVar(&peersStr, "peers", "", "http/s addresses of other nodes, comma separated. use this if you shard your data and want to query other instances")
 	clusterCfg.StringVar(&probeIntervalStr, "probe-interval", "2s", "Interval to probe peer nodes")
 	clusterCfg.StringVar(&mode, "mode", "single", "Operating mode of cluster. (single|multi)")

--- a/cluster/node.go
+++ b/cluster/node.go
@@ -78,7 +78,7 @@ type Node struct {
 	name          string
 	version       string
 	started       time.Time
-	remoteAddr    *url.URL
+	remoteAddr    *url.URL //will be Nil for ThisNode
 	primary       bool
 	primaryChange time.Time
 	state         NodeState

--- a/cluster/node.go
+++ b/cluster/node.go
@@ -51,6 +51,28 @@ func NodeStateFromString(s string) NodeState {
 	return NodeNotReady
 }
 
+type Error struct {
+	code int
+	err  error
+}
+
+func NewError(code int, err error) *Error {
+	return &Error{
+		code: code,
+		err:  err,
+	}
+}
+
+// implement errors.Error interface
+func (r *Error) Error() string {
+	return r.err.Error()
+}
+
+// implement response.Response
+func (r *Error) Code() int {
+	return r.code
+}
+
 type Node struct {
 	sync.RWMutex
 	name          string
@@ -181,7 +203,7 @@ func (n *Node) Get(path string, query interface{}) ([]byte, error) {
 	if query != nil {
 		qstr, err := toQueryString(query)
 		if err != nil {
-			return nil, err
+			return nil, NewError(http.StatusInternalServerError, err)
 		}
 		path = path + "?" + qstr
 	}
@@ -190,11 +212,12 @@ func (n *Node) Get(path string, query interface{}) ([]byte, error) {
 	n.RUnlock()
 	req, err := http.NewRequest("GET", addr, nil)
 	if err != nil {
-		return nil, err
+		return nil, NewError(http.StatusInternalServerError, err)
 	}
 	rsp, err := client.Do(req)
 	if err != nil {
-		return nil, err
+		log.Error(3, "Cluster Node: %s unreachable. %s", n.GetName(), err.Error())
+		return nil, NewError(http.StatusServiceUnavailable, fmt.Errorf("cluster node unavailable"))
 	}
 	return handleResp(rsp)
 }
@@ -202,7 +225,7 @@ func (n *Node) Get(path string, query interface{}) ([]byte, error) {
 func (n *Node) Post(path string, body interface{}) ([]byte, error) {
 	b, err := json.Marshal(body)
 	if err != nil {
-		return nil, err
+		return nil, NewError(http.StatusInternalServerError, err)
 	}
 	var reader *bytes.Reader
 	reader = bytes.NewReader(b)
@@ -211,12 +234,13 @@ func (n *Node) Post(path string, body interface{}) ([]byte, error) {
 	n.RUnlock()
 	req, err := http.NewRequest("POST", addr, reader)
 	if err != nil {
-		return nil, err
+		return nil, NewError(http.StatusInternalServerError, err)
 	}
 	req.Header.Add("Content-Type", "application/json")
 	rsp, err := client.Do(req)
 	if err != nil {
-		return nil, err
+		log.Error(3, "Cluster Node: %s unreachable. %s", n.GetName(), err.Error())
+		return nil, NewError(http.StatusServiceUnavailable, fmt.Errorf("cluster node unavailable"))
 	}
 	return handleResp(rsp)
 }
@@ -224,7 +248,7 @@ func (n *Node) Post(path string, body interface{}) ([]byte, error) {
 func handleResp(rsp *http.Response) ([]byte, error) {
 	defer rsp.Body.Close()
 	if rsp.StatusCode != 200 {
-		return nil, fmt.Errorf("error encountered. %s", rsp.Status)
+		return nil, NewError(rsp.StatusCode, fmt.Errorf(rsp.Status))
 	}
 	return ioutil.ReadAll(rsp.Body)
 }

--- a/cluster/node.go
+++ b/cluster/node.go
@@ -1,9 +1,19 @@
 package cluster
 
 import (
+	"bytes"
+	"crypto/tls"
 	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"net"
+	"net/http"
+	"net/url"
 	"sync"
 	"time"
+
+	"github.com/google/go-querystring/query"
+	"github.com/raintank/worldping-api/pkg/log"
 )
 
 //go:generate stringer -type=NodeState
@@ -12,22 +22,54 @@ type NodeState int
 const (
 	NodeNotReady NodeState = iota
 	NodeReady
+	NodeUnreachable
 )
 
-type Node struct {
-	name    string
-	version string
-	started time.Time
+var client = http.Client{
+	Transport: &http.Transport{
+		TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
+		Proxy:           http.ProxyFromEnvironment,
+		Dial: (&net.Dialer{
+			Timeout:   time.Second * 5,
+			KeepAlive: 30 * time.Second,
+		}).Dial,
+		TLSHandshakeTimeout: time.Second,
+	},
+	Timeout: time.Second,
+}
 
+func NodeStateFromString(s string) NodeState {
+	switch s {
+	case "NodeNotReady":
+		return NodeNotReady
+	case "NodeReady":
+		return NodeReady
+	case "NodeUnreachable":
+		return NodeUnreachable
+	}
+	//default
+	return NodeNotReady
+}
+
+type Node struct {
 	sync.RWMutex
+	name          string
+	version       string
+	started       time.Time
+	remoteAddr    *url.URL
 	primary       bool
 	primaryChange time.Time
 	state         NodeState
 	stateChange   time.Time
+	partitions    []int32
+	probing       bool
 }
 
 func (n *Node) GetName() string {
-	return n.name
+	n.RLock()
+	name := n.name
+	n.RUnlock()
+	return name
 }
 
 // Returns True if the node is a Primary node which
@@ -75,18 +117,150 @@ func (n *Node) SetState(s NodeState) {
 	n.Unlock()
 }
 
-// provide thread safe json Marshaling
-func (n *Node) MarshalJSON() ([]byte, error) {
+func (n *Node) SetPartitions(part []int32) {
+	n.Lock()
+	n.partitions = part
+	n.Unlock()
+}
+func (n *Node) GetPartitions() []int32 {
 	n.RLock()
-	defer n.RUnlock()
-	return json.Marshal(&nodeJS{
+	part := n.partitions
+	n.RUnlock()
+	return part
+}
+
+func (n *Node) Probe() {
+	n.Lock()
+	if n.probing {
+		n.Unlock()
+		return
+	}
+	n.probing = true
+	n.Unlock()
+	update := nodeJS{}
+	resp, err := n.Get("/node", nil)
+	n.Lock()
+	defer func() {
+		n.probing = false
+		n.Unlock()
+	}()
+	if err != nil {
+		log.Warn("cluster: failed to get status of peer %s. %s", n.name, err)
+		if n.state != NodeUnreachable {
+			n.state = NodeUnreachable
+			n.stateChange = time.Now()
+		}
+		return
+	}
+
+	err = json.Unmarshal(resp, &update)
+	if err != nil {
+		log.Warn("cluster: failed to decode response from peer at address %s: %s\n\n%s", n.remoteAddr.String(), err, resp)
+		if n.state != NodeNotReady {
+			n.state = NodeNotReady
+			n.stateChange = time.Now()
+		}
+		return
+	}
+
+	if n.state.String() != update.State {
+		log.Info("cluster: node %s in new state: %s", update.Name, update.State)
+	}
+
+	n.name = update.Name
+	n.version = update.Version
+	n.started = update.Started
+	n.primary = update.Primary
+	n.primaryChange = update.PrimaryChange
+	n.state = NodeStateFromString(update.State)
+	n.stateChange = update.StateChange
+	n.partitions = update.Partitions
+}
+
+func (n *Node) Get(path string, query interface{}) ([]byte, error) {
+	if query != nil {
+		qstr, err := toQueryString(query)
+		if err != nil {
+			return nil, err
+		}
+		path = path + "?" + qstr
+	}
+	n.RLock()
+	addr := n.remoteAddr.String() + path
+	n.RUnlock()
+	req, err := http.NewRequest("GET", addr, nil)
+	if err != nil {
+		return nil, err
+	}
+	rsp, err := client.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	return handleResp(rsp)
+}
+
+func (n *Node) Post(path string, body interface{}) ([]byte, error) {
+	b, err := json.Marshal(body)
+	if err != nil {
+		return nil, err
+	}
+	var reader *bytes.Reader
+	reader = bytes.NewReader(b)
+	n.RLock()
+	addr := n.remoteAddr.String() + path
+	n.RUnlock()
+	req, err := http.NewRequest("POST", addr, reader)
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Add("Content-Type", "application/json")
+	rsp, err := client.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	return handleResp(rsp)
+}
+
+func handleResp(rsp *http.Response) ([]byte, error) {
+	defer rsp.Body.Close()
+	if rsp.StatusCode != 200 {
+		return nil, fmt.Errorf("error encountered. %s", rsp.Status)
+	}
+	return ioutil.ReadAll(rsp.Body)
+}
+
+// Convert an interface{} to a urlencoded querystring
+func toQueryString(q interface{}) (string, error) {
+	v, err := query.Values(q)
+	if err != nil {
+		return "", err
+	}
+	return v.Encode(), nil
+}
+
+func (n *Node) toNodeJS() nodeJS {
+	n.RLock()
+	addr := ""
+	if n.remoteAddr != nil {
+		addr = n.remoteAddr.String()
+	}
+	njs := nodeJS{
 		Name:          n.name,
 		Version:       n.version,
 		Primary:       n.primary,
 		PrimaryChange: n.primaryChange,
 		State:         n.state.String(),
 		StateChange:   n.stateChange,
-	})
+		Partitions:    n.partitions,
+		RemoteAddress: addr,
+	}
+	n.RUnlock()
+	return njs
+}
+
+// provide thread safe json Marshaling
+func (n *Node) MarshalJSON() ([]byte, error) {
+	return json.Marshal(n.toNodeJS())
 }
 
 // intermediary struct to enable thread safe json marshaling
@@ -98,4 +272,6 @@ type nodeJS struct {
 	State         string    `json:"state"`
 	Started       time.Time `json:"started"`
 	StateChange   time.Time `json:"stateChange"`
+	Partitions    []int32   `json:"partitions"`
+	RemoteAddress string    `json:"remoteAddress"`
 }

--- a/cluster/nodestate_string.go
+++ b/cluster/nodestate_string.go
@@ -4,9 +4,9 @@ package cluster
 
 import "fmt"
 
-const _NodeState_name = "NodeNotReadyNodeReady"
+const _NodeState_name = "NodeNotReadyNodeReadyNodeUnreachable"
 
-var _NodeState_index = [...]uint8{0, 12, 21}
+var _NodeState_index = [...]uint8{0, 12, 21, 36}
 
 func (i NodeState) String() string {
 	if i < 0 || i >= NodeState(len(_NodeState_index)-1) {

--- a/docs/cassandra.md
+++ b/docs/cassandra.md
@@ -34,11 +34,20 @@ CREATE TABLE IF NOT EXISTS raintank.metric (
 If you are using the [cassandra-idx](https://github.com/raintank/metrictank/blob/master/docs/metadata.md) (Cassandra backed storage for the MetricDefinitions index), the following table will also be created.
 
 ```
-CREATE TABLE IF NOT EXISTS raintank.metric_def_idx (
-    id text PRIMARY KEY,
-    def blob,
+CREATE TABLE IF NOT EXISTS raintank.metric_idx (
+    id text,
+    partition int,
+    name text,
+    metric text,
+    interval int,
+    unit text,
+    mtype text,
+    tags set<text>,
+    lastupdate int,
+    PRIMARY KEY (id, partition)
 ) WITH compaction = {'class': 'SizeTieredCompactionStrategy'}
-    AND compression = {'sstable_compression': 'org.apache.cassandra.io.compress.LZ4Compressor'}
+    AND compression = {'sstable_compression': 'org.apache.cassandra.io.compress.LZ4Compressor'};
+CREATE INDEX IF NOT EXISTS ON raintank.metric_idx(partition);
 ```
 
 These settings are good for development and geared towards Cassandra 3.0
@@ -57,11 +66,20 @@ CREATE TABLE IF NOT EXISTS raintank.metric (
     AND compaction = {'class': 'org.apache.cassandra.db.compaction.TimeWindowCompactionStrategy'}
     AND compression = {'sstable_compression': 'org.apache.cassandra.io.compress.LZ4Compressor'};
 
-CREATE TABLE IF NOT EXISTS raintank.metric_def_idx (
-    id text PRIMARY KEY,
-    def blob,
+CREATE TABLE IF NOT EXISTS raintank.metric_idx (
+    id text,
+    partition int,
+    name text,
+    metric text,
+    interval int,
+    unit text,
+    mtype text,
+    tags set<text>,
+    lastupdate int,
+    PRIMARY KEY (id, partition)
 ) WITH compaction = {'class': 'SizeTieredCompactionStrategy'}
     AND compression = {'sstable_compression': 'org.apache.cassandra.io.compress.LZ4Compressor'};
+CREATE INDEX IF NOT EXISTS ON raintank.metric_idx(partition);
 ```
 
 If you need to run Cassandra 2.2, the backported [TimeWindowCompactionStrategy](https://github.com/jeffjirsa/twcs) is probably your best bet.

--- a/docs/clustering.md
+++ b/docs/clustering.md
@@ -81,3 +81,13 @@ partitions | 0,1 | 0,2 | 1,3 | 2,3 |
 This would offer better load balancing should node A fail (B and C will each take over a portion of the load), but will require making primary status a per-partition concept.
 Hence, this is currently **not supported**.
 
+
+## Caveats
+
+If you get the following error:
+```
+2016/11/23 09:27:34 [metrictank.go:334 main()] [E] failed to initialize cassandra. java.lang.RuntimeException: java.util.concurrent.ExecutionException: org.apache.cassandra.exceptions.ConfigurationException: Column family ID mismatch (found 103be8f0-b15f-11e6-92df-7964cb8cd63c; expected 103902c0-b15f-11e6-92df-7964cb8cd63c)
+```
+
+This is because you start multiple metrictanks concurrently and they all try to initialize cassandra.
+You should start one instance, and once it's running, do the others.

--- a/docs/config.md
+++ b/docs/config.md
@@ -57,6 +57,7 @@ warm-up-period = 1h
 # with these aggregation rules: 5min:1h:2:3mon,1h:6h:2:1y:false
 # 5 min of data, store in a chunk that lasts 1hour, keep 2 chunks in memory, keep for 3months in cassandra
 # 1hr worth of data, in chunks of 6 hours, 2 chunks in mem, keep for 1 year, but this series is not ready yet for querying.
+# When running multiple instances of metrictank in a cluster, all nodes in the cluster should have the same agg-settings config.
 agg-settings =
 ```
 

--- a/docs/config.md
+++ b/docs/config.md
@@ -57,7 +57,7 @@ warm-up-period = 1h
 # with these aggregation rules: 5min:1h:2:3mon,1h:6h:2:1y:false
 # 5 min of data, store in a chunk that lasts 1hour, keep 2 chunks in memory, keep for 3months in cassandra
 # 1hr worth of data, in chunks of 6 hours, 2 chunks in mem, keep for 1 year, but this series is not ready yet for querying.
-# When running multiple instances of metrictank in a cluster, all nodes in the cluster should have the same agg-settings config.
+# When running a cluster of metrictank instances, all instances should have the same agg-settings.
 agg-settings =
 ```
 

--- a/docs/config.md
+++ b/docs/config.md
@@ -31,13 +31,6 @@ instance = default
 accounting-period = 5min
 ```
 
-## clustering ##
-
-```
-# the primary node writes data to cassandra. There should only be 1 primary node per cluster of nodes
-primary-node = false
-```
-
 ## data ##
 
 ```
@@ -66,8 +59,6 @@ warm-up-period = 1h
 # 1hr worth of data, in chunks of 6 hours, 2 chunks in mem, keep for 1 year, but this series is not ready yet for querying.
 agg-settings =
 ```
-
-
 
 ## metric data storage in cassandra ##
 
@@ -169,6 +160,8 @@ log-min-dur = 5min
 enabled = false
 # tcp address
 addr = :2003
+# represents the "partition" of your data if you decide to partition your data.
+partition = 1
 # needed to know your raw resolution for your metrics. see http://graphite.readthedocs.io/en/latest/config-carbon.html#storage-schemas-conf
 # NOTE: does NOT use aggregation and retention settings from this file.  We use agg-settings and ttl for that.
 schemas-file = /path/to/your/schemas-file
@@ -186,6 +179,8 @@ topics = mdm
 # offset to start consuming from. Can be one of newest, oldest,last or a time duration
 # the further back in time you go, the more old data you can load into metrictank, but the longer it takes to catch up to realtime data
 offset = last
+# kafka partitions to consume. use '*' or a comma separated list of id's
+partitions = *
 # save interval for offsets
 offset-commit-interval = 5s
 # directory to store partition offsets index. supports relative or absolute paths. empty means working dir.
@@ -203,7 +198,21 @@ consumer-max-processing-time = 1s
 net-max-open-requests = 100
 ```
 
-## clustering transports ##
+## basic clustering settings ##
+
+```
+[cluster]
+# The primary node writes data to cassandra. There should only be 1 primary node per shardGroup.
+primary-node = true
+# http/s addresses of other nodes, comma separated. use this if you shard your data and want to query other instances
+peers =
+# Interval to probe peer nodes
+probe-interval = 2s
+# Operating mode of cluster. (single|multi)
+mode = single
+```
+
+## clustering transports for tracking chunk saves between replicated instances ##
 ### kafka as transport for clustering messages (recommended)
 
 ```

--- a/docs/http-api.md
+++ b/docs/http-api.md
@@ -1,5 +1,7 @@
 # HTTP api
 
+This documents endpoints aimed to be used by users.
+(for internal clustering http endpoints, which may change, refer to the source)
 Note that some of the endpoints rely on being a fed a proper Org-Id.
 You may not want to expose directly to people if they can control that header.
 Instead, you may want to run [graphite-metrictank](https://github.com/raintank/graphite-metrictank) in front,

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -6,7 +6,7 @@ While Metrictank takes in tag metadata in the form of [metrics2.0](http://metric
 There will be various benefits in adopting metrics2.0 fully (better choices for consolidation, data conversion, supplying unit information to Grafana, etc)
 see [Tags](https://github.com/raintank/metrictank/blob/master/docs/tags.md)
 
-## Sharding / partitioning
+## More advanced clustering
 
-As mentioned above Cassandra already does that for the storage layer, but at a certain point we'll need it for the memory layer as well.
-
+Current limitations: manual promotions, statically defined peers, per-instance primary status instead of per-shard, so you can't shuffle shard replicas across nodes.
+see [clustering](https://github.com/raintank/metrictank/blob/master/docs/clustering.md) for more info)

--- a/idx/cassandra/cassandra_test.go
+++ b/idx/cassandra/cassandra_test.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/raintank/met/helper"
+	"github.com/raintank/metrictank/cluster"
 	"github.com/raintank/metrictank/idx"
 	. "github.com/smartystreets/goconvey/convey"
 	"gopkg.in/raintank/schema.v1"
@@ -22,6 +23,8 @@ func init() {
 	numConns = 1
 	writeQueueSize = 1000
 	protoVer = 4
+
+	cluster.Init("default", "test", time.Now())
 }
 
 func getSeriesNames(depth, count int, prefix string) []string {
@@ -80,7 +83,7 @@ func TestGetAddKey(t *testing.T) {
 		orgId := series[0].OrgId
 		Convey(fmt.Sprintf("When indexing metrics for orgId %d", orgId), t, func() {
 			for _, s := range series {
-				ix.Add(s)
+				ix.Add(s, 1)
 			}
 			Convey(fmt.Sprintf("Then listing metrics for OrgId %d", orgId), func() {
 				defs := ix.List(orgId)
@@ -98,7 +101,7 @@ func TestGetAddKey(t *testing.T) {
 		for _, series := range org1Series {
 			series.Interval = 60
 			series.SetId()
-			ix.Add(series)
+			ix.Add(series, 1)
 		}
 		Convey("then listing metrics", func() {
 			defs := ix.List(1)
@@ -112,19 +115,19 @@ func TestFind(t *testing.T) {
 	stats, _ := helper.New(false, "", "standard", "metrictank", "")
 	ix.Init(stats)
 	for _, s := range getMetricData(-1, 2, 5, 10, "metric.demo") {
-		ix.Add(s)
+		ix.Add(s, 1)
 	}
 	for _, s := range getMetricData(1, 2, 5, 10, "metric.demo") {
-		ix.Add(s)
+		ix.Add(s, 1)
 	}
 	for _, s := range getMetricData(1, 1, 5, 10, "foo.demo") {
-		ix.Add(s)
+		ix.Add(s, 1)
 		s.Interval = 60
 		s.SetId()
-		ix.Add(s)
+		ix.Add(s, 1)
 	}
 	for _, s := range getMetricData(2, 2, 5, 10, "metric.foo") {
-		ix.Add(s)
+		ix.Add(s, 1)
 	}
 
 	Convey("When listing root nodes", t, func() {
@@ -246,7 +249,7 @@ func insertDefs(ix idx.MetricIndex, i int) {
 			OrgId:    1,
 		}
 		data.SetId()
-		ix.Add(data)
+		ix.Add(data, 1)
 	}
 }
 

--- a/idx/elasticsearch/elasticsearch.go
+++ b/idx/elasticsearch/elasticsearch.go
@@ -228,7 +228,7 @@ func (e *EsIdx) Add(data *schema.MetricData, partition int32) error {
 	}
 	def := schema.MetricDefinitionFromMetricData(data)
 	def.Partition = partition
-	if inMemory && existing.Partition != def.Partition {
+	if inMemory && existing.Partition == def.Partition {
 		log.Debug("def already seen before. Just updating memory Index")
 		e.MemoryIdx.AddDef(def)
 		return nil

--- a/idx/elasticsearch/mapping.go
+++ b/idx/elasticsearch/mapping.go
@@ -1,80 +1,83 @@
 package elasticsearch
 
 var mapping = `{
-	"mappings": {
-	    "_default_": {
-		"dynamic_templates": [
-		    {
-			"strings": {
-			    "mapping": {
-				"index": "not_analyzed",
-				"type": "string"
-			    },
-			    "match_mapping_type": "string"
-			}
-		    }
-		],
-		"_all": {
-		    "enabled": false
-		},
-		"properties": {}
-	    },
-	    "metric_index": {
-		"dynamic_templates": [
-		    {
-			"strings": {
-			    "mapping": {
-				"index": "not_analyzed",
-				"type": "string"
-			    },
-			    "match_mapping_type": "string"
-			}
-		    }
-		],
-		"_all": {
-		    "enabled": false
-		},
-		"_timestamp": {
-		    "enabled": false
-		},
-		"properties": {
-		    "id": {
-			"type": "string",
-			"index": "not_analyzed"
-		    },
-		    "interval": {
-			"type": "long"
-		    },
-		    "lastUpdate": {
-			"type": "long"
-		    },
-		    "metric": {
-			"type": "string",
-			"index": "not_analyzed"
-		    },
-		    "name": {
-			"type": "string",
-			"index": "not_analyzed"
-		    },
-		    "node_count": {
-			"type": "long"
-		    },
-		    "org_id": {
-			"type": "long"
-		    },
-		    "tags": {
-			"type": "string",
-			"index": "not_analyzed"
-		    },
-		    "mtype": {
-			"type": "string",
-			"index": "not_analyzed"
-		    },
-		    "unit": {
-			"type": "string",
-			"index": "not_analyzed"
-		    }
-		}
+    "mappings": {
+        "_default_": {
+            "dynamic_templates": [
+                {
+                    "strings": {
+                        "mapping": {
+                            "index": "not_analyzed",
+                            "type": "string"
+                        },
+                        "match_mapping_type": "string"
+                    }
+                }
+            ],
+            "_all": {
+                "enabled": false
+            },
+            "properties": {}
+        },
+        "metric_index": {
+            "dynamic_templates": [
+                {
+                    "strings": {
+                        "mapping": {
+                            "index": "not_analyzed",
+                            "type": "string"
+                        },
+                        "match_mapping_type": "string"
+                    }
+                }
+            ],
+            "_all": {
+                "enabled": false
+            },
+            "_timestamp": {
+                "enabled": false
+            },
+            "properties": {
+                "id": {
+                    "type": "string",
+                    "index": "not_analyzed"
+                },
+                "interval": {
+                    "type": "long"
+                },
+                "lastUpdate": {
+                    "type": "long"
+                },
+                "metric": {
+                    "type": "string",
+                    "index": "not_analyzed"
+                },
+                "name": {
+                    "type": "string",
+                    "index": "not_analyzed"
+                },
+                "node_count": {
+                    "type": "long"
+                },
+                "org_id": {
+                    "type": "long"
+                },
+                "tags": {
+                    "type": "string",
+                    "index": "not_analyzed"
+                },
+                "mtype": {
+                    "type": "string",
+                    "index": "not_analyzed"
+                },
+                "unit": {
+                    "type": "string",
+                    "index": "not_analyzed"
+                },
+                 "partition": {
+                    "type": "integer"
+                },
             }
-	}
+        }
+    }
 }`

--- a/idx/idx.go
+++ b/idx/idx.go
@@ -16,6 +16,7 @@ var (
 	BranchUnderLeaf   = errors.New("can't add branch under leaf")
 )
 
+//go:generate msgp
 type Node struct {
 	Path string
 	Leaf bool
@@ -48,9 +49,10 @@ Interface
 * Stop():
  This will be called when metrictank is shutting down.
 
-* Add(*schema.MetricData) error:
+* Add(*schema.MetricData, int32) error:
   Every metric received will result in a call to this method to ensure the
-  metric has been added to the index.
+  metric has been added to the index. The method is passed the metricData
+  payload and the partition id of the metric
 
 * Get(string) (schema.MetricDefinition, error):
   This method should return the  MetricDefintion with the passed Id.
@@ -85,7 +87,7 @@ Interface
 type MetricIndex interface {
 	Init(met.Backend) error
 	Stop()
-	Add(*schema.MetricData) error
+	Add(*schema.MetricData, int32) error
 	Get(string) (schema.MetricDefinition, error)
 	Delete(int, string) ([]schema.MetricDefinition, error)
 	Find(int, string, int64) ([]Node, error)

--- a/idx/idx_gen.go
+++ b/idx/idx_gen.go
@@ -1,0 +1,187 @@
+package idx
+
+// NOTE: THIS FILE WAS PRODUCED BY THE
+// MSGP CODE GENERATION TOOL (github.com/tinylib/msgp)
+// DO NOT EDIT
+
+import (
+	"github.com/tinylib/msgp/msgp"
+	"gopkg.in/raintank/schema.v1"
+)
+
+// DecodeMsg implements msgp.Decodable
+func (z *Node) DecodeMsg(dc *msgp.Reader) (err error) {
+	var field []byte
+	_ = field
+	var zbzg uint32
+	zbzg, err = dc.ReadMapHeader()
+	if err != nil {
+		return
+	}
+	for zbzg > 0 {
+		zbzg--
+		field, err = dc.ReadMapKeyPtr()
+		if err != nil {
+			return
+		}
+		switch msgp.UnsafeString(field) {
+		case "Path":
+			z.Path, err = dc.ReadString()
+			if err != nil {
+				return
+			}
+		case "Leaf":
+			z.Leaf, err = dc.ReadBool()
+			if err != nil {
+				return
+			}
+		case "Defs":
+			var zbai uint32
+			zbai, err = dc.ReadArrayHeader()
+			if err != nil {
+				return
+			}
+			if cap(z.Defs) >= int(zbai) {
+				z.Defs = (z.Defs)[:zbai]
+			} else {
+				z.Defs = make([]schema.MetricDefinition, zbai)
+			}
+			for zxvk := range z.Defs {
+				err = z.Defs[zxvk].DecodeMsg(dc)
+				if err != nil {
+					return
+				}
+			}
+		default:
+			err = dc.Skip()
+			if err != nil {
+				return
+			}
+		}
+	}
+	return
+}
+
+// EncodeMsg implements msgp.Encodable
+func (z *Node) EncodeMsg(en *msgp.Writer) (err error) {
+	// map header, size 3
+	// write "Path"
+	err = en.Append(0x83, 0xa4, 0x50, 0x61, 0x74, 0x68)
+	if err != nil {
+		return err
+	}
+	err = en.WriteString(z.Path)
+	if err != nil {
+		return
+	}
+	// write "Leaf"
+	err = en.Append(0xa4, 0x4c, 0x65, 0x61, 0x66)
+	if err != nil {
+		return err
+	}
+	err = en.WriteBool(z.Leaf)
+	if err != nil {
+		return
+	}
+	// write "Defs"
+	err = en.Append(0xa4, 0x44, 0x65, 0x66, 0x73)
+	if err != nil {
+		return err
+	}
+	err = en.WriteArrayHeader(uint32(len(z.Defs)))
+	if err != nil {
+		return
+	}
+	for zxvk := range z.Defs {
+		err = z.Defs[zxvk].EncodeMsg(en)
+		if err != nil {
+			return
+		}
+	}
+	return
+}
+
+// MarshalMsg implements msgp.Marshaler
+func (z *Node) MarshalMsg(b []byte) (o []byte, err error) {
+	o = msgp.Require(b, z.Msgsize())
+	// map header, size 3
+	// string "Path"
+	o = append(o, 0x83, 0xa4, 0x50, 0x61, 0x74, 0x68)
+	o = msgp.AppendString(o, z.Path)
+	// string "Leaf"
+	o = append(o, 0xa4, 0x4c, 0x65, 0x61, 0x66)
+	o = msgp.AppendBool(o, z.Leaf)
+	// string "Defs"
+	o = append(o, 0xa4, 0x44, 0x65, 0x66, 0x73)
+	o = msgp.AppendArrayHeader(o, uint32(len(z.Defs)))
+	for zxvk := range z.Defs {
+		o, err = z.Defs[zxvk].MarshalMsg(o)
+		if err != nil {
+			return
+		}
+	}
+	return
+}
+
+// UnmarshalMsg implements msgp.Unmarshaler
+func (z *Node) UnmarshalMsg(bts []byte) (o []byte, err error) {
+	var field []byte
+	_ = field
+	var zcmr uint32
+	zcmr, bts, err = msgp.ReadMapHeaderBytes(bts)
+	if err != nil {
+		return
+	}
+	for zcmr > 0 {
+		zcmr--
+		field, bts, err = msgp.ReadMapKeyZC(bts)
+		if err != nil {
+			return
+		}
+		switch msgp.UnsafeString(field) {
+		case "Path":
+			z.Path, bts, err = msgp.ReadStringBytes(bts)
+			if err != nil {
+				return
+			}
+		case "Leaf":
+			z.Leaf, bts, err = msgp.ReadBoolBytes(bts)
+			if err != nil {
+				return
+			}
+		case "Defs":
+			var zajw uint32
+			zajw, bts, err = msgp.ReadArrayHeaderBytes(bts)
+			if err != nil {
+				return
+			}
+			if cap(z.Defs) >= int(zajw) {
+				z.Defs = (z.Defs)[:zajw]
+			} else {
+				z.Defs = make([]schema.MetricDefinition, zajw)
+			}
+			for zxvk := range z.Defs {
+				bts, err = z.Defs[zxvk].UnmarshalMsg(bts)
+				if err != nil {
+					return
+				}
+			}
+		default:
+			bts, err = msgp.Skip(bts)
+			if err != nil {
+				return
+			}
+		}
+	}
+	o = bts
+	return
+}
+
+// Msgsize returns an upper bound estimate of the number of bytes occupied by the serialized message
+func (z *Node) Msgsize() (s int) {
+	s = 1 + 5 + msgp.StringPrefixSize + len(z.Path) + 5 + msgp.BoolSize + 5 + msgp.ArrayHeaderSize
+	for zxvk := range z.Defs {
+		s += z.Defs[zxvk].Msgsize()
+	}
+	return
+}

--- a/idx/idx_gen_test.go
+++ b/idx/idx_gen_test.go
@@ -1,0 +1,125 @@
+package idx
+
+// NOTE: THIS FILE WAS PRODUCED BY THE
+// MSGP CODE GENERATION TOOL (github.com/tinylib/msgp)
+// DO NOT EDIT
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/tinylib/msgp/msgp"
+)
+
+func TestMarshalUnmarshalNode(t *testing.T) {
+	v := Node{}
+	bts, err := v.MarshalMsg(nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	left, err := v.UnmarshalMsg(bts)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(left) > 0 {
+		t.Errorf("%d bytes left over after UnmarshalMsg(): %q", len(left), left)
+	}
+
+	left, err = msgp.Skip(bts)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(left) > 0 {
+		t.Errorf("%d bytes left over after Skip(): %q", len(left), left)
+	}
+}
+
+func BenchmarkMarshalMsgNode(b *testing.B) {
+	v := Node{}
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		v.MarshalMsg(nil)
+	}
+}
+
+func BenchmarkAppendMsgNode(b *testing.B) {
+	v := Node{}
+	bts := make([]byte, 0, v.Msgsize())
+	bts, _ = v.MarshalMsg(bts[0:0])
+	b.SetBytes(int64(len(bts)))
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		bts, _ = v.MarshalMsg(bts[0:0])
+	}
+}
+
+func BenchmarkUnmarshalNode(b *testing.B) {
+	v := Node{}
+	bts, _ := v.MarshalMsg(nil)
+	b.ReportAllocs()
+	b.SetBytes(int64(len(bts)))
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_, err := v.UnmarshalMsg(bts)
+		if err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func TestEncodeDecodeNode(t *testing.T) {
+	v := Node{}
+	var buf bytes.Buffer
+	msgp.Encode(&buf, &v)
+
+	m := v.Msgsize()
+	if buf.Len() > m {
+		t.Logf("WARNING: Msgsize() for %v is inaccurate", v)
+	}
+
+	vn := Node{}
+	err := msgp.Decode(&buf, &vn)
+	if err != nil {
+		t.Error(err)
+	}
+
+	buf.Reset()
+	msgp.Encode(&buf, &v)
+	err = msgp.NewReader(&buf).Skip()
+	if err != nil {
+		t.Error(err)
+	}
+}
+
+func BenchmarkEncodeNode(b *testing.B) {
+	v := Node{}
+	var buf bytes.Buffer
+	msgp.Encode(&buf, &v)
+	b.SetBytes(int64(buf.Len()))
+	en := msgp.NewWriter(msgp.Nowhere)
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		v.EncodeMsg(en)
+	}
+	en.Flush()
+}
+
+func BenchmarkDecodeNode(b *testing.B) {
+	v := Node{}
+	var buf bytes.Buffer
+	msgp.Encode(&buf, &v)
+	b.SetBytes(int64(buf.Len()))
+	rd := msgp.NewEndlessReader(buf.Bytes(), b)
+	dc := msgp.NewReader(rd)
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		err := v.DecodeMsg(dc)
+		if err != nil {
+			b.Fatal(err)
+		}
+	}
+}

--- a/idx/memory/memory.go
+++ b/idx/memory/memory.go
@@ -82,7 +82,7 @@ func (m *MemoryIdx) Stop() {
 	return
 }
 
-func (m *MemoryIdx) Add(data *schema.MetricData) error {
+func (m *MemoryIdx) Add(data *schema.MetricData, partition int32) error {
 	pre := time.Now()
 	m.Lock()
 	defer m.Unlock()
@@ -130,9 +130,9 @@ func (m *MemoryIdx) AddDef(def *schema.MetricDefinition) error {
 	pre := time.Now()
 	m.Lock()
 	defer m.Unlock()
-	if existing, ok := m.DefById[def.Id]; ok {
+	if _, ok := m.DefById[def.Id]; ok {
 		log.Debug("memory-idx: metricDef with id %s already in index.", def.Id)
-		existing.LastUpdate = def.LastUpdate
+		m.DefById[def.Id] = def
 		idxOk.Inc(1)
 		idxAddDuration.Value(time.Since(pre))
 		return nil

--- a/idx/memory/memory_find_test.go
+++ b/idx/memory/memory_find_test.go
@@ -65,7 +65,7 @@ func Init() {
 			OrgId:    1,
 		}
 		data.SetId()
-		ix.Add(data)
+		ix.Add(data, 1)
 	}
 	for _, series := range diskMetrics(5, 1000, 0, 10, "collectd") {
 		data = &schema.MetricData{
@@ -75,7 +75,7 @@ func Init() {
 			OrgId:    1,
 		}
 		data.SetId()
-		ix.Add(data)
+		ix.Add(data, 1)
 	}
 	// orgId has 1,680,000 series
 
@@ -87,7 +87,7 @@ func Init() {
 			OrgId:    2,
 		}
 		data.SetId()
-		ix.Add(data)
+		ix.Add(data, 1)
 	}
 	for _, series := range diskMetrics(5, 100, 950, 10, "collectd") {
 		data = &schema.MetricData{
@@ -97,7 +97,7 @@ func Init() {
 			OrgId:    2,
 		}
 		data.SetId()
-		ix.Add(data)
+		ix.Add(data, 1)
 	}
 	//orgId 2 has 168,000 mertics
 

--- a/idx/memory/memory_test.go
+++ b/idx/memory/memory_test.go
@@ -70,7 +70,7 @@ func TestGetAddKey(t *testing.T) {
 		orgId := series[0].OrgId
 		Convey(fmt.Sprintf("When indexing metrics for orgId %d", orgId), t, func() {
 			for _, s := range series {
-				ix.Add(s)
+				ix.Add(s, 1)
 			}
 			Convey(fmt.Sprintf("Then listing metrics for OrgId %d", orgId), func() {
 				defs := ix.List(orgId)
@@ -88,7 +88,7 @@ func TestGetAddKey(t *testing.T) {
 		for _, series := range org1Series {
 			series.Interval = 60
 			series.SetId()
-			ix.Add(series)
+			ix.Add(series, 1)
 		}
 		Convey("then listing metrics", func() {
 			defs := ix.List(1)
@@ -103,23 +103,23 @@ func TestFind(t *testing.T) {
 	ix.Init(stats)
 	for _, s := range getMetricData(-1, 2, 5, 10, "metric.demo") {
 		s.Time = 10 * 86400
-		ix.Add(s)
+		ix.Add(s, 1)
 	}
 	for _, s := range getMetricData(1, 2, 5, 10, "metric.demo") {
 		s.Time = 10 * 86400
-		ix.Add(s)
+		ix.Add(s, 1)
 	}
 	for _, s := range getMetricData(1, 1, 5, 10, "foo.demo") {
 		s.Time = 1 * 86400
-		ix.Add(s)
+		ix.Add(s, 1)
 		s.Time = 2 * 86400
 		s.Interval = 60
 		s.SetId()
-		ix.Add(s)
+		ix.Add(s, 1)
 	}
 	for _, s := range getMetricData(2, 2, 5, 10, "metric.foo") {
 		s.Time = 1 * 86400
-		ix.Add(s)
+		ix.Add(s, 1)
 	}
 
 	Convey("When listing root nodes", t, func() {
@@ -230,10 +230,10 @@ func TestDelete(t *testing.T) {
 	org1Series := getMetricData(1, 2, 5, 10, "metric.org1")
 
 	for _, s := range publicSeries {
-		ix.Add(s)
+		ix.Add(s, 1)
 	}
 	for _, s := range org1Series {
-		ix.Add(s)
+		ix.Add(s, 1)
 	}
 	Convey("when deleting exact path", t, func() {
 		defs, err := ix.Delete(1, org1Series[0].Name)
@@ -312,11 +312,11 @@ func TestBadAdd(t *testing.T) {
 
 	Convey("when adding the first metric", t, func() {
 
-		err := ix.Add(first)
+		err := ix.Add(first, 1)
 		So(err, ShouldBeNil)
 		Convey("we should not be able to add a leaf under another leaf", func() {
 
-			err = ix.Add(bad1)
+			err = ix.Add(bad1, 1)
 			So(err, ShouldEqual, idx.BranchUnderLeaf)
 			_, err := ix.Get(bad1.Id)
 			So(err, ShouldEqual, idx.DefNotFound)
@@ -326,7 +326,7 @@ func TestBadAdd(t *testing.T) {
 		})
 		Convey("we should not be able to add a leaf that collides with an existing branch", func() {
 
-			err = ix.Add(bad2)
+			err = ix.Add(bad2, 1)
 			So(err, ShouldEqual, idx.BothBranchAndLeaf)
 			_, err := ix.Get(bad2.Id)
 			So(err, ShouldEqual, idx.DefNotFound)
@@ -360,11 +360,11 @@ func TestDeleteLeafAddBranch(t *testing.T) {
 
 	Convey("when adding the first metric", t, func() {
 
-		err := ix.Add(first)
+		err := ix.Add(first, 1)
 		So(err, ShouldBeNil)
 		Convey("we should not be able to add a leaf under another leaf", func() {
 
-			err = ix.Add(second)
+			err = ix.Add(second, 1)
 			So(err, ShouldEqual, idx.BranchUnderLeaf)
 
 			_, err := ix.Get(second.Id)
@@ -384,7 +384,7 @@ func TestDeleteLeafAddBranch(t *testing.T) {
 
 					Convey("we should be able to add a new branch under it", func() {
 
-						ix.Add(second)
+						ix.Add(second, 1)
 
 						// validate Get
 						s, err := ix.Get(second.Id)
@@ -425,7 +425,7 @@ func TestPrune(t *testing.T) {
 			Time:     1,
 		}
 		d.SetId()
-		ix.Add(d)
+		ix.Add(d, 1)
 	}
 	//new series
 	for _, s := range getSeriesNames(2, 5, "metric.foo") {
@@ -437,7 +437,7 @@ func TestPrune(t *testing.T) {
 			Time:     10,
 		}
 		d.SetId()
-		ix.Add(d)
+		ix.Add(d, 1)
 	}
 	Convey("after populating index", t, func() {
 		defs := ix.List(-1)
@@ -493,6 +493,6 @@ func BenchmarkIndexing(b *testing.B) {
 			OrgId:    1,
 		}
 		data.SetId()
-		ix.Add(data)
+		ix.Add(data, 1)
 	}
 }

--- a/input/carbon/carbon_test.go
+++ b/input/carbon/carbon_test.go
@@ -20,7 +20,7 @@ import (
 
 func Test_HandleMessage(t *testing.T) {
 	stats, _ := helper.New(false, "", "standard", "metrictank", "")
-	cluster.Init("default", "test", false, time.Now())
+	cluster.Init("default", "test", time.Now())
 	mdata.InitMetrics(stats)
 	store := mdata.NewDevnullStore()
 	aggmetrics := mdata.NewAggMetrics(store, 600, 10, 800, 8000, 10000, 0, make([]mdata.AggSetting, 0))

--- a/input/input.go
+++ b/input/input.go
@@ -43,7 +43,7 @@ func New(metrics mdata.Metrics, metricIndex idx.MetricIndex, usage *usage.Usage,
 // process makes sure the data is stored and the metadata is in the index,
 // and the usage is tracked, if enabled.
 // concurrency-safe.
-func (in Input) Process(metric *schema.MetricData) {
+func (in Input) Process(metric *schema.MetricData, partition int32) {
 	if metric == nil {
 		return
 	}
@@ -57,7 +57,7 @@ func (in Input) Process(metric *schema.MetricData) {
 	if metric.Time == 0 {
 		log.Warn("in: invalid metric. metric.Time is 0. %s", metric.Id)
 	} else {
-		in.metricIndex.Add(metric)
+		in.metricIndex.Add(metric, partition)
 		m := in.metrics.GetOrCreate(metric.Id)
 		m.Add(uint32(metric.Time), metric.Value)
 		if in.usage != nil {

--- a/input/input_test.go
+++ b/input/input_test.go
@@ -16,7 +16,7 @@ import (
 
 func Test_Process(t *testing.T) {
 	stats, _ := helper.New(false, "", "standard", "metrictank", "")
-	cluster.Init("default", "test", false, time.Now())
+	cluster.Init("default", "test", time.Now())
 	mdata.InitMetrics(stats)
 	store := mdata.NewDevnullStore()
 	aggmetrics := mdata.NewAggMetrics(store, 600, 10, 800, 8000, 10000, 0, make([]mdata.AggSetting, 0))
@@ -81,14 +81,14 @@ func test_Process(worker int, in *Input, t *testing.T) map[string]int {
 		}
 		metric.SetId()
 		metrics[metric.Id] = id
-		in.Process(metric)
+		in.Process(metric, 1)
 	}
 	return metrics
 }
 
 func BenchmarkProcess(b *testing.B) {
 	stats, _ := helper.New(false, "", "standard", "metrictank", "")
-	cluster.Init("default", "test", false, time.Now())
+	cluster.Init("default", "test", time.Now())
 	mdata.InitMetrics(stats)
 
 	store := mdata.NewDevnullStore()
@@ -118,6 +118,6 @@ func BenchmarkProcess(b *testing.B) {
 
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		in.Process(datas[i])
+		in.Process(datas[i], 1)
 	}
 }

--- a/input/kafkamdm/kafkamdm_test.go
+++ b/input/kafkamdm/kafkamdm_test.go
@@ -18,7 +18,7 @@ import (
 
 func Test_HandleMessage(t *testing.T) {
 	stats, _ := helper.New(false, "", "standard", "metrictank", "")
-	cluster.Init("default", "test", false, time.Now())
+	cluster.Init("default", "test", time.Now())
 	mdata.InitMetrics(stats)
 	store := mdata.NewDevnullStore()
 	aggmetrics := mdata.NewAggMetrics(store, 600, 10, 800, 8000, 10000, 0, make([]mdata.AggSetting, 0))
@@ -91,7 +91,7 @@ func test_handleMessage(worker int, k *KafkaMdm, t *testing.T) map[string]int {
 		if err != nil {
 			t.Fatal(err.Error())
 		}
-		k.handleMsg(data)
+		k.handleMsg(data, 1)
 	}
 	return metrics
 }

--- a/mdata/aggmetric_test.go
+++ b/mdata/aggmetric_test.go
@@ -73,7 +73,7 @@ func (c *Checker) Verify(primary bool, from, to, first, last uint32) {
 
 func TestAggMetric(t *testing.T) {
 	stats, _ := helper.New(false, "", "standard", "metrictank", "")
-	cluster.Init("default", "test", false, time.Now())
+	cluster.Init("default", "test", time.Now())
 	InitMetrics(stats)
 
 	c := NewChecker(t, NewAggMetric(dnstore, "foo", 100, 5, 1, []AggSetting{}...))
@@ -155,7 +155,7 @@ func TestAggMetric(t *testing.T) {
 func BenchmarkAggMetrics1000Metrics1Day(b *testing.B) {
 	stats, _ := helper.New(false, "", "standard", "metrictank", "")
 	InitMetrics(stats)
-	cluster.Init("default", "test", false, time.Now())
+	cluster.Init("default", "test", time.Now())
 	// we will store 10s metrics in 5 chunks of 2 hours
 	// aggragate them in 5min buckets, stored in 1 chunk of 24hours
 	chunkSpan := uint32(2 * 3600)
@@ -197,7 +197,7 @@ func BenchmarkAggMetrics1kSeries2Chunks1kQueueSize(b *testing.B) {
 	chunkMaxStale := uint32(3600)
 	metricMaxStale := uint32(21600)
 
-	cluster.Init("default", "test", false, time.Now())
+	cluster.Init("default", "test", time.Now())
 
 	ttl := uint32(84600)
 	aggSettings := []AggSetting{
@@ -234,7 +234,7 @@ func BenchmarkAggMetrics10kSeries2Chunks10kQueueSize(b *testing.B) {
 	chunkMaxStale := uint32(3600)
 	metricMaxStale := uint32(21600)
 
-	cluster.Init("default", "test", false, time.Now())
+	cluster.Init("default", "test", time.Now())
 
 	ttl := uint32(84600)
 	aggSettings := []AggSetting{
@@ -271,7 +271,7 @@ func BenchmarkAggMetrics100kSeries2Chunks100kQueueSize(b *testing.B) {
 	chunkMaxStale := uint32(3600)
 	metricMaxStale := uint32(21600)
 
-	cluster.Init("default", "test", false, time.Now())
+	cluster.Init("default", "test", time.Now())
 
 	ttl := uint32(84600)
 	aggSettings := []AggSetting{

--- a/mdata/aggregator_test.go
+++ b/mdata/aggregator_test.go
@@ -38,7 +38,7 @@ func TestAggBoundary(t *testing.T) {
 
 // note that values don't get "committed" to the metric until the aggregation interval is complete
 func TestAggregator(t *testing.T) {
-	cluster.Init("default", "test", false, time.Now())
+	cluster.Init("default", "test", time.Now())
 	compare := func(key string, metric Metric, expected []schema.Point) {
 		cluster.ThisNode.SetPrimary(true)
 		_, iters := metric.Get(0, 1000)

--- a/metrictank-sample.ini
+++ b/metrictank-sample.ini
@@ -37,6 +37,7 @@ warm-up-period = 1h
 # with these aggregation rules: 5min:1h:2:3mon,1h:6h:2:1y:false
 # 5 min of data, store in a chunk that lasts 1hour, keep 2 chunks in memory, keep for 3months in cassandra
 # 1hr worth of data, in chunks of 6 hours, 2 chunks in mem, keep for 1 year, but this series is not ready yet for querying.
+# When running a cluster of metrictank instances, all instances should have the same agg-settings.
 agg-settings =
 
 ## metric data storage in cassandra ##

--- a/metrictank-sample.ini
+++ b/metrictank-sample.ini
@@ -9,11 +9,6 @@ instance = default
 # accounting period to track per-org usage metrics
 accounting-period = 5min
 
-## clustering ##
-
-# the primary node writes data to cassandra. There should only be 1 primary node per cluster of nodes
-primary-node = false
-
 ## data ##
 
 # see https://github.com/raintank/metrictank/blob/master/docs/data-knobs.md for more details
@@ -142,6 +137,8 @@ log-min-dur = 5min
 enabled = false
 # tcp address
 addr = :2003
+# represents the "partition" of your data if you decide to partition your data.
+partition = 1
 # needed to know your raw resolution for your metrics. see http://graphite.readthedocs.io/en/latest/config-carbon.html#storage-schemas-conf
 # NOTE: does NOT use aggregation and retention settings from this file.  We use agg-settings and ttl for that.
 schemas-file = /path/to/your/schemas-file
@@ -156,6 +153,8 @@ topics = mdm
 # offset to start consuming from. Can be one of newest, oldest,last or a time duration
 # the further back in time you go, the more old data you can load into metrictank, but the longer it takes to catch up to realtime data
 offset = last
+# kafka partitions to consume. use '*' or a comma separated list of id's
+partitions = *
 # save interval for offsets
 offset-commit-interval = 5s
 # directory to store partition offsets index. supports relative or absolute paths. empty means working dir.
@@ -174,8 +173,18 @@ consumer-max-processing-time = 1s
 # How many outstanding requests a connection is allowed to have before sending on it blocks
 net-max-open-requests = 100
 
-## clustering transports ##
+## basic clustering settings ##
+[cluster]
+# The primary node writes data to cassandra. There should only be 1 primary node per shardGroup.
+primary-node = true
+# http/s addresses of other nodes, comma separated. use this if you shard your data and want to query other instances
+peers =
+# Interval to probe peer nodes
+probe-interval = 2s
+# Operating mode of cluster. (single|multi)
+mode = single
 
+## clustering transports for tracking chunk saves between replicated instances ##
 ### kafka as transport for clustering messages (recommended)
 [kafka-cluster]
 enabled = false

--- a/scripts/config/metrictank-docker.ini
+++ b/scripts/config/metrictank-docker.ini
@@ -34,6 +34,7 @@ warm-up-period = 1h
 # with these aggregation rules: 5min:1h:2:3mon,1h:6h:2:1y:false
 # 5 min of data, store in a chunk that lasts 1hour, keep 2 chunks in memory, keep for 3months in cassandra
 # 1hr worth of data, in chunks of 6 hours, 2 chunks in mem, keep for 1 year, but this series is not ready yet for querying.
+# When running a cluster of metrictank instances, all instances should have the same agg-settings.
 agg-settings =
 
 ## metric data storage in cassandra ##

--- a/scripts/config/metrictank-docker.ini
+++ b/scripts/config/metrictank-docker.ini
@@ -6,11 +6,6 @@ instance = default
 # accounting period to track per-org usage metrics
 accounting-period = 5min
 
-## clustering ##
-
-# the primary node writes data to cassandra. There should only be 1 primary node per cluster of nodes
-primary-node = true
-
 ## data ##
 
 # see https://github.com/raintank/metrictank/blob/master/docs/data-knobs.md for more details
@@ -137,6 +132,8 @@ log-min-dur = 5min
 enabled = true
 # tcp address
 addr = :2003
+# represents the "partition" of your data if you decide to partition your data.
+partition = 1
 # needed to know your raw resolution for your metrics. see http://graphite.readthedocs.io/en/latest/config-carbon.html#storage-schemas-conf
 # NOTE: does NOT use aggregation and retention settings from this file.  We use agg-settings and ttl for that.
 schemas-file = /etc/raintank/storage-schemas.conf
@@ -151,6 +148,8 @@ topics = mdm
 # offset to start consuming from. Can be one of newest, oldest,last or a time duration
 # the further back in time you go, the more old data you can load into metrictank, but the longer it takes to catch up to realtime data
 offset = last
+# kafka partitions to consume. use '*' or a comma separated list of id's
+partitions = *
 # save interval for offsets
 offset-commit-interval = 5s
 # directory to store partition offsets index. supports relative or absolute paths. empty means working dir.
@@ -169,8 +168,18 @@ consumer-max-processing-time = 1s
 # How many outstanding requests a connection is allowed to have before sending on it blocks
 net-max-open-requests = 100
 
-## clustering transports ##
+## basic clustering settings ##
+[cluster]
+# The primary node writes data to cassandra. There should only be 1 primary node per shardGroup.
+primary-node = true
+# http/s addresses of other nodes, comma separated. use this if you shard your data and want to query other instances
+peers =
+# Interval to probe peer nodes
+probe-interval = 2s
+# Operating mode of cluster. (single|multi)
+mode = single
 
+## clustering transports for tracking chunk saves between replicated instances ##
 ### kafka as transport for clustering messages (recommended)
 [kafka-cluster]
 enabled = false

--- a/scripts/config/metrictank-package.ini
+++ b/scripts/config/metrictank-package.ini
@@ -34,6 +34,7 @@ warm-up-period = 1h
 # with these aggregation rules: 5min:1h:2:3mon,1h:6h:2:1y:false
 # 5 min of data, store in a chunk that lasts 1hour, keep 2 chunks in memory, keep for 3months in cassandra
 # 1hr worth of data, in chunks of 6 hours, 2 chunks in mem, keep for 1 year, but this series is not ready yet for querying.
+# When running a cluster of metrictank instances, all instances should have the same agg-settings.
 agg-settings =
 
 ## metric data storage in cassandra ##

--- a/scripts/config/metrictank-package.ini
+++ b/scripts/config/metrictank-package.ini
@@ -6,11 +6,6 @@ instance = default
 # accounting period to track per-org usage metrics
 accounting-period = 5min
 
-## clustering ##
-
-# the primary node writes data to cassandra. There should only be 1 primary node per cluster of nodes
-primary-node = true
-
 ## data ##
 
 # see https://github.com/raintank/metrictank/blob/master/docs/data-knobs.md for more details
@@ -125,6 +120,8 @@ log-min-dur = 5min
 enabled = true
 # tcp address
 addr = :2003
+# represents the "partition" of your data if you decide to partition your data.
+partition = 1
 # needed to know your raw resolution for your metrics. see http://graphite.readthedocs.io/en/latest/config-carbon.html#storage-schemas-conf
 # NOTE: does NOT use aggregation and retention settings from this file.  We use agg-settings and ttl for that.
 schemas-file = /etc/raintank/storage-schemas.conf
@@ -139,6 +136,8 @@ topics = mdm
 # offset to start consuming from. Can be one of newest, oldest,last or a time duration
 # the further back in time you go, the more old data you can load into metrictank, but the longer it takes to catch up to realtime data
 offset = last
+# kafka partitions to consume. use '*' or a comma separated list of id's
+partitions = *
 # save interval for offsets
 offset-commit-interval = 5s
 # directory to store partition offsets index. supports relative or absolute paths. empty means working dir.
@@ -157,8 +156,18 @@ consumer-max-processing-time = 1s
 # How many outstanding requests a connection is allowed to have before sending on it blocks
 net-max-open-requests = 100
 
-## clustering transports ##
+## basic clustering settings ##
+[cluster]
+# The primary node writes data to cassandra. There should only be 1 primary node per shardGroup.
+primary-node = true
+# http/s addresses of other nodes, comma separated. use this if you shard your data and want to query other instances
+peers =
+# Interval to probe peer nodes
+probe-interval = 2s
+# Operating mode of cluster. (single|multi)
+mode = single
 
+## clustering transports for tracking chunk saves between replicated instances ##
 ### kafka as transport for clustering messages (recommended)
 [kafka-cluster]
 enabled = false

--- a/usage/usage.go
+++ b/usage/usage.go
@@ -103,7 +103,8 @@ func (u *Usage) Report() {
 
 		m := metrics.GetOrCreate(met.Id)
 		m.Add(uint32(met.Time), met.Value)
-		metricIndex.Add(met)
+		//TODO: how to set the partition of the metric?  We probably just need to publish the metric to our Input Plugin
+		metricIndex.Add(met, 0)
 	}
 	for {
 		ticker := tick()

--- a/vendor/github.com/google/go-querystring/LICENSE
+++ b/vendor/github.com/google/go-querystring/LICENSE
@@ -1,0 +1,27 @@
+Copyright (c) 2013 Google. All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are
+met:
+
+   * Redistributions of source code must retain the above copyright
+notice, this list of conditions and the following disclaimer.
+   * Redistributions in binary form must reproduce the above
+copyright notice, this list of conditions and the following disclaimer
+in the documentation and/or other materials provided with the
+distribution.
+   * Neither the name of Google Inc. nor the names of its
+contributors may be used to endorse or promote products derived from
+this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/vendor/github.com/google/go-querystring/query/encode.go
+++ b/vendor/github.com/google/go-querystring/query/encode.go
@@ -1,0 +1,311 @@
+// Copyright 2013 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// Package query implements encoding of structs into URL query parameters.
+//
+// As a simple example:
+//
+// 	type Options struct {
+// 		Query   string `url:"q"`
+// 		ShowAll bool   `url:"all"`
+// 		Page    int    `url:"page"`
+// 	}
+//
+// 	opt := Options{ "foo", true, 2 }
+// 	v, _ := query.Values(opt)
+// 	fmt.Print(v.Encode()) // will output: "q=foo&all=true&page=2"
+//
+// The exact mapping between Go values and url.Values is described in the
+// documentation for the Values() function.
+package query
+
+import (
+	"bytes"
+	"fmt"
+	"net/url"
+	"reflect"
+	"strconv"
+	"strings"
+	"time"
+)
+
+var timeType = reflect.TypeOf(time.Time{})
+
+var encoderType = reflect.TypeOf(new(Encoder)).Elem()
+
+// Encoder is an interface implemented by any type that wishes to encode
+// itself into URL values in a non-standard way.
+type Encoder interface {
+	EncodeValues(key string, v *url.Values) error
+}
+
+// Values returns the url.Values encoding of v.
+//
+// Values expects to be passed a struct, and traverses it recursively using the
+// following encoding rules.
+//
+// Each exported struct field is encoded as a URL parameter unless
+//
+//	- the field's tag is "-", or
+//	- the field is empty and its tag specifies the "omitempty" option
+//
+// The empty values are false, 0, any nil pointer or interface value, any array
+// slice, map, or string of length zero, and any time.Time that returns true
+// for IsZero().
+//
+// The URL parameter name defaults to the struct field name but can be
+// specified in the struct field's tag value.  The "url" key in the struct
+// field's tag value is the key name, followed by an optional comma and
+// options.  For example:
+//
+// 	// Field is ignored by this package.
+// 	Field int `url:"-"`
+//
+// 	// Field appears as URL parameter "myName".
+// 	Field int `url:"myName"`
+//
+// 	// Field appears as URL parameter "myName" and the field is omitted if
+// 	// its value is empty
+// 	Field int `url:"myName,omitempty"`
+//
+// 	// Field appears as URL parameter "Field" (the default), but the field
+// 	// is skipped if empty.  Note the leading comma.
+// 	Field int `url:",omitempty"`
+//
+// For encoding individual field values, the following type-dependent rules
+// apply:
+//
+// Boolean values default to encoding as the strings "true" or "false".
+// Including the "int" option signals that the field should be encoded as the
+// strings "1" or "0".
+//
+// time.Time values default to encoding as RFC3339 timestamps.  Including the
+// "unix" option signals that the field should be encoded as a Unix time (see
+// time.Unix())
+//
+// Slice and Array values default to encoding as multiple URL values of the
+// same name.  Including the "comma" option signals that the field should be
+// encoded as a single comma-delimited value.  Including the "space" option
+// similarly encodes the value as a single space-delimited string. Including
+// the "brackets" option signals that the multiple URL values should have "[]"
+// appended to the value name.
+//
+// Anonymous struct fields are usually encoded as if their inner exported
+// fields were fields in the outer struct, subject to the standard Go
+// visibility rules.  An anonymous struct field with a name given in its URL
+// tag is treated as having that name, rather than being anonymous.
+//
+// Non-nil pointer values are encoded as the value pointed to.
+//
+// Nested structs are encoded including parent fields in value names for
+// scoping. e.g:
+//
+// 	"user[name]=acme&user[addr][postcode]=1234&user[addr][city]=SFO"
+//
+// All other values are encoded using their default string representation.
+//
+// Multiple fields that encode to the same URL parameter name will be included
+// as multiple URL values of the same name.
+func Values(v interface{}) (url.Values, error) {
+	values := make(url.Values)
+	val := reflect.ValueOf(v)
+	for val.Kind() == reflect.Ptr {
+		if val.IsNil() {
+			return values, nil
+		}
+		val = val.Elem()
+	}
+
+	if v == nil {
+		return values, nil
+	}
+
+	if val.Kind() != reflect.Struct {
+		return nil, fmt.Errorf("query: Values() expects struct input. Got %v", val.Kind())
+	}
+
+	err := reflectValue(values, val, "")
+	return values, err
+}
+
+// reflectValue populates the values parameter from the struct fields in val.
+// Embedded structs are followed recursively (using the rules defined in the
+// Values function documentation) breadth-first.
+func reflectValue(values url.Values, val reflect.Value, scope string) error {
+	var embedded []reflect.Value
+
+	typ := val.Type()
+	for i := 0; i < typ.NumField(); i++ {
+		sf := typ.Field(i)
+		if sf.PkgPath != "" && !sf.Anonymous { // unexported
+			continue
+		}
+
+		sv := val.Field(i)
+		tag := sf.Tag.Get("url")
+		if tag == "-" {
+			continue
+		}
+		name, opts := parseTag(tag)
+		if name == "" {
+			if sf.Anonymous && sv.Kind() == reflect.Struct {
+				// save embedded struct for later processing
+				embedded = append(embedded, sv)
+				continue
+			}
+
+			name = sf.Name
+		}
+
+		if scope != "" {
+			name = scope + "[" + name + "]"
+		}
+
+		if opts.Contains("omitempty") && isEmptyValue(sv) {
+			continue
+		}
+
+		if sv.Type().Implements(encoderType) {
+			if !reflect.Indirect(sv).IsValid() {
+				sv = reflect.New(sv.Type().Elem())
+			}
+
+			m := sv.Interface().(Encoder)
+			if err := m.EncodeValues(name, &values); err != nil {
+				return err
+			}
+			continue
+		}
+
+		if sv.Kind() == reflect.Slice || sv.Kind() == reflect.Array {
+			var del byte
+			if opts.Contains("comma") {
+				del = ','
+			} else if opts.Contains("space") {
+				del = ' '
+			} else if opts.Contains("brackets") {
+				name = name + "[]"
+			}
+
+			if del != 0 {
+				s := new(bytes.Buffer)
+				first := true
+				for i := 0; i < sv.Len(); i++ {
+					if first {
+						first = false
+					} else {
+						s.WriteByte(del)
+					}
+					s.WriteString(valueString(sv.Index(i), opts))
+				}
+				values.Add(name, s.String())
+			} else {
+				for i := 0; i < sv.Len(); i++ {
+					values.Add(name, valueString(sv.Index(i), opts))
+				}
+			}
+			continue
+		}
+
+		if sv.Type() == timeType {
+			values.Add(name, valueString(sv, opts))
+			continue
+		}
+
+		for sv.Kind() == reflect.Ptr {
+			if sv.IsNil() {
+				break
+			}
+			sv = sv.Elem()
+		}
+
+		if sv.Kind() == reflect.Struct {
+			reflectValue(values, sv, name)
+			continue
+		}
+
+		values.Add(name, valueString(sv, opts))
+	}
+
+	for _, f := range embedded {
+		if err := reflectValue(values, f, scope); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+// valueString returns the string representation of a value.
+func valueString(v reflect.Value, opts tagOptions) string {
+	for v.Kind() == reflect.Ptr {
+		if v.IsNil() {
+			return ""
+		}
+		v = v.Elem()
+	}
+
+	if v.Kind() == reflect.Bool && opts.Contains("int") {
+		if v.Bool() {
+			return "1"
+		}
+		return "0"
+	}
+
+	if v.Type() == timeType {
+		t := v.Interface().(time.Time)
+		if opts.Contains("unix") {
+			return strconv.FormatInt(t.Unix(), 10)
+		}
+		return t.Format(time.RFC3339)
+	}
+
+	return fmt.Sprint(v.Interface())
+}
+
+// isEmptyValue checks if a value should be considered empty for the purposes
+// of omitting fields with the "omitempty" option.
+func isEmptyValue(v reflect.Value) bool {
+	switch v.Kind() {
+	case reflect.Array, reflect.Map, reflect.Slice, reflect.String:
+		return v.Len() == 0
+	case reflect.Bool:
+		return !v.Bool()
+	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
+		return v.Int() == 0
+	case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64, reflect.Uintptr:
+		return v.Uint() == 0
+	case reflect.Float32, reflect.Float64:
+		return v.Float() == 0
+	case reflect.Interface, reflect.Ptr:
+		return v.IsNil()
+	}
+
+	if v.Type() == timeType {
+		return v.Interface().(time.Time).IsZero()
+	}
+
+	return false
+}
+
+// tagOptions is the string following a comma in a struct field's "url" tag, or
+// the empty string. It does not include the leading comma.
+type tagOptions []string
+
+// parseTag splits a struct field's url tag into its name and comma-separated
+// options.
+func parseTag(tag string) (string, tagOptions) {
+	s := strings.Split(tag, ",")
+	return s[0], s[1:]
+}
+
+// Contains checks whether the tagOptions contains the specified option.
+func (o tagOptions) Contains(option string) bool {
+	for _, s := range o {
+		if s == option {
+			return true
+		}
+	}
+	return false
+}

--- a/vendor/gopkg.in/raintank/schema.v1/event_gen.go
+++ b/vendor/gopkg.in/raintank/schema.v1/event_gen.go
@@ -4,21 +4,19 @@ package schema
 // MSGP CODE GENERATION TOOL (github.com/tinylib/msgp)
 // DO NOT EDIT
 
-import (
-	"github.com/tinylib/msgp/msgp"
-)
+import "github.com/tinylib/msgp/msgp"
 
 // DecodeMsg implements msgp.Decodable
 func (z *ProbeEvent) DecodeMsg(dc *msgp.Reader) (err error) {
 	var field []byte
 	_ = field
-	var isz uint32
-	isz, err = dc.ReadMapHeader()
+	var zbai uint32
+	zbai, err = dc.ReadMapHeader()
 	if err != nil {
 		return
 	}
-	for isz > 0 {
-		isz--
+	for zbai > 0 {
+		zbai--
 		field, err = dc.ReadMapKeyPtr()
 		if err != nil {
 			return
@@ -60,31 +58,31 @@ func (z *ProbeEvent) DecodeMsg(dc *msgp.Reader) (err error) {
 				return
 			}
 		case "Tags":
-			var msz uint32
-			msz, err = dc.ReadMapHeader()
+			var zcmr uint32
+			zcmr, err = dc.ReadMapHeader()
 			if err != nil {
 				return
 			}
-			if z.Tags == nil && msz > 0 {
-				z.Tags = make(map[string]string, msz)
+			if z.Tags == nil && zcmr > 0 {
+				z.Tags = make(map[string]string, zcmr)
 			} else if len(z.Tags) > 0 {
 				for key, _ := range z.Tags {
 					delete(z.Tags, key)
 				}
 			}
-			for msz > 0 {
-				msz--
-				var xvk string
-				var bzg string
-				xvk, err = dc.ReadString()
+			for zcmr > 0 {
+				zcmr--
+				var zxvk string
+				var zbzg string
+				zxvk, err = dc.ReadString()
 				if err != nil {
 					return
 				}
-				bzg, err = dc.ReadString()
+				zbzg, err = dc.ReadString()
 				if err != nil {
 					return
 				}
-				z.Tags[xvk] = bzg
+				z.Tags[zxvk] = zbzg
 			}
 		default:
 			err = dc.Skip()
@@ -171,12 +169,12 @@ func (z *ProbeEvent) EncodeMsg(en *msgp.Writer) (err error) {
 	if err != nil {
 		return
 	}
-	for xvk, bzg := range z.Tags {
-		err = en.WriteString(xvk)
+	for zxvk, zbzg := range z.Tags {
+		err = en.WriteString(zxvk)
 		if err != nil {
 			return
 		}
-		err = en.WriteString(bzg)
+		err = en.WriteString(zbzg)
 		if err != nil {
 			return
 		}
@@ -212,9 +210,9 @@ func (z *ProbeEvent) MarshalMsg(b []byte) (o []byte, err error) {
 	// string "Tags"
 	o = append(o, 0xa4, 0x54, 0x61, 0x67, 0x73)
 	o = msgp.AppendMapHeader(o, uint32(len(z.Tags)))
-	for xvk, bzg := range z.Tags {
-		o = msgp.AppendString(o, xvk)
-		o = msgp.AppendString(o, bzg)
+	for zxvk, zbzg := range z.Tags {
+		o = msgp.AppendString(o, zxvk)
+		o = msgp.AppendString(o, zbzg)
 	}
 	return
 }
@@ -223,13 +221,13 @@ func (z *ProbeEvent) MarshalMsg(b []byte) (o []byte, err error) {
 func (z *ProbeEvent) UnmarshalMsg(bts []byte) (o []byte, err error) {
 	var field []byte
 	_ = field
-	var isz uint32
-	isz, bts, err = msgp.ReadMapHeaderBytes(bts)
+	var zajw uint32
+	zajw, bts, err = msgp.ReadMapHeaderBytes(bts)
 	if err != nil {
 		return
 	}
-	for isz > 0 {
-		isz--
+	for zajw > 0 {
+		zajw--
 		field, bts, err = msgp.ReadMapKeyZC(bts)
 		if err != nil {
 			return
@@ -271,31 +269,31 @@ func (z *ProbeEvent) UnmarshalMsg(bts []byte) (o []byte, err error) {
 				return
 			}
 		case "Tags":
-			var msz uint32
-			msz, bts, err = msgp.ReadMapHeaderBytes(bts)
+			var zwht uint32
+			zwht, bts, err = msgp.ReadMapHeaderBytes(bts)
 			if err != nil {
 				return
 			}
-			if z.Tags == nil && msz > 0 {
-				z.Tags = make(map[string]string, msz)
+			if z.Tags == nil && zwht > 0 {
+				z.Tags = make(map[string]string, zwht)
 			} else if len(z.Tags) > 0 {
 				for key, _ := range z.Tags {
 					delete(z.Tags, key)
 				}
 			}
-			for msz > 0 {
-				var xvk string
-				var bzg string
-				msz--
-				xvk, bts, err = msgp.ReadStringBytes(bts)
+			for zwht > 0 {
+				var zxvk string
+				var zbzg string
+				zwht--
+				zxvk, bts, err = msgp.ReadStringBytes(bts)
 				if err != nil {
 					return
 				}
-				bzg, bts, err = msgp.ReadStringBytes(bts)
+				zbzg, bts, err = msgp.ReadStringBytes(bts)
 				if err != nil {
 					return
 				}
-				z.Tags[xvk] = bzg
+				z.Tags[zxvk] = zbzg
 			}
 		default:
 			bts, err = msgp.Skip(bts)
@@ -308,12 +306,13 @@ func (z *ProbeEvent) UnmarshalMsg(bts []byte) (o []byte, err error) {
 	return
 }
 
+// Msgsize returns an upper bound estimate of the number of bytes occupied by the serialized message
 func (z *ProbeEvent) Msgsize() (s int) {
 	s = 1 + 3 + msgp.StringPrefixSize + len(z.Id) + 10 + msgp.StringPrefixSize + len(z.EventType) + 6 + msgp.Int64Size + 9 + msgp.StringPrefixSize + len(z.Severity) + 7 + msgp.StringPrefixSize + len(z.Source) + 10 + msgp.Int64Size + 8 + msgp.StringPrefixSize + len(z.Message) + 5 + msgp.MapHeaderSize
 	if z.Tags != nil {
-		for xvk, bzg := range z.Tags {
-			_ = bzg
-			s += msgp.StringPrefixSize + len(xvk) + msgp.StringPrefixSize + len(bzg)
+		for zxvk, zbzg := range z.Tags {
+			_ = zbzg
+			s += msgp.StringPrefixSize + len(zxvk) + msgp.StringPrefixSize + len(zbzg)
 		}
 	}
 	return

--- a/vendor/gopkg.in/raintank/schema.v1/metric.go
+++ b/vendor/gopkg.in/raintank/schema.v1/metric.go
@@ -7,7 +7,6 @@ import (
 	"errors"
 	"fmt"
 	"sort"
-	"strings"
 )
 
 var errInvalidIntervalzero = errors.New("interval cannot be 0")
@@ -77,17 +76,16 @@ type MetricDataArray []*MetricData
 
 // for ES
 type MetricDefinition struct {
-	Id         string            `json:"id"`
-	OrgId      int               `json:"org_id"`
-	Name       string            `json:"name" elastic:"type:string,index:not_analyzed"` // graphite format
-	Metric     string            `json:"metric"`                                        // kairosdb format (like graphite, but not including some tags)
-	Interval   int               `json:"interval"`                                      // minimum 10
-	Unit       string            `json:"unit"`
-	Mtype      string            `json:"mtype"`
-	Tags       []string          `json:"tags" elastic:"type:string,index:not_analyzed"`
-	LastUpdate int64             `json:"lastUpdate"` // unix timestamp
-	Nodes      map[string]string `json:"nodes"`
-	NodeCount  int               `json:"node_count"`
+	Id         string   `json:"id"`
+	OrgId      int      `json:"org_id"`
+	Name       string   `json:"name" elastic:"type:string,index:not_analyzed"` // graphite format
+	Metric     string   `json:"metric"`                                        // kairosdb format (like graphite, but not including some tags)
+	Interval   int      `json:"interval"`                                      // minimum 10
+	Unit       string   `json:"unit"`
+	Mtype      string   `json:"mtype"`
+	Tags       []string `json:"tags" elastic:"type:string,index:not_analyzed"`
+	LastUpdate int64    `json:"lastUpdate"` // unix timestamp
+	Partition  int32    `json:"partition"`
 }
 
 func (m *MetricDefinition) SetId() {
@@ -138,12 +136,6 @@ func MetricDefinitionFromJSON(b []byte) (*MetricDefinition, error) {
 // MetricDefinitionFromMetricData yields a MetricDefinition that has no references
 // to the original MetricData
 func MetricDefinitionFromMetricData(d *MetricData) *MetricDefinition {
-	nodesMap := make(map[string]string)
-	nodes := strings.Split(d.Name, ".")
-	for i, n := range nodes {
-		key := fmt.Sprintf("n%d", i)
-		nodesMap[key] = n
-	}
 	tags := make([]string, len(d.Tags))
 	copy(tags, d.Tags)
 	return &MetricDefinition{
@@ -156,7 +148,5 @@ func MetricDefinitionFromMetricData(d *MetricData) *MetricDefinition {
 		LastUpdate: d.Time,
 		Unit:       d.Unit,
 		Tags:       tags,
-		Nodes:      nodesMap,
-		NodeCount:  len(nodes),
 	}
 }

--- a/vendor/gopkg.in/raintank/schema.v1/metric_gen.go
+++ b/vendor/gopkg.in/raintank/schema.v1/metric_gen.go
@@ -4,21 +4,19 @@ package schema
 // MSGP CODE GENERATION TOOL (github.com/tinylib/msgp)
 // DO NOT EDIT
 
-import (
-	"github.com/tinylib/msgp/msgp"
-)
+import "github.com/tinylib/msgp/msgp"
 
 // DecodeMsg implements msgp.Decodable
 func (z *MetricData) DecodeMsg(dc *msgp.Reader) (err error) {
 	var field []byte
 	_ = field
-	var isz uint32
-	isz, err = dc.ReadMapHeader()
+	var zbzg uint32
+	zbzg, err = dc.ReadMapHeader()
 	if err != nil {
 		return
 	}
-	for isz > 0 {
-		isz--
+	for zbzg > 0 {
+		zbzg--
 		field, err = dc.ReadMapKeyPtr()
 		if err != nil {
 			return
@@ -70,18 +68,18 @@ func (z *MetricData) DecodeMsg(dc *msgp.Reader) (err error) {
 				return
 			}
 		case "Tags":
-			var xsz uint32
-			xsz, err = dc.ReadArrayHeader()
+			var zbai uint32
+			zbai, err = dc.ReadArrayHeader()
 			if err != nil {
 				return
 			}
-			if cap(z.Tags) >= int(xsz) {
-				z.Tags = z.Tags[:xsz]
+			if cap(z.Tags) >= int(zbai) {
+				z.Tags = (z.Tags)[:zbai]
 			} else {
-				z.Tags = make([]string, xsz)
+				z.Tags = make([]string, zbai)
 			}
-			for xvk := range z.Tags {
-				z.Tags[xvk], err = dc.ReadString()
+			for zxvk := range z.Tags {
+				z.Tags[zxvk], err = dc.ReadString()
 				if err != nil {
 					return
 				}
@@ -189,8 +187,8 @@ func (z *MetricData) EncodeMsg(en *msgp.Writer) (err error) {
 	if err != nil {
 		return
 	}
-	for xvk := range z.Tags {
-		err = en.WriteString(z.Tags[xvk])
+	for zxvk := range z.Tags {
+		err = en.WriteString(z.Tags[zxvk])
 		if err != nil {
 			return
 		}
@@ -232,8 +230,8 @@ func (z *MetricData) MarshalMsg(b []byte) (o []byte, err error) {
 	// string "Tags"
 	o = append(o, 0xa4, 0x54, 0x61, 0x67, 0x73)
 	o = msgp.AppendArrayHeader(o, uint32(len(z.Tags)))
-	for xvk := range z.Tags {
-		o = msgp.AppendString(o, z.Tags[xvk])
+	for zxvk := range z.Tags {
+		o = msgp.AppendString(o, z.Tags[zxvk])
 	}
 	return
 }
@@ -242,13 +240,13 @@ func (z *MetricData) MarshalMsg(b []byte) (o []byte, err error) {
 func (z *MetricData) UnmarshalMsg(bts []byte) (o []byte, err error) {
 	var field []byte
 	_ = field
-	var isz uint32
-	isz, bts, err = msgp.ReadMapHeaderBytes(bts)
+	var zcmr uint32
+	zcmr, bts, err = msgp.ReadMapHeaderBytes(bts)
 	if err != nil {
 		return
 	}
-	for isz > 0 {
-		isz--
+	for zcmr > 0 {
+		zcmr--
 		field, bts, err = msgp.ReadMapKeyZC(bts)
 		if err != nil {
 			return
@@ -300,18 +298,18 @@ func (z *MetricData) UnmarshalMsg(bts []byte) (o []byte, err error) {
 				return
 			}
 		case "Tags":
-			var xsz uint32
-			xsz, bts, err = msgp.ReadArrayHeaderBytes(bts)
+			var zajw uint32
+			zajw, bts, err = msgp.ReadArrayHeaderBytes(bts)
 			if err != nil {
 				return
 			}
-			if cap(z.Tags) >= int(xsz) {
-				z.Tags = z.Tags[:xsz]
+			if cap(z.Tags) >= int(zajw) {
+				z.Tags = (z.Tags)[:zajw]
 			} else {
-				z.Tags = make([]string, xsz)
+				z.Tags = make([]string, zajw)
 			}
-			for xvk := range z.Tags {
-				z.Tags[xvk], bts, err = msgp.ReadStringBytes(bts)
+			for zxvk := range z.Tags {
+				z.Tags[zxvk], bts, err = msgp.ReadStringBytes(bts)
 				if err != nil {
 					return
 				}
@@ -327,38 +325,39 @@ func (z *MetricData) UnmarshalMsg(bts []byte) (o []byte, err error) {
 	return
 }
 
+// Msgsize returns an upper bound estimate of the number of bytes occupied by the serialized message
 func (z *MetricData) Msgsize() (s int) {
 	s = 1 + 3 + msgp.StringPrefixSize + len(z.Id) + 6 + msgp.IntSize + 5 + msgp.StringPrefixSize + len(z.Name) + 7 + msgp.StringPrefixSize + len(z.Metric) + 9 + msgp.IntSize + 6 + msgp.Float64Size + 5 + msgp.StringPrefixSize + len(z.Unit) + 5 + msgp.Int64Size + 6 + msgp.StringPrefixSize + len(z.Mtype) + 5 + msgp.ArrayHeaderSize
-	for xvk := range z.Tags {
-		s += msgp.StringPrefixSize + len(z.Tags[xvk])
+	for zxvk := range z.Tags {
+		s += msgp.StringPrefixSize + len(z.Tags[zxvk])
 	}
 	return
 }
 
 // DecodeMsg implements msgp.Decodable
 func (z *MetricDataArray) DecodeMsg(dc *msgp.Reader) (err error) {
-	var xsz uint32
-	xsz, err = dc.ReadArrayHeader()
+	var zcua uint32
+	zcua, err = dc.ReadArrayHeader()
 	if err != nil {
 		return
 	}
-	if cap((*z)) >= int(xsz) {
-		(*z) = (*z)[:xsz]
+	if cap((*z)) >= int(zcua) {
+		(*z) = (*z)[:zcua]
 	} else {
-		(*z) = make(MetricDataArray, xsz)
+		(*z) = make(MetricDataArray, zcua)
 	}
-	for bai := range *z {
+	for zhct := range *z {
 		if dc.IsNil() {
 			err = dc.ReadNil()
 			if err != nil {
 				return
 			}
-			(*z)[bai] = nil
+			(*z)[zhct] = nil
 		} else {
-			if (*z)[bai] == nil {
-				(*z)[bai] = new(MetricData)
+			if (*z)[zhct] == nil {
+				(*z)[zhct] = new(MetricData)
 			}
-			err = (*z)[bai].DecodeMsg(dc)
+			err = (*z)[zhct].DecodeMsg(dc)
 			if err != nil {
 				return
 			}
@@ -373,14 +372,14 @@ func (z MetricDataArray) EncodeMsg(en *msgp.Writer) (err error) {
 	if err != nil {
 		return
 	}
-	for cmr := range z {
-		if z[cmr] == nil {
+	for zxhx := range z {
+		if z[zxhx] == nil {
 			err = en.WriteNil()
 			if err != nil {
 				return
 			}
 		} else {
-			err = z[cmr].EncodeMsg(en)
+			err = z[zxhx].EncodeMsg(en)
 			if err != nil {
 				return
 			}
@@ -393,11 +392,11 @@ func (z MetricDataArray) EncodeMsg(en *msgp.Writer) (err error) {
 func (z MetricDataArray) MarshalMsg(b []byte) (o []byte, err error) {
 	o = msgp.Require(b, z.Msgsize())
 	o = msgp.AppendArrayHeader(o, uint32(len(z)))
-	for cmr := range z {
-		if z[cmr] == nil {
+	for zxhx := range z {
+		if z[zxhx] == nil {
 			o = msgp.AppendNil(o)
 		} else {
-			o, err = z[cmr].MarshalMsg(o)
+			o, err = z[zxhx].MarshalMsg(o)
 			if err != nil {
 				return
 			}
@@ -408,28 +407,28 @@ func (z MetricDataArray) MarshalMsg(b []byte) (o []byte, err error) {
 
 // UnmarshalMsg implements msgp.Unmarshaler
 func (z *MetricDataArray) UnmarshalMsg(bts []byte) (o []byte, err error) {
-	var xsz uint32
-	xsz, bts, err = msgp.ReadArrayHeaderBytes(bts)
+	var zdaf uint32
+	zdaf, bts, err = msgp.ReadArrayHeaderBytes(bts)
 	if err != nil {
 		return
 	}
-	if cap((*z)) >= int(xsz) {
-		(*z) = (*z)[:xsz]
+	if cap((*z)) >= int(zdaf) {
+		(*z) = (*z)[:zdaf]
 	} else {
-		(*z) = make(MetricDataArray, xsz)
+		(*z) = make(MetricDataArray, zdaf)
 	}
-	for ajw := range *z {
+	for zlqf := range *z {
 		if msgp.IsNil(bts) {
 			bts, err = msgp.ReadNilBytes(bts)
 			if err != nil {
 				return
 			}
-			(*z)[ajw] = nil
+			(*z)[zlqf] = nil
 		} else {
-			if (*z)[ajw] == nil {
-				(*z)[ajw] = new(MetricData)
+			if (*z)[zlqf] == nil {
+				(*z)[zlqf] = new(MetricData)
 			}
-			bts, err = (*z)[ajw].UnmarshalMsg(bts)
+			bts, err = (*z)[zlqf].UnmarshalMsg(bts)
 			if err != nil {
 				return
 			}
@@ -439,13 +438,14 @@ func (z *MetricDataArray) UnmarshalMsg(bts []byte) (o []byte, err error) {
 	return
 }
 
+// Msgsize returns an upper bound estimate of the number of bytes occupied by the serialized message
 func (z MetricDataArray) Msgsize() (s int) {
 	s = msgp.ArrayHeaderSize
-	for wht := range z {
-		if z[wht] == nil {
+	for zpks := range z {
+		if z[zpks] == nil {
 			s += msgp.NilSize
 		} else {
-			s += z[wht].Msgsize()
+			s += z[zpks].Msgsize()
 		}
 	}
 	return
@@ -455,13 +455,13 @@ func (z MetricDataArray) Msgsize() (s int) {
 func (z *MetricDefinition) DecodeMsg(dc *msgp.Reader) (err error) {
 	var field []byte
 	_ = field
-	var isz uint32
-	isz, err = dc.ReadMapHeader()
+	var zcxo uint32
+	zcxo, err = dc.ReadMapHeader()
 	if err != nil {
 		return
 	}
-	for isz > 0 {
-		isz--
+	for zcxo > 0 {
+		zcxo--
 		field, err = dc.ReadMapKeyPtr()
 		if err != nil {
 			return
@@ -503,18 +503,18 @@ func (z *MetricDefinition) DecodeMsg(dc *msgp.Reader) (err error) {
 				return
 			}
 		case "Tags":
-			var xsz uint32
-			xsz, err = dc.ReadArrayHeader()
+			var zeff uint32
+			zeff, err = dc.ReadArrayHeader()
 			if err != nil {
 				return
 			}
-			if cap(z.Tags) >= int(xsz) {
-				z.Tags = z.Tags[:xsz]
+			if cap(z.Tags) >= int(zeff) {
+				z.Tags = (z.Tags)[:zeff]
 			} else {
-				z.Tags = make([]string, xsz)
+				z.Tags = make([]string, zeff)
 			}
-			for hct := range z.Tags {
-				z.Tags[hct], err = dc.ReadString()
+			for zjfb := range z.Tags {
+				z.Tags[zjfb], err = dc.ReadString()
 				if err != nil {
 					return
 				}
@@ -524,35 +524,8 @@ func (z *MetricDefinition) DecodeMsg(dc *msgp.Reader) (err error) {
 			if err != nil {
 				return
 			}
-		case "Nodes":
-			var msz uint32
-			msz, err = dc.ReadMapHeader()
-			if err != nil {
-				return
-			}
-			if z.Nodes == nil && msz > 0 {
-				z.Nodes = make(map[string]string, msz)
-			} else if len(z.Nodes) > 0 {
-				for key, _ := range z.Nodes {
-					delete(z.Nodes, key)
-				}
-			}
-			for msz > 0 {
-				msz--
-				var cua string
-				var xhx string
-				cua, err = dc.ReadString()
-				if err != nil {
-					return
-				}
-				xhx, err = dc.ReadString()
-				if err != nil {
-					return
-				}
-				z.Nodes[cua] = xhx
-			}
-		case "NodeCount":
-			z.NodeCount, err = dc.ReadInt()
+		case "Partition":
+			z.Partition, err = dc.ReadInt32()
 			if err != nil {
 				return
 			}
@@ -568,9 +541,9 @@ func (z *MetricDefinition) DecodeMsg(dc *msgp.Reader) (err error) {
 
 // EncodeMsg implements msgp.Encodable
 func (z *MetricDefinition) EncodeMsg(en *msgp.Writer) (err error) {
-	// map header, size 11
+	// map header, size 10
 	// write "Id"
-	err = en.Append(0x8b, 0xa2, 0x49, 0x64)
+	err = en.Append(0x8a, 0xa2, 0x49, 0x64)
 	if err != nil {
 		return err
 	}
@@ -641,8 +614,8 @@ func (z *MetricDefinition) EncodeMsg(en *msgp.Writer) (err error) {
 	if err != nil {
 		return
 	}
-	for hct := range z.Tags {
-		err = en.WriteString(z.Tags[hct])
+	for zjfb := range z.Tags {
+		err = en.WriteString(z.Tags[zjfb])
 		if err != nil {
 			return
 		}
@@ -656,31 +629,12 @@ func (z *MetricDefinition) EncodeMsg(en *msgp.Writer) (err error) {
 	if err != nil {
 		return
 	}
-	// write "Nodes"
-	err = en.Append(0xa5, 0x4e, 0x6f, 0x64, 0x65, 0x73)
+	// write "Partition"
+	err = en.Append(0xa9, 0x50, 0x61, 0x72, 0x74, 0x69, 0x74, 0x69, 0x6f, 0x6e)
 	if err != nil {
 		return err
 	}
-	err = en.WriteMapHeader(uint32(len(z.Nodes)))
-	if err != nil {
-		return
-	}
-	for cua, xhx := range z.Nodes {
-		err = en.WriteString(cua)
-		if err != nil {
-			return
-		}
-		err = en.WriteString(xhx)
-		if err != nil {
-			return
-		}
-	}
-	// write "NodeCount"
-	err = en.Append(0xa9, 0x4e, 0x6f, 0x64, 0x65, 0x43, 0x6f, 0x75, 0x6e, 0x74)
-	if err != nil {
-		return err
-	}
-	err = en.WriteInt(z.NodeCount)
+	err = en.WriteInt32(z.Partition)
 	if err != nil {
 		return
 	}
@@ -690,9 +644,9 @@ func (z *MetricDefinition) EncodeMsg(en *msgp.Writer) (err error) {
 // MarshalMsg implements msgp.Marshaler
 func (z *MetricDefinition) MarshalMsg(b []byte) (o []byte, err error) {
 	o = msgp.Require(b, z.Msgsize())
-	// map header, size 11
+	// map header, size 10
 	// string "Id"
-	o = append(o, 0x8b, 0xa2, 0x49, 0x64)
+	o = append(o, 0x8a, 0xa2, 0x49, 0x64)
 	o = msgp.AppendString(o, z.Id)
 	// string "OrgId"
 	o = append(o, 0xa5, 0x4f, 0x72, 0x67, 0x49, 0x64)
@@ -715,22 +669,15 @@ func (z *MetricDefinition) MarshalMsg(b []byte) (o []byte, err error) {
 	// string "Tags"
 	o = append(o, 0xa4, 0x54, 0x61, 0x67, 0x73)
 	o = msgp.AppendArrayHeader(o, uint32(len(z.Tags)))
-	for hct := range z.Tags {
-		o = msgp.AppendString(o, z.Tags[hct])
+	for zjfb := range z.Tags {
+		o = msgp.AppendString(o, z.Tags[zjfb])
 	}
 	// string "LastUpdate"
 	o = append(o, 0xaa, 0x4c, 0x61, 0x73, 0x74, 0x55, 0x70, 0x64, 0x61, 0x74, 0x65)
 	o = msgp.AppendInt64(o, z.LastUpdate)
-	// string "Nodes"
-	o = append(o, 0xa5, 0x4e, 0x6f, 0x64, 0x65, 0x73)
-	o = msgp.AppendMapHeader(o, uint32(len(z.Nodes)))
-	for cua, xhx := range z.Nodes {
-		o = msgp.AppendString(o, cua)
-		o = msgp.AppendString(o, xhx)
-	}
-	// string "NodeCount"
-	o = append(o, 0xa9, 0x4e, 0x6f, 0x64, 0x65, 0x43, 0x6f, 0x75, 0x6e, 0x74)
-	o = msgp.AppendInt(o, z.NodeCount)
+	// string "Partition"
+	o = append(o, 0xa9, 0x50, 0x61, 0x72, 0x74, 0x69, 0x74, 0x69, 0x6f, 0x6e)
+	o = msgp.AppendInt32(o, z.Partition)
 	return
 }
 
@@ -738,13 +685,13 @@ func (z *MetricDefinition) MarshalMsg(b []byte) (o []byte, err error) {
 func (z *MetricDefinition) UnmarshalMsg(bts []byte) (o []byte, err error) {
 	var field []byte
 	_ = field
-	var isz uint32
-	isz, bts, err = msgp.ReadMapHeaderBytes(bts)
+	var zrsw uint32
+	zrsw, bts, err = msgp.ReadMapHeaderBytes(bts)
 	if err != nil {
 		return
 	}
-	for isz > 0 {
-		isz--
+	for zrsw > 0 {
+		zrsw--
 		field, bts, err = msgp.ReadMapKeyZC(bts)
 		if err != nil {
 			return
@@ -786,18 +733,18 @@ func (z *MetricDefinition) UnmarshalMsg(bts []byte) (o []byte, err error) {
 				return
 			}
 		case "Tags":
-			var xsz uint32
-			xsz, bts, err = msgp.ReadArrayHeaderBytes(bts)
+			var zxpk uint32
+			zxpk, bts, err = msgp.ReadArrayHeaderBytes(bts)
 			if err != nil {
 				return
 			}
-			if cap(z.Tags) >= int(xsz) {
-				z.Tags = z.Tags[:xsz]
+			if cap(z.Tags) >= int(zxpk) {
+				z.Tags = (z.Tags)[:zxpk]
 			} else {
-				z.Tags = make([]string, xsz)
+				z.Tags = make([]string, zxpk)
 			}
-			for hct := range z.Tags {
-				z.Tags[hct], bts, err = msgp.ReadStringBytes(bts)
+			for zjfb := range z.Tags {
+				z.Tags[zjfb], bts, err = msgp.ReadStringBytes(bts)
 				if err != nil {
 					return
 				}
@@ -807,35 +754,8 @@ func (z *MetricDefinition) UnmarshalMsg(bts []byte) (o []byte, err error) {
 			if err != nil {
 				return
 			}
-		case "Nodes":
-			var msz uint32
-			msz, bts, err = msgp.ReadMapHeaderBytes(bts)
-			if err != nil {
-				return
-			}
-			if z.Nodes == nil && msz > 0 {
-				z.Nodes = make(map[string]string, msz)
-			} else if len(z.Nodes) > 0 {
-				for key, _ := range z.Nodes {
-					delete(z.Nodes, key)
-				}
-			}
-			for msz > 0 {
-				var cua string
-				var xhx string
-				msz--
-				cua, bts, err = msgp.ReadStringBytes(bts)
-				if err != nil {
-					return
-				}
-				xhx, bts, err = msgp.ReadStringBytes(bts)
-				if err != nil {
-					return
-				}
-				z.Nodes[cua] = xhx
-			}
-		case "NodeCount":
-			z.NodeCount, bts, err = msgp.ReadIntBytes(bts)
+		case "Partition":
+			z.Partition, bts, err = msgp.ReadInt32Bytes(bts)
 			if err != nil {
 				return
 			}
@@ -850,18 +770,12 @@ func (z *MetricDefinition) UnmarshalMsg(bts []byte) (o []byte, err error) {
 	return
 }
 
+// Msgsize returns an upper bound estimate of the number of bytes occupied by the serialized message
 func (z *MetricDefinition) Msgsize() (s int) {
 	s = 1 + 3 + msgp.StringPrefixSize + len(z.Id) + 6 + msgp.IntSize + 5 + msgp.StringPrefixSize + len(z.Name) + 7 + msgp.StringPrefixSize + len(z.Metric) + 9 + msgp.IntSize + 5 + msgp.StringPrefixSize + len(z.Unit) + 6 + msgp.StringPrefixSize + len(z.Mtype) + 5 + msgp.ArrayHeaderSize
-	for hct := range z.Tags {
-		s += msgp.StringPrefixSize + len(z.Tags[hct])
+	for zjfb := range z.Tags {
+		s += msgp.StringPrefixSize + len(z.Tags[zjfb])
 	}
-	s += 11 + msgp.Int64Size + 6 + msgp.MapHeaderSize
-	if z.Nodes != nil {
-		for cua, xhx := range z.Nodes {
-			_ = xhx
-			s += msgp.StringPrefixSize + len(cua) + msgp.StringPrefixSize + len(xhx)
-		}
-	}
-	s += 10 + msgp.IntSize
+	s += 11 + msgp.Int64Size + 10 + msgp.Int32Size
 	return
 }

--- a/vendor/gopkg.in/raintank/schema.v1/point.go
+++ b/vendor/gopkg.in/raintank/schema.v1/point.go
@@ -1,5 +1,6 @@
 package schema
 
+//go:generate msgp
 type Point struct {
 	Val float64
 	Ts  uint32

--- a/vendor/gopkg.in/raintank/schema.v1/point_gen.go
+++ b/vendor/gopkg.in/raintank/schema.v1/point_gen.go
@@ -1,0 +1,125 @@
+package schema
+
+// NOTE: THIS FILE WAS PRODUCED BY THE
+// MSGP CODE GENERATION TOOL (github.com/tinylib/msgp)
+// DO NOT EDIT
+
+import (
+	"github.com/tinylib/msgp/msgp"
+)
+
+// DecodeMsg implements msgp.Decodable
+func (z *Point) DecodeMsg(dc *msgp.Reader) (err error) {
+	var field []byte
+	_ = field
+	var zxvk uint32
+	zxvk, err = dc.ReadMapHeader()
+	if err != nil {
+		return
+	}
+	for zxvk > 0 {
+		zxvk--
+		field, err = dc.ReadMapKeyPtr()
+		if err != nil {
+			return
+		}
+		switch msgp.UnsafeString(field) {
+		case "Val":
+			z.Val, err = dc.ReadFloat64()
+			if err != nil {
+				return
+			}
+		case "Ts":
+			z.Ts, err = dc.ReadUint32()
+			if err != nil {
+				return
+			}
+		default:
+			err = dc.Skip()
+			if err != nil {
+				return
+			}
+		}
+	}
+	return
+}
+
+// EncodeMsg implements msgp.Encodable
+func (z Point) EncodeMsg(en *msgp.Writer) (err error) {
+	// map header, size 2
+	// write "Val"
+	err = en.Append(0x82, 0xa3, 0x56, 0x61, 0x6c)
+	if err != nil {
+		return err
+	}
+	err = en.WriteFloat64(z.Val)
+	if err != nil {
+		return
+	}
+	// write "Ts"
+	err = en.Append(0xa2, 0x54, 0x73)
+	if err != nil {
+		return err
+	}
+	err = en.WriteUint32(z.Ts)
+	if err != nil {
+		return
+	}
+	return
+}
+
+// MarshalMsg implements msgp.Marshaler
+func (z Point) MarshalMsg(b []byte) (o []byte, err error) {
+	o = msgp.Require(b, z.Msgsize())
+	// map header, size 2
+	// string "Val"
+	o = append(o, 0x82, 0xa3, 0x56, 0x61, 0x6c)
+	o = msgp.AppendFloat64(o, z.Val)
+	// string "Ts"
+	o = append(o, 0xa2, 0x54, 0x73)
+	o = msgp.AppendUint32(o, z.Ts)
+	return
+}
+
+// UnmarshalMsg implements msgp.Unmarshaler
+func (z *Point) UnmarshalMsg(bts []byte) (o []byte, err error) {
+	var field []byte
+	_ = field
+	var zbzg uint32
+	zbzg, bts, err = msgp.ReadMapHeaderBytes(bts)
+	if err != nil {
+		return
+	}
+	for zbzg > 0 {
+		zbzg--
+		field, bts, err = msgp.ReadMapKeyZC(bts)
+		if err != nil {
+			return
+		}
+		switch msgp.UnsafeString(field) {
+		case "Val":
+			z.Val, bts, err = msgp.ReadFloat64Bytes(bts)
+			if err != nil {
+				return
+			}
+		case "Ts":
+			z.Ts, bts, err = msgp.ReadUint32Bytes(bts)
+			if err != nil {
+				return
+			}
+		default:
+			bts, err = msgp.Skip(bts)
+			if err != nil {
+				return
+			}
+		}
+	}
+	o = bts
+	return
+}
+
+// Msgsize returns an upper bound estimate of the number of bytes occupied by the serialized message
+func (z Point) Msgsize() (s int) {
+	s = 1 + 4 + msgp.Float64Size + 3 + msgp.Uint32Size
+	return
+}

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -447,10 +447,10 @@
 			"revisionTime": "2016-08-26T18:07:28Z"
 		},
 		{
-			"checksumSHA1": "Fv3Cdgosf28iev/JTFWO6nsPFCA=",
+			"checksumSHA1": "q1kuLxEK8/xbIpd3YU3kuv90JDQ=",
 			"path": "gopkg.in/raintank/schema.v1",
-			"revision": "a2ba0a7af66d6cc470d93bb5725f22f4b3c1ea79",
-			"revisionTime": "2016-07-20T14:31:18Z"
+			"revision": "d601c94bb87d6de4a46ad73f9d1182cb8b414a5b",
+			"revisionTime": "2016-12-06T17:30:17Z"
 		}
 	],
 	"rootPath": "github.com/raintank/metrictank"


### PR DESCRIPTION
- keep track of nodes in the cluster
- assign "partitions" to each node
- include partition info in the metric index for each metric
- update MetricIndex plugins to be partition aware
  - this means the data stored in the backend stores will change so we will need to provide some migration tools.
- make carbon and kafkamdm input plugins partition aware
- when calling graphite's /render api fan out the request to
  one node for each partition
- when calling graphite's /metrics/find api fan out the requests
  to one node for each partition
- when calling graphites /metrics/index.jon api fan out the requests
  to one node for each partition
- add internal "cluster" api's to support the clustered graphite api
  requests