### PR TITLE
Introduces a second chunk format to include length

### DIFF
--- a/docs/config.md
+++ b/docs/config.md
@@ -52,12 +52,13 @@ gc-interval = 1h
 # in clusters, best to assure the primary has saved all the data that a newly warmup instance will need to query, to prevent gaps in charts
 warm-up-period = 1h
 # settings for rollups (aggregation for archives)
-# comma-separated of archive specifications.
+# comma-separated list of archive specifications.
 # archive specification is of the form: aggSpan:chunkSpan:numChunks:TTL[:ready as bool. default true]
 # with these aggregation rules: 5min:1h:2:3mon,1h:6h:2:1y:false
 # 5 min of data, store in a chunk that lasts 1hour, keep 2 chunks in memory, keep for 3months in cassandra
 # 1hr worth of data, in chunks of 6 hours, 2 chunks in mem, keep for 1 year, but this series is not ready yet for querying.
 # When running a cluster of metrictank instances, all instances should have the same agg-settings.
+# chunk spans must be valid values as described here https://github.com/raintank/metrictank/blob/master/docs/data-knobs.md
 agg-settings =
 ```
 

--- a/docs/consolidation.md
+++ b/docs/consolidation.md
@@ -107,6 +107,9 @@ should be able to transition from one band's maxT to the next minT
 must cleanly multiply between one another (why again?)
 try to minimize storage overhead of each band
 
+SPAN CHOICE
+As described in the page [Data knobs](https://github.com/raintank/metrictank/blob/master/docs/data-knobs.md#valid-chunk-spans), only a finite set of values are valid chunk spans. This applies to rolled up chunks as well.
+
 RETENTION:
 should at the minimum be maxT otherwise what's the point
 shouldn't exceed the next band's minT, because that data wouldn't be used very much

--- a/docs/data-knobs.md
+++ b/docs/data-knobs.md
@@ -19,7 +19,7 @@ For more details, see the [go-tsz eval program](https://github.com/dgryski/go-ts
 
 ### Basic guideline
 
-`chunkspan` is how long of a timeframe should be covered by your chunks. E.g. you could store anywhere between 10 minutes to 24 hours worth of data in a chunk (chunks for each raw metric).
+`chunkspan` is how long of a timeframe should be covered by your chunks. E.g. you could store anywhere between 1 second to 24 hours worth of data in a chunk (chunks for each raw metric).
 `numchunks` is simply how many chunks should be retained in RAM. (for each raw metric)
 
 figuring out optimal configuration for the `chunkspan` and `numchunks` is not trivial.
@@ -44,7 +44,17 @@ Note:
 
 Several factors come into play that may affect the above recommendation:
 
+#### Valid chunk spans
+
+Chunkspans can be set to one of the following:
+```
+1sec, 5sec, 10sec, 15sec, 20sec, 30sec, 60sec, 90sec, 2min, 3min, 5min, 10min, 15min, 20min,
+30min, 45min, 1h, 90min, 2h, 150min, 3h, 4h, 5h, 6h, 7h, 8h, 9h, 10h, 12h, 15h, 18h, 24h
+```
+This list can be extended in the future.
+
 #### Rollups remove the need to keep large number of higher resolution chunks
+
 If you roll-up data for archival storage, those chunks will also be in memory as per your configuration.
 Querying for large timeframes may use the consolidated chunks in RAM, and keeping
 extra raw (or higher-resolution) data in RAM becomes pointless, putting an upper bound on how many chunks to keep.  

--- a/mdata/aggmetric.go
+++ b/mdata/aggmetric.go
@@ -356,6 +356,7 @@ func (a *AggMetric) persist(pos int) {
 		chunk:     chunk,
 		ttl:       a.ttl,
 		timestamp: time.Now(),
+		span:      a.ChunkSpan,
 	}
 
 	// if we recently became the primary, there may be older chunks
@@ -375,6 +376,7 @@ func (a *AggMetric) persist(pos int) {
 			chunk:     previousChunk,
 			ttl:       a.ttl,
 			timestamp: time.Now(),
+			span:      a.ChunkSpan,
 		})
 		previousPos--
 		if previousPos < 0 {

--- a/mdata/chunk/format.go
+++ b/mdata/chunk/format.go
@@ -10,4 +10,5 @@ type Format uint8
 // identifier of message format
 const (
 	FormatStandardGoTsz Format = iota
+	FormatStandardGoTszWithSpan
 )

--- a/mdata/chunk/spans.go
+++ b/mdata/chunk/spans.go
@@ -1,0 +1,49 @@
+package chunk
+
+type SpanCode uint8
+
+const min = 60
+const hour = 60 * min
+
+var ChunkSpans = [32]uint32{
+	1,
+	5,
+	10,
+	15,
+	20,
+	30,
+	60,        // 1m
+	90,        // 1.5m
+	2 * 60,    // 2m
+	3 * 60,    // 3m
+	5 * 60,    // 5m
+	10 * 60,   // 10m
+	15 * 60,   // 15m
+	20 * 60,   // 20m
+	30 * 60,   // 30m
+	45 * 60,   // 45m
+	3600,      // 1h
+	90 * 60,   // 1.5h
+	2 * 3600,  // 2h
+	150 * 60,  // 2.5h
+	3 * 3600,  // 3h
+	4 * 3600,  // 4h
+	5 * 3600,  // 5h
+	6 * 3600,  // 6h
+	7 * 3600,  // 7h
+	8 * 3600,  // 8h
+	9 * 3600,  // 9h
+	10 * 3600, // 10h
+	12 * 3600, // 12h
+	15 * 3600, // 15h
+	18 * 3600, // 18h
+	24 * 3600, // 24h
+}
+
+var RevChunkSpans = make(map[uint32]SpanCode, len(ChunkSpans))
+
+func init() {
+	for k, v := range ChunkSpans {
+		RevChunkSpans[v] = SpanCode(k)
+	}
+}

--- a/mdata/cwr.go
+++ b/mdata/cwr.go
@@ -20,4 +20,5 @@ type ChunkWriteRequest struct {
 	chunk     *chunk.Chunk
 	ttl       uint32
 	timestamp time.Time
+	span      uint32
 }

--- a/metrictank-sample.ini
+++ b/metrictank-sample.ini
@@ -32,12 +32,13 @@ gc-interval = 1h
 warm-up-period = 1h
 
 # settings for rollups (aggregation for archives)
-# comma-separated of archive specifications.
+# comma-separated list of archive specifications.
 # archive specification is of the form: aggSpan:chunkSpan:numChunks:TTL[:ready as bool. default true]
 # with these aggregation rules: 5min:1h:2:3mon,1h:6h:2:1y:false
 # 5 min of data, store in a chunk that lasts 1hour, keep 2 chunks in memory, keep for 3months in cassandra
 # 1hr worth of data, in chunks of 6 hours, 2 chunks in mem, keep for 1 year, but this series is not ready yet for querying.
 # When running a cluster of metrictank instances, all instances should have the same agg-settings.
+# chunk spans must be valid values as described here https://github.com/raintank/metrictank/blob/master/docs/data-knobs.md
 agg-settings =
 
 ## metric data storage in cassandra ##

--- a/metrictank.go
+++ b/metrictank.go
@@ -253,6 +253,10 @@ func main() {
 	if (mdata.Month_sec % chunkSpan) != 0 {
 		log.Fatal(4, "chunkSpan must fit without remainders into month_sec (28*24*60*60)")
 	}
+	_, ok := chunk.RevChunkSpans[chunkSpan]
+	if !ok {
+		log.Fatal(4, "chunkSpan %s is not a valid value (https://github.com/raintank/metrictank/blob/master/docs/data-knobs.md#valid-chunk-spans)", *chunkSpanStr)
+	}
 
 	set := strings.Split(*aggSettings, ",")
 	finalSettings := make([]mdata.AggSetting, 0)
@@ -271,6 +275,10 @@ func main() {
 		aggTTL := dur.MustParseUNsec("aggsettings", fields[3])
 		if (mdata.Month_sec % aggChunkSpan) != 0 {
 			log.Fatal(4, "aggChunkSpan must fit without remainders into month_sec (28*24*60*60)")
+		}
+		_, ok := chunk.RevChunkSpans[aggChunkSpan]
+		if !ok {
+			log.Fatal(4, "aggChunkSpan %s is not a valid value (https://github.com/raintank/metrictank/blob/master/docs/data-knobs.md#valid-chunk-spans)", fields[1])
 		}
 		highestChunkSpan = util.Max(highestChunkSpan, aggChunkSpan)
 		ready := true

--- a/scripts/config/metrictank-docker.ini
+++ b/scripts/config/metrictank-docker.ini
@@ -29,12 +29,13 @@ gc-interval = 1h
 warm-up-period = 1h
 
 # settings for rollups (aggregation for archives)
-# comma-separated of archive specifications.
+# comma-separated list of archive specifications.
 # archive specification is of the form: aggSpan:chunkSpan:numChunks:TTL[:ready as bool. default true]
 # with these aggregation rules: 5min:1h:2:3mon,1h:6h:2:1y:false
 # 5 min of data, store in a chunk that lasts 1hour, keep 2 chunks in memory, keep for 3months in cassandra
 # 1hr worth of data, in chunks of 6 hours, 2 chunks in mem, keep for 1 year, but this series is not ready yet for querying.
 # When running a cluster of metrictank instances, all instances should have the same agg-settings.
+# chunk spans must be valid values as described here https://github.com/raintank/metrictank/blob/master/docs/data-knobs.md
 agg-settings =
 
 ## metric data storage in cassandra ##

--- a/scripts/config/metrictank-package.ini
+++ b/scripts/config/metrictank-package.ini
@@ -29,12 +29,13 @@ gc-interval = 1h
 warm-up-period = 1h
 
 # settings for rollups (aggregation for archives)
-# comma-separated of archive specifications.
+# comma-separated list of archive specifications.
 # archive specification is of the form: aggSpan:chunkSpan:numChunks:TTL[:ready as bool. default true]
 # with these aggregation rules: 5min:1h:2:3mon,1h:6h:2:1y:false
 # 5 min of data, store in a chunk that lasts 1hour, keep 2 chunks in memory, keep for 3months in cassandra
 # 1hr worth of data, in chunks of 6 hours, 2 chunks in mem, keep for 1 year, but this series is not ready yet for querying.
 # When running a cluster of metrictank instances, all instances should have the same agg-settings.
+# chunk spans must be valid values as described here https://github.com/raintank/metrictank/blob/master/docs/data-knobs.md
 agg-settings =
 
 ## metric data storage in cassandra ##


### PR DESCRIPTION
By default all new chunks will be written in the new format. This means
the second byte of the binary data is a `uint8` that specifies how many
10min intervals this chunk is long.

We only specify with a precision of 10min to require less space to
define the length.

If a configured chunk span (or aggmetric chunk span) is not dividable
by 10min we error at startup, same if it exceeds the maximum length of 2^8 * 10min.