### PR TITLE
Refactor dataprocessor

### DIFF
--- a/api/dataprocessor_test.go
+++ b/api/dataprocessor_test.go
@@ -539,8 +539,8 @@ func TestPrevBoundary(t *testing.T) {
 	}
 }
 
-// TestGetSeries assures that series data is returned in proper form.
-func TestGetSeries(t *testing.T) {
+// TestGetSeriesFixed assures that series data is returned in proper form.
+func TestGetSeriesFixed(t *testing.T) {
 	cluster.Init("default", "test", time.Now())
 	stats, _ := helper.New(false, "", "standard", "metrictank", "")
 	store := mdata.NewDevnullStore()
@@ -577,7 +577,7 @@ func TestGetSeries(t *testing.T) {
 				metric.Add(40+offset, 50) // this point will always be quantized to 50
 				req := models.NewReq(name, name, from, to, 1000, 10, consolidation.Avg, cluster.ThisNode)
 				req.ArchInterval = 10
-				points := srv.getSeries(req, consolidation.None)
+				points := srv.getSeriesFixed(req, consolidation.None)
 				if !reflect.DeepEqual(expected, points) {
 					t.Errorf("case %q - exp: %v - got %v", name, expected, points)
 				}


### PR DESCRIPTION
Refactor the `getSeries()` methods to satisfy two goals:

1) Reduce complexity of any single function. `getSeries()` is very complex, especially after the `chunk-cache` PR, so it should be broken up to make the single parts of it more easily understandable. Furthermore it's much easier to avoid creating bugs when modifying small functions that only do one thing than if there is a lot of potential for side effects due to a large number of variables and operations interacting with each other.
2) Make all the single steps that happen inside `getSeries()` testable separately. If `getSeries()` calls `fix()` before returning there is no way to test for the generated results before `fix()` has fixed them.