### PR TITLE
mt-index-cat

### DIFF
--- a/cmd/mt-index-cat/README.md
+++ b/cmd/mt-index-cat/README.md
@@ -1,0 +1,1 @@
+tool to query metric metadata for sanity checks and stress testing

--- a/cmd/mt-index-cat/main.go
+++ b/cmd/mt-index-cat/main.go
@@ -1,0 +1,116 @@
+package main
+
+import (
+	"flag"
+	"fmt"
+	"log"
+	"os"
+	"strconv"
+	"time"
+
+	"github.com/davecgh/go-spew/spew"
+	"github.com/raintank/dur"
+	"github.com/raintank/inspect/idx/cass"
+	"github.com/raintank/inspect/inspect-idx/out"
+	"gopkg.in/raintank/schema.v1"
+)
+
+func perror(err error) {
+	if err != nil {
+		log.Fatal(err)
+	}
+}
+
+func main() {
+
+	var (
+		addr   string
+		from   string
+		maxAge string
+		count  bool
+		old    bool
+
+		total int
+	)
+
+	flag.StringVar(&addr, "addr", "http://localhost:6060", "graphite/metrictank address")
+	flag.StringVar(&from, "from", "30min", "from. eg '30min', '5h', '14d', etc. or a unix timestamp")
+	flag.StringVar(&maxAge, "max-age", "6h30min", "max age (last update diff with now) of metricdefs.  use 0 to disable")
+	flag.BoolVar(&count, "count", false, "print number of metrics loaded to stderr")
+	flag.BoolVar(&old, "old", false, "use old cassandra table, metric_def_idx. (prior to clustering)")
+
+	flag.Usage = func() {
+		fmt.Printf("%s by Dieter_be\n", os.Args[0])
+		fmt.Println("Usage:")
+		fmt.Printf("  inspect-idx [flags] idxtype host keyspace/index output \n")
+		fmt.Printf("  idxtype cass: \n")
+		fmt.Printf("    host: comma separated list of cassandra addresses in host:port form\n")
+		fmt.Printf("    keyspace: cassandra keyspace\n")
+		fmt.Printf("  idxtype es: not supported at this point\n")
+		fmt.Printf("  output: dump|list|vegeta-render|vegeta-render-patterns\n")
+		fmt.Println("Flags:")
+		flag.PrintDefaults()
+	}
+	flag.Parse()
+	if flag.NArg() != 4 {
+		flag.Usage()
+		os.Exit(-1)
+	}
+	args := flag.Args()
+	var show func(d schema.MetricDefinition)
+
+	switch args[3] {
+	case "dump":
+		show = out.Dump
+	case "list":
+		show = out.List
+	case "vegeta-render":
+		show = out.GetVegetaRender(addr, from)
+	case "vegeta-render-patterns":
+		show = out.GetVegetaRenderPattern(addr, from)
+	default:
+		log.Fatal("invalid output")
+	}
+
+	// from should either a unix timestamp, or a specification that graphite/metrictank will recognize.
+	_, err := strconv.Atoi(from)
+	if err != nil {
+		_, err = dur.ParseUNsec(from)
+		perror(err)
+	}
+
+	maxAgeInt := int64(0)
+	if maxAge != "0" {
+		var i uint32
+		i, err = dur.ParseUNsec(maxAge)
+		perror(err)
+		maxAgeInt = int64(i)
+	}
+
+	if args[0] != "cass" {
+		fmt.Fprintf(os.Stderr, "only cass supported at this point")
+		flag.Usage()
+		os.Exit(-1)
+	}
+
+	table := "metric_idx"
+	if old {
+		table = "metric_def_idx"
+	}
+	idx := cass.New(args[1], args[2], table)
+
+	defs, err := idx.Get()
+	perror(err)
+	spew.Dump(defs)
+
+	for _, d := range defs {
+		if maxAgeInt != 0 && d.LastUpdate > time.Now().Unix()-maxAgeInt {
+			total += 1
+			show(d)
+		}
+	}
+
+	if count {
+		fmt.Fprintf(os.Stderr, "listed %d metrics\n", total)
+	}
+}

