### PR TITLE
Fix #454

### DIFF
--- a/mdata/cache/ccache.go
+++ b/mdata/cache/ccache.go
@@ -104,6 +104,10 @@ func (c *CCache) Search(metric string, from, until uint32) *CCSearchResult {
 		Until: until,
 	}
 
+	if from == until {
+		return res
+	}
+
 	c.RLock()
 	defer c.RUnlock()
 

--- a/mdata/cache/ccache_metric.go
+++ b/mdata/cache/ccache_metric.go
@@ -12,14 +12,6 @@ import (
 type CCacheMetric struct {
 	sync.RWMutex
 
-	// points to the timestamp of the newest cache chunk currently held
-	// the head of the linked list that containes the cache chunks
-	newest uint32
-
-	// points to the timestamp of the oldest cache chunk currently held
-	// the tail of the linked list that containes the cache chunks
-	oldest uint32
-
 	// points at cached data chunks, indexed by their according time stamp
 	chunks map[uint32]*CCacheChunk
 }
@@ -32,8 +24,6 @@ func NewCCacheMetric() *CCacheMetric {
 
 func (mc *CCacheMetric) Init(prev uint32, itergen chunk.IterGen) {
 	mc.Add(prev, itergen)
-	mc.oldest = itergen.Ts()
-	mc.newest = itergen.Ts()
 }
 
 func (mc *CCacheMetric) Del(ts uint32) int {
@@ -104,13 +94,6 @@ func (mc *CCacheMetric) Add(prev uint32, itergen chunk.IterGen) {
 			mc.chunks[nextTs].Prev = ts
 			mc.chunks[ts].Next = nextTs
 		}
-	}
-
-	// update list head/tail if necessary
-	if ts > mc.newest {
-		mc.newest = ts
-	} else if ts < mc.oldest {
-		mc.oldest = ts
 	}
 
 	return
@@ -259,7 +242,6 @@ func (mc *CCacheMetric) Search(res *CCSearchResult, from, until uint32) {
 
 func (mc *CCacheMetric) debugMetric(keys []uint32) {
 	log.Debug("CCacheMetric debugMetric: --- debugging metric ---\n")
-	log.Debug("CCacheMetric debugMetric: oldest %d; newest %d\n", mc.oldest, mc.newest)
 	for _, key := range keys {
 		log.Debug("CCacheMetric debugMetric: ts %d; prev %d; next %d\n", key, mc.chunks[key].Prev, mc.chunks[key].Next)
 	}

--- a/mdata/cache/ccache_metric.go
+++ b/mdata/cache/ccache_metric.go
@@ -204,10 +204,9 @@ func (mc *CCacheMetric) searchBackward(from, until uint32, keys []uint32, res *C
 	for ; ts != 0; ts = mc.chunks[ts].Prev {
 		log.Debug("CCacheMetric searchBackward: backward search adds chunk ts %d to end", ts)
 		res.End = append(res.End, mc.chunks[ts].Itgen)
-		startTs := mc.chunks[ts].Ts
-		res.Until = startTs
+		res.Until = ts
 
-		if startTs <= from {
+		if ts <= from {
 			break
 		}
 	}

--- a/mdata/cache/ccache_metric.go
+++ b/mdata/cache/ccache_metric.go
@@ -231,7 +231,7 @@ func (mc *CCacheMetric) Search(res *CCSearchResult, from, until uint32) {
 	mc.RLock()
 	defer mc.RUnlock()
 
-	if len(mc.chunks) < 1 || from == until {
+	if len(mc.chunks) < 1 {
 		return
 	}
 

--- a/mdata/cache/ccache_metric.go
+++ b/mdata/cache/ccache_metric.go
@@ -244,12 +244,11 @@ func (mc *CCacheMetric) Search(res *CCSearchResult, from, until uint32) {
 
 	if !res.Complete && res.From > res.Until {
 		log.Debug("CCacheMetric Search: Found from > until (%d/%d), printing chunks\n", res.From, res.Until)
-		mc.debugMetric()
+		mc.debugMetric(keys)
 	}
 }
 
-func (mc *CCacheMetric) debugMetric() {
-	keys := mc.sortedTs()
+func (mc *CCacheMetric) debugMetric(keys []uint32) {
 	log.Debug("CCacheMetric debugMetric: --- debugging metric ---\n")
 	log.Debug("CCacheMetric debugMetric: oldest %d; newest %d\n", mc.oldest, mc.newest)
 	for _, key := range keys {


### PR DESCRIPTION
I've gone through the Add/Delete/Search methods of the chunk cache one more time, with the goal of making sure that there can't be a situation where the returned `from` is > `until`, as described in #454 . 
Since I don't have enough debug data to be sure what exactly happened in #454 I can't exactly reproduce the problem and hence I can't be sure this really fixes it.

While going through the code I also found a short list of other optimizations:
- If the cache search returns a result where `from == until` we don't need to hit Cassandra. This situation can occur if the chunks are not span aware and there is a disconnect in the cache internal linked list despite the fact that all queried chunks are present (for example if insertions happened at a weird order).
- If the cache is queried for a `from == until` we can save a few ops by not even looking up whether the specified metric is present
- The `debugMetrics` method can reuse the already present `keys` slice, we don't need to rebuild it
- Saving the allocation of some variables that are not necessary
- When adding a chunk to the cache without specifying the `ts` of the previous chunk (happens if this is the first chunk of that insertion) then the `Add()` method should try to figure out if the previous chunk is present, and if it is it connects them in the internal linked list. This only works reliably if either the chunks are span aware or if the span has not changes since `> 2 * chunkSpan`
- adding more tests for chunk insertion scenarios
- the chunk cache used to keep track of the `oldest` and `newest` present chunk per metric, but these variables are not used at all, so we can drop them
- we keep regenerating the sorted list of `keys` in `CCacheMetric`, let's rather just keep it until it changes instead