### PR TITLE
Refactor iterators to add a way to get size of data

### DIFF
--- a/idx/memory/memory.go
+++ b/idx/memory/memory.go
@@ -114,7 +114,7 @@ func (m *MemoryIdx) Add(data *schema.MetricData) error {
 func (m *MemoryIdx) Load(defs []schema.MetricDefinition) {
 	m.Lock()
 	var pre time.Time
-	for i, _ := range defs {
+	for i := range defs {
 		def := defs[i]
 		pre = time.Now()
 		if _, ok := m.DefById[def.Id]; ok {

--- a/iter/iter.go
+++ b/iter/iter.go
@@ -7,12 +7,10 @@ import (
 // Iter is a simple wrapper around a tsz.Iter to make debug logging easier
 type Iter struct {
 	*tsz.Iter
-	Cass bool //true = cass, false = mem
 }
 
-func New(i *tsz.Iter, cass bool) Iter {
+func New(i *tsz.Iter) Iter {
 	return Iter{
 		i,
-		cass,
 	}
 }

--- a/iter/itergen.go
+++ b/iter/itergen.go
@@ -1,0 +1,37 @@
+package iter
+
+import (
+	"github.com/dgryski/go-tsz"
+	"github.com/raintank/worldping-api/pkg/log"
+)
+
+type IterGen struct {
+	b   []byte
+	ts  uint32
+	len uint64
+}
+
+func NewGen(b []byte, ts uint32, len uint64) IterGen {
+	return IterGen{
+		b,
+		ts,
+		len,
+	}
+}
+
+func (ig *IterGen) Get() (*Iter, error) {
+	it, err := tsz.NewIterator(ig.b)
+	if err != nil {
+		log.Error(3, "failed to unpack cassandra payload. %s", err)
+		return nil, err
+	}
+	return &Iter{it}, nil
+}
+
+func (ig *IterGen) Length() uint64 {
+	return ig.len
+}
+
+func (ig *IterGen) Ts() uint32 {
+	return ig.ts
+}

--- a/mdata/aggmetric.go
+++ b/mdata/aggmetric.go
@@ -303,17 +303,19 @@ func (a *AggMetric) Get(from, to uint32) (uint32, []iter.Iter) {
 
 	// now just start at oldestPos and move through the Chunks circular Buffer to newestPos
 	iters := make([]iter.Iter, 0, a.NumChunks)
-	for oldestPos != newestPos {
+	for {
 		chunk := a.getChunk(oldestPos)
-		iters = append(iters, iter.New(chunk.Iter(), false))
+		iters = append(iters, iter.New(chunk.Iter()))
+
+		if oldestPos == newestPos {
+			break
+		}
+
 		oldestPos++
 		if oldestPos >= len(a.Chunks) {
 			oldestPos = 0
 		}
 	}
-	// add the last chunk
-	chunk := a.getChunk(oldestPos)
-	iters = append(iters, iter.New(chunk.Iter(), false))
 
 	memToIterDuration.Value(time.Now().Sub(pre))
 	return oldestChunk.T0, iters

--- a/mdata/aggmetric_test.go
+++ b/mdata/aggmetric_test.go
@@ -56,7 +56,6 @@ func (c *Checker) Verify(primary bool, from, to, first, last uint32) {
 		for iter.Next() {
 			index++
 			tt, vv := iter.Values()
-			//c.t.Logf("got (%v,%v).. should be (%v,%v)", tt, vv, c.points[index].ts, c.points[index].val)
 			if index > pj {
 				c.t.Fatalf("Values()=(%v,%v), want end of stream\n", tt, vv)
 			}

--- a/mdata/store.go
+++ b/mdata/store.go
@@ -6,6 +6,6 @@ import (
 
 type Store interface {
 	Add(cwr *ChunkWriteRequest)
-	Search(key string, start, end uint32) ([]iter.Iter, error)
+	Search(key string, start, end uint32) ([]iter.IterGen, error)
 	Stop()
 }

--- a/mdata/store_cassandra.go
+++ b/mdata/store_cassandra.go
@@ -9,7 +9,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/dgryski/go-tsz"
 	"github.com/gocql/gocql"
 	"github.com/hailocab/go-hostpool"
 	"github.com/raintank/met"
@@ -277,10 +276,10 @@ func (c *cassandraStore) processReadQueue() {
 
 // Basic search of cassandra.
 // start inclusive, end exclusive
-func (c *cassandraStore) Search(key string, start, end uint32) ([]iter.Iter, error) {
-	iters := make([]iter.Iter, 0)
+func (c *cassandraStore) Search(key string, start, end uint32) ([]iter.IterGen, error) {
+	itergens := make([]iter.IterGen, 0)
 	if start > end {
-		return iters, errStartBeforeEnd
+		return itergens, errStartBeforeEnd
 	}
 
 	pre := time.Now()
@@ -357,18 +356,13 @@ func (c *cassandraStore) Search(key string, start, end uint32) ([]iter.Iter, err
 			chunkSizeAtLoad.Value(int64(len(b)))
 			if len(b) < 2 {
 				log.Error(3, errChunkTooSmall.Error())
-				return iters, errChunkTooSmall
+				return itergens, errChunkTooSmall
 			}
 			if chunk.Format(b[0]) != chunk.FormatStandardGoTsz {
 				log.Error(3, errUnknownChunkFormat.Error())
-				return iters, errUnknownChunkFormat
+				return itergens, errUnknownChunkFormat
 			}
-			it, err := tsz.NewIterator(b[1:])
-			if err != nil {
-				log.Error(3, "failed to unpack cassandra payload. %s", err)
-				return iters, err
-			}
-			iters = append(iters, iter.New(it, true))
+			itergens = append(itergens, iter.NewGen(b[1:], uint32(ts), uint64(len(b[1:]))))
 		}
 		err := outcome.i.Close()
 		if err != nil {
@@ -380,8 +374,8 @@ func (c *cassandraStore) Search(key string, start, end uint32) ([]iter.Iter, err
 	}
 	cassToIterDuration.Value(time.Now().Sub(pre))
 	cassRowsPerResponse.Value(int64(len(outcomes)))
-	log.Debug("CS: searchCassandra(): %d outcomes (queries), %d total iters", len(outcomes), len(iters))
-	return iters, nil
+	log.Debug("CS: searchCassandra(): %d outcomes (queries), %d total itergens", len(outcomes), len(itergens))
+	return itergens, nil
 }
 
 func (c *cassandraStore) Stop() {

--- a/mdata/store_devnull.go
+++ b/mdata/store_devnull.go
@@ -13,7 +13,7 @@ func NewDevnullStore() *devnullStore {
 func (c *devnullStore) Add(cwr *ChunkWriteRequest) {
 }
 
-func (c *devnullStore) Search(key string, start, end uint32) ([]iter.Iter, error) {
+func (c *devnullStore) Search(key string, start, end uint32) ([]iter.IterGen, error) {
 	return nil, nil
 }
 


### PR DESCRIPTION
Previously our `iter.Iter` structs only referred to iterators returned by
the `go-tsz` packages. The problem we're trying to solve is that from the
`go-tsz` iterators there's no way to get the length of the underlying
data, but we need to know that to limit the size of the chunk cache.
This patch makes structs that implement the `mdata.Store` interface return
lists of iterator generators. These can be cached and reused, which is
what we need for the chunk cache.

The commit also includes some changes done by `gofmt`.