--- a/cmd/mt-index-cat/main.go
+++ b/cmd/mt-index-cat/main.go
@@ -119,12 +119,10 @@ func main() {
 		perror(err)
 	}
 
-	maxAgeInt := int64(0)
+	maxAgeInt := uint32(0)
 	if maxAge != "0" {
-		var i uint32
-		i, err = dur.ParseUNsec(maxAge)
+		maxAgeInt, err = dur.ParseUNsec(maxAge)
 		perror(err)
-		maxAgeInt = int64(i)
 	}
 
 	defs := idx.Load(nil)
@@ -136,7 +134,7 @@ func main() {
 			show(d)
 		}
 	} else {
-		cutoff := time.Now().Unix() - maxAgeInt
+		cutoff := time.Now().Unix() - int64(maxAgeInt)
 		for _, d := range defs {
 			if d.LastUpdate > cutoff {
 				total += 1

--- a/cmd/mt-index-cat/out/out.go
+++ b/cmd/mt-index-cat/out/out.go
@@ -1,0 +1,51 @@
+package out
+
+import (
+	"fmt"
+	"math/rand"
+	"strings"
+
+	"github.com/davecgh/go-spew/spew"
+
+	"gopkg.in/raintank/schema.v1"
+)
+
+func Dump(d schema.MetricDefinition) {
+	spew.Dump(d)
+}
+
+func List(d schema.MetricDefinition) {
+	fmt.Println(d.OrgId, d.Name)
+}
+
+func GetVegetaRender(addr, from string) func(d schema.MetricDefinition) {
+	return func(d schema.MetricDefinition) {
+		fmt.Printf("GET %s/render?target=%s&from=-%s\nX-Org-Id: %d\n\n", addr, d.Name, from, d.OrgId)
+	}
+}
+
+func GetVegetaRenderPattern(addr, from string) func(d schema.MetricDefinition) {
+	return func(d schema.MetricDefinition) {
+		fmt.Printf("GET %s/render?target=%s&from=-%s\nX-Org-Id: %d\n\n", addr, pattern(d.Name), from, d.OrgId)
+	}
+}
+
+func pattern(in string) string {
+	mode := rand.Intn(3)
+	if mode == 0 {
+		// in this mode, replaces a node with a wildcard
+		parts := strings.Split(in, ".")
+		parts[rand.Intn(len(parts))] = "*"
+		return strings.Join(parts, ".")
+	} else if mode == 1 {
+		// randomly replace chars with a *
+		// note that in 1/5 cases, nothing happens
+		// and otherwise, sometimes valid patterns are produced,
+		// but it's also possible to produce patterns that won't match anything (if '.' was taken out)
+		chars := rand.Intn(5)
+		pos := rand.Intn(len(in) - chars)
+		return in[0:pos] + "*" + in[pos+chars:]
+	}
+	// mode 3: do nothing :)
+	return in
+}

--- a/idx/cassandra/cassandra.go
+++ b/idx/cassandra/cassandra.go
@@ -270,10 +270,9 @@ func (c *CasIdx) LoadPartition(partition int32, defs []schema.MetricDefinition) 
 func (c *CasIdx) load(defs []schema.MetricDefinition, iter *gocql.Iter) []schema.MetricDefinition {
 	mdef := schema.MetricDefinition{}
 	var id, name, metric, unit, mtype string
-	var orgId int
+	var orgId, interval int
 	var partition int32
 	var lastupdate int64
-	var interval int
 	var tags []string
 	for iter.Scan(&id, &orgId, &partition, &name, &metric, &interval, &unit, &mtype, &tags, &lastupdate) {
 		mdef.Id = id

--- a/scripts/build_tools.sh
+++ b/scripts/build_tools.sh
@@ -19,4 +19,5 @@ cd $GOPATH/src/github.com/raintank/metrictank/cmd
 for tool in *; do
   cd $tool
   go build -ldflags "-X main.GitHash=$GITVERSION" -o $BUILDDIR/$tool
+  cd ..
 done


### PR DESCRIPTION
this tool aims to make it easy to see what's in the index, though the most common use is the vegeta output format which lets you generate queries to target different series on metrictank, so you can pipe the output into `vegeta attack`