### PR TITLE
Refactor iterators to add a way to get size of data

### DIFF
--- a/api/dataprocessor.go
+++ b/api/dataprocessor.go
@@ -332,11 +332,7 @@ func (s *Server) getSeries(req models.Req, consolidator consolidation.Consolidat
 			}
 		}
 		if LogLevel < 2 {
-			if iter.Cass {
-				log.Debug("DP getSeries: iter cass %d values good/total %d/%d", iter.T0, good, total)
-			} else {
-				log.Debug("DP getSeries: iter mem %d values good/total %d/%d", iter.T0, good, total)
-			}
+			log.Debug("DP getSeries: iter %d values good/total %d/%d", iter.T0, good, total)
 		}
 	}
 	itersToPointsDuration.Value(time.Now().Sub(pre))
@@ -359,7 +355,7 @@ func mergeSeries(in []models.Series) []models.Series {
 			// point and if it is null, we then check the other series for a non null
 			// value to use instead.
 			log.Debug("%s has multiple series.", series[0].Target)
-			for i, _ := range series[0].Datapoints {
+			for i := range series[0].Datapoints {
 				for j := 0; j < len(series); j++ {
 					if !math.IsNaN(series[j].Datapoints[i].Val) {
 						series[0].Datapoints[i].Val = series[j].Datapoints[i].Val

--- a/idx/memory/memory.go
+++ b/idx/memory/memory.go
@@ -114,7 +114,7 @@ func (m *MemoryIdx) Add(data *schema.MetricData) error {
 func (m *MemoryIdx) Load(defs []schema.MetricDefinition) {
 	m.Lock()
 	var pre time.Time
-	for i, _ := range defs {
+	for i := range defs {
 		def := defs[i]
 		pre = time.Now()
 		if _, ok := m.DefById[def.Id]; ok {

--- a/iter/iter.go
+++ b/iter/iter.go
@@ -7,12 +7,12 @@ import (
 // Iter is a simple wrapper around a tsz.Iter to make debug logging easier
 type Iter struct {
 	*tsz.Iter
-	Cass bool //true = cass, false = mem
+	Length int
 }
 
-func New(i *tsz.Iter, cass bool) Iter {
+func New(i *tsz.Iter, l int) Iter {
 	return Iter{
 		i,
-		cass,
+		l,
 	}
 }

--- a/mdata/aggmetric.go
+++ b/mdata/aggmetric.go
@@ -303,17 +303,19 @@ func (a *AggMetric) Get(from, to uint32) (uint32, []iter.Iter) {
 
 	// now just start at oldestPos and move through the Chunks circular Buffer to newestPos
 	iters := make([]iter.Iter, 0, a.NumChunks)
-	for oldestPos != newestPos {
+	for {
 		chunk := a.getChunk(oldestPos)
-		iters = append(iters, iter.New(chunk.Iter(), false))
+		iters = append(iters, iter.New(chunk.Iter(), len(chunk.Bytes())))
+
+		if oldestPos == newestPos {
+			break
+		}
+
 		oldestPos++
 		if oldestPos >= len(a.Chunks) {
 			oldestPos = 0
 		}
 	}
-	// add the last chunk
-	chunk := a.getChunk(oldestPos)
-	iters = append(iters, iter.New(chunk.Iter(), false))
 
 	memToIterDuration.Value(time.Now().Sub(pre))
 	return oldestChunk.T0, iters

--- a/mdata/aggmetric_test.go
+++ b/mdata/aggmetric_test.go
@@ -56,7 +56,6 @@ func (c *Checker) Verify(primary bool, from, to, first, last uint32) {
 		for iter.Next() {
 			index++
 			tt, vv := iter.Values()
-			//c.t.Logf("got (%v,%v).. should be (%v,%v)", tt, vv, c.points[index].ts, c.points[index].val)
 			if index > pj {
 				c.t.Fatalf("Values()=(%v,%v), want end of stream\n", tt, vv)
 			}

--- a/mdata/store_cassandra.go
+++ b/mdata/store_cassandra.go
@@ -368,7 +368,7 @@ func (c *cassandraStore) Search(key string, start, end uint32) ([]iter.Iter, err
 				log.Error(3, "failed to unpack cassandra payload. %s", err)
 				return iters, err
 			}
-			iters = append(iters, iter.New(it, true))
+			iters = append(iters, iter.New(it, len(b)))
 		}
 		err := outcome.i.Close()
 		if err != nil {


### PR DESCRIPTION
Previously our `iter.Iter` structs only referred to iterators returned by
the `go-tsz` packages. The problem we're trying to solve is that from the
`go-tsz` iterators there's no way to get the length of the underlying
data, but we need to know that to limit the size of the chunk cache.
This patch passes a length attribute to each instance of `iter.Iter`,
along with the `go-tsz` iterator.

This means we can get the length of the underlying byte slice from an
iterator, which will later be necessary for the chunk cache (#401).

The commit also includes some changes done by `gofmt`.
