### PR TITLE
adopt grafana trick to get golang 1.7.3

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -6,6 +6,13 @@ machine:
   environment:
     GOPATH: "/home/ubuntu/.go_workspace"
     IMPORTPATH: "/home/ubuntu/.go_workspace/src/github.com/raintank/metrictank"
+    GODIST: "go1.7.3.linux-amd64.tar.gz"
+  post:
+    - mkdir -p download
+    - test -e download/$GODIST || curl -o download/$GODIST https://storage.googleapis.com/golang/$GODIST
+    - sudo rm -rf /usr/local/go
+    - sudo tar -C /usr/local -xzf download/$GODIST
+
 test:
   override:
     - cd $IMPORTPATH && go test -v -race $(go list ./... | grep -v /vendor/)


### PR DESCRIPTION
taken from
https://github.com/grafana/grafana/blob/70b9ba257357628efec51a81f09070f6f30a43b3/circle.yml

I've used 1.7 on local dev builds for testing and benching for a long
time. it's safe.