### PR TITLE
update sarama to latest tag relase. fixes compression handling

### DIFF
--- a/vendor/github.com/Shopify/sarama/CHANGELOG.md
+++ b/vendor/github.com/Shopify/sarama/CHANGELOG.md
@@ -1,5 +1,20 @@
 # Changelog
 
+#### Version 1.10.1 (2016-08-30)
+
+Bug Fixes:
+ - Fix the documentation for `HashPartitioner` which was incorrect
+   ([#717](https://github.com/Shopify/sarama/pull/717)).
+ - Permit client creation even when it is limited by ACLs
+   ([#722](https://github.com/Shopify/sarama/pull/722)).
+ - Several fixes to the consumer timer optimization code, regressions introduced
+   in v1.10.0. Go's timers are finicky
+   ([#730](https://github.com/Shopify/sarama/pull/730),
+    [#733](https://github.com/Shopify/sarama/pull/733),
+    [#734](https://github.com/Shopify/sarama/pull/734)).
+ - Handle consuming compressed relative offsets with Kafka 0.10
+   ([#735](https://github.com/Shopify/sarama/pull/735)).
+
 #### Version 1.10.0 (2016-08-02)
 
 _Important:_ As of Sarama 1.10 it is necessary to tell Sarama the version of

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -15,10 +15,10 @@
 			"revisionTime": "2016-10-07T15:24:48Z"
 		},
 		{
-			"checksumSHA1": "AAXMx9vb6vmVZF2ieqNepAfeJFM=",
+			"checksumSHA1": "uqfutMkGN018AvjoQET06lhOM3g=",
 			"path": "github.com/Shopify/sarama",
-			"revision": "94895118af045d13c7e576477276a53afccdd6b1",
-			"revisionTime": "2016-08-23T12:00:18Z"
+			"revision": "bd61cae2be85fa6ff40eb23dcdd24567967ac2ae",
+			"revisionTime": "2016-08-30T13:25:53Z"
 		},
 		{
 			"checksumSHA1": "USQFwXWz6tO69wtZdj3zZDB1MA4=",


### PR DESCRIPTION
handling of compression was fixed in Sarama back in August, this is also when the latest tag was cut (v1.10.1).

