### PR TITLE
Push chunks of hot metrics into cache when they get completed by `AggMetric`

### DIFF
--- a/api/dataprocessor_test.go
+++ b/api/dataprocessor_test.go
@@ -545,8 +545,7 @@ func TestPrevBoundary(t *testing.T) {
 func TestGetSeriesFixed(t *testing.T) {
 	cluster.Init("default", "test", time.Now(), "http", 6060)
 	store := mdata.NewDevnullStore()
-	metrics := mdata.NewAggMetrics(store, 600, 10, 0, 0, 0, 0, []mdata.AggSetting{})
-	Addr = "localhost:6060"
+	metrics := mdata.NewAggMetrics(store, &cache.MockCache{}, 600, 10, 0, 0, 0, 0, []mdata.AggSetting{})
 	srv, _ := NewServer()
 	srv.BindBackendStore(store)
 	srv.BindMemoryStore(metrics)
@@ -1231,7 +1230,7 @@ func TestGetSeriesCachedStore(t *testing.T) {
 	srv, _ := NewServer()
 	store := mdata.NewMockStore()
 	srv.BindBackendStore(store)
-	metrics := mdata.NewAggMetrics(store, 1, 1, 0, 0, 0, 0, []mdata.AggSetting{})
+	metrics := mdata.NewAggMetrics(store, &cache.MockCache{}, 1, 1, 0, 0, 0, 0, []mdata.AggSetting{})
 	srv.BindMemoryStore(metrics)
 	metric := "metric1"
 	var c *cache.CCache
@@ -1407,8 +1406,7 @@ func TestGetSeriesAggMetrics(t *testing.T) {
 	store := mdata.NewMockStore()
 	chunkSpan := uint32(600)
 	numChunks := uint32(10)
-	metrics := mdata.NewAggMetrics(store, chunkSpan, numChunks, 0, 0, 0, 0, []mdata.AggSetting{})
-	Addr = "localhost:6060"
+	metrics := mdata.NewAggMetrics(store, &cache.MockCache{}, chunkSpan, numChunks, 0, 0, 0, 0, []mdata.AggSetting{})
 	srv, _ := NewServer()
 	srv.BindBackendStore(store)
 	srv.BindMemoryStore(metrics)

--- a/input/carbon/carbon_test.go
+++ b/input/carbon/carbon_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/raintank/metrictank/cluster"
 	"github.com/raintank/metrictank/idx/memory"
 	"github.com/raintank/metrictank/mdata"
+	"github.com/raintank/metrictank/mdata/cache"
 	"github.com/raintank/metrictank/usage"
 	"gopkg.in/raintank/schema.v1"
 )
@@ -20,7 +21,7 @@ import (
 func Test_HandleMessage(t *testing.T) {
 	cluster.Init("default", "test", time.Now(), "http", 6060)
 	store := mdata.NewDevnullStore()
-	aggmetrics := mdata.NewAggMetrics(store, 600, 10, 800, 8000, 10000, 0, make([]mdata.AggSetting, 0))
+	aggmetrics := mdata.NewAggMetrics(store, &cache.MockCache{}, 600, 10, 800, 8000, 10000, 0, make([]mdata.AggSetting, 0))
 	metricIndex := memory.New()
 	metricIndex.Init()
 	usage := usage.New(300, aggmetrics, metricIndex, clock.New())

--- a/input/input_test.go
+++ b/input/input_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/raintank/metrictank/cluster"
 	"github.com/raintank/metrictank/idx/memory"
 	"github.com/raintank/metrictank/mdata"
+	"github.com/raintank/metrictank/mdata/cache"
 	"github.com/raintank/metrictank/usage"
 	"gopkg.in/raintank/schema.v1"
 )
@@ -16,7 +17,7 @@ import (
 func Test_Process(t *testing.T) {
 	cluster.Init("default", "test", time.Now(), "http", 6060)
 	store := mdata.NewDevnullStore()
-	aggmetrics := mdata.NewAggMetrics(store, 600, 10, 800, 8000, 10000, 0, make([]mdata.AggSetting, 0))
+	aggmetrics := mdata.NewAggMetrics(store, &cache.MockCache{}, 600, 10, 800, 8000, 10000, 0, make([]mdata.AggSetting, 0))
 	metricIndex := memory.New()
 	metricIndex.Init()
 	usage := usage.New(300, aggmetrics, metricIndex, clock.New())
@@ -87,7 +88,7 @@ func BenchmarkProcess(b *testing.B) {
 	cluster.Init("default", "test", time.Now(), "http", 6060)
 
 	store := mdata.NewDevnullStore()
-	aggmetrics := mdata.NewAggMetrics(store, 600, 10, 800, 8000, 10000, 0, make([]mdata.AggSetting, 0))
+	aggmetrics := mdata.NewAggMetrics(store, &cache.MockCache{}, 600, 10, 800, 8000, 10000, 0, make([]mdata.AggSetting, 0))
 	metricIndex := memory.New()
 	metricIndex.Init()
 	usage := usage.New(300, aggmetrics, metricIndex, clock.New())

--- a/input/kafkamdm/kafkamdm_test.go
+++ b/input/kafkamdm/kafkamdm_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/raintank/metrictank/idx/memory"
 	"github.com/raintank/metrictank/input"
 	"github.com/raintank/metrictank/mdata"
+	"github.com/raintank/metrictank/mdata/cache"
 	"github.com/raintank/metrictank/usage"
 
 	"gopkg.in/raintank/schema.v1"
@@ -18,7 +19,7 @@ import (
 func Test_HandleMessage(t *testing.T) {
 	cluster.Init("default", "test", time.Now(), "http", 6060)
 	store := mdata.NewDevnullStore()
-	aggmetrics := mdata.NewAggMetrics(store, 600, 10, 800, 8000, 10000, 0, make([]mdata.AggSetting, 0))
+	aggmetrics := mdata.NewAggMetrics(store, &cache.MockCache{}, 600, 10, 800, 8000, 10000, 0, make([]mdata.AggSetting, 0))
 	metricIndex := memory.New()
 	metricIndex.Init()
 	usage := usage.New(300, aggmetrics, metricIndex, clock.New())

--- a/mdata/aggmetric.go
+++ b/mdata/aggmetric.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/raintank/metrictank/cluster"
 	"github.com/raintank/metrictank/consolidation"
+	"github.com/raintank/metrictank/mdata/cache"
 	"github.com/raintank/metrictank/mdata/chunk"
 	"github.com/raintank/worldping-api/pkg/log"
 )
@@ -20,7 +21,8 @@ import (
 // in addition, keep in mind that the last chunk is always a work in progress and not useable for aggregation
 // AggMetric is concurrency-safe
 type AggMetric struct {
-	store Store
+	store       Store
+	cachePusher cache.CachePusher
 	sync.RWMutex
 	Key             string
 	CurrentChunkPos int    // element in []Chunks that is active. All others are either finished or nil.
@@ -37,20 +39,21 @@ type AggMetric struct {
 
 // NewAggMetric creates a metric with given key, it retains the given number of chunks each chunkSpan seconds long
 // it optionally also creates aggregations with the given settings
-func NewAggMetric(store Store, key string, chunkSpan, numChunks uint32, ttl uint32, aggsetting ...AggSetting) *AggMetric {
+func NewAggMetric(store Store, cachePusher cache.CachePusher, key string, chunkSpan, numChunks uint32, ttl uint32, aggsetting ...AggSetting) *AggMetric {
 	m := AggMetric{
-		store:     store,
-		Key:       key,
-		ChunkSpan: chunkSpan,
-		NumChunks: numChunks,
-		Chunks:    make([]*chunk.Chunk, 0, numChunks),
-		ttl:       ttl,
+		cachePusher: cachePusher,
+		store:       store,
+		Key:         key,
+		ChunkSpan:   chunkSpan,
+		NumChunks:   numChunks,
+		Chunks:      make([]*chunk.Chunk, 0, numChunks),
+		ttl:         ttl,
 		// we set LastWrite here to make sure a new Chunk doesn't get immediately
 		// garbage collected right after creating it, before we can push to it.
 		lastWrite: uint32(time.Now().Unix()),
 	}
 	for _, as := range aggsetting {
-		m.aggregators = append(m.aggregators, NewAggregator(store, key, as.Span, as.ChunkSpan, as.NumChunks, as.Ttl))
+		m.aggregators = append(m.aggregators, NewAggregator(store, cachePusher, key, as.Span, as.ChunkSpan, as.NumChunks, as.Ttl))
 	}
 
 	return &m
@@ -252,6 +255,19 @@ func (a *AggMetric) addAggregators(ts uint32, val float64) {
 	}
 }
 
+func (a *AggMetric) pushToCache(c *chunk.Chunk) {
+	// push into cache
+	go a.cachePusher.CacheIfHot(
+		a.Key,
+		0,
+		*chunk.NewBareIterGen(
+			c.Bytes(),
+			c.T0,
+			a.ChunkSpan,
+		),
+	)
+}
+
 // write a chunk to persistent storage. This should only be called while holding a.Lock()
 func (a *AggMetric) persist(pos int) {
 	chunk := a.Chunks[pos]
@@ -326,7 +342,6 @@ func (a *AggMetric) persist(pos int) {
 			log.Debug("AM persist(): sealing chunk %d/%d (%s:%d) and adding to write queue.", pendingChunk, len(pending), a.Key, chunk.T0)
 		}
 		a.store.Add(pending[pendingChunk])
-
 		pendingChunk--
 	}
 	persistDuration.Value(time.Now().Sub(pre))
@@ -389,6 +404,7 @@ func (a *AggMetric) Add(ts uint32, val float64) {
 			currentChunk.Finish()
 		}
 
+		a.pushToCache(currentChunk)
 		// If we are a primary node, then add the chunk to the write queue to be saved to Cassandra
 		if cluster.Manager.IsPrimary() {
 			if LogLevel < 2 {

--- a/mdata/aggmetric_test.go
+++ b/mdata/aggmetric_test.go
@@ -70,6 +70,63 @@ func (c *Checker) Verify(primary bool, from, to, first, last uint32) {
 	cluster.Manager.SetPrimary(currentClusterStatus)
 }
 
+func TestMetricPersistBeingPrimary(t *testing.T) {
+	testMetricPersistOptionalPrimary(t, true)
+}
+
+func TestMetricPersistBeingSecondary(t *testing.T) {
+	testMetricPersistOptionalPrimary(t, false)
+}
+
+func testMetricPersistOptionalPrimary(t *testing.T, primary bool) {
+	// always reset the counter when entering and leaving the test
+	dnstore.Reset()
+	defer dnstore.Reset()
+
+	cluster.Init("default", "test", time.Now(), "http", 6060)
+	cluster.Manager.SetPrimary(primary)
+
+	callCount := uint32(0)
+	calledCb := make(chan bool)
+
+	mockCache := cache.MockCache{}
+	mockCache.CacheIfHotCb = func() { calledCb <- true }
+
+	numChunks, chunkAddCount, chunkSpan := uint32(5), uint32(10), uint32(300)
+	agg := NewAggMetric(dnstore, &mockCache, "foo", chunkSpan, numChunks, 1, []AggSetting{}...)
+
+	ts := uint32(1000)
+	for i := uint32(0); i < chunkAddCount; i++ {
+		agg.Add(ts, 1)
+		ts += chunkSpan
+	}
+
+	timeout := time.After(1 * time.Second)
+
+	for i := uint32(0); i < chunkAddCount-1; i++ {
+		select {
+		case <-timeout:
+			t.Fatalf("timed out waiting for a callback call")
+		case <-calledCb:
+			callCount = callCount + 1
+		}
+	}
+
+	if callCount < chunkAddCount-1 {
+		t.Fatalf("there should have been %d chunk pushes, but go %d", chunkAddCount-1, callCount)
+	}
+
+	if primary {
+		if dnstore.AddCount != chunkAddCount-1 {
+			t.Fatalf("there should have been %d chunk adds on store, but go %d", chunkAddCount-1, dnstore.AddCount)
+		}
+	} else {
+		if dnstore.AddCount != 0 {
+			t.Fatalf("there should have been %d chunk adds on store, but go %d", 0, dnstore.AddCount)
+		}
+	}
+}
+
 func TestAggMetric(t *testing.T) {
 	cluster.Init("default", "test", time.Now(), "http", 6060)
 

--- a/mdata/aggmetric_test.go
+++ b/mdata/aggmetric_test.go
@@ -95,10 +95,8 @@ func testMetricPersistOptionalPrimary(t *testing.T, primary bool) {
 	numChunks, chunkAddCount, chunkSpan := uint32(5), uint32(10), uint32(300)
 	agg := NewAggMetric(dnstore, &mockCache, "foo", chunkSpan, numChunks, 1, []AggSetting{}...)
 
-	ts := uint32(1000)
-	for i := uint32(0); i < chunkAddCount; i++ {
+	for ts := chunkSpan; ts <= chunkSpan*chunkAddCount; ts += chunkSpan {
 		agg.Add(ts, 1)
-		ts += chunkSpan
 	}
 
 	timeout := time.After(1 * time.Second)

--- a/mdata/aggmetric_test.go
+++ b/mdata/aggmetric_test.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/raintank/metrictank/cluster"
+	"github.com/raintank/metrictank/mdata/cache"
 )
 
 var dnstore = NewDevnullStore()
@@ -72,7 +73,7 @@ func (c *Checker) Verify(primary bool, from, to, first, last uint32) {
 func TestAggMetric(t *testing.T) {
 	cluster.Init("default", "test", time.Now(), "http", 6060)
 
-	c := NewChecker(t, NewAggMetric(dnstore, "foo", 100, 5, 1, []AggSetting{}...))
+	c := NewChecker(t, NewAggMetric(dnstore, &cache.MockCache{}, "foo", 100, 5, 1, []AggSetting{}...))
 
 	// basic case, single range
 	c.Add(101, 101)
@@ -170,7 +171,7 @@ func BenchmarkAggMetrics1000Metrics1Day(b *testing.B) {
 		keys[i] = fmt.Sprintf("hello.this.is.a.test.key.%d", i)
 	}
 
-	metrics := NewAggMetrics(dnstore, chunkSpan, numChunks, chunkMaxStale, metricMaxStale, ttl, 0, aggSettings)
+	metrics := NewAggMetrics(dnstore, &cache.MockCache{}, chunkSpan, numChunks, chunkMaxStale, metricMaxStale, ttl, 0, aggSettings)
 
 	maxT := 3600 * 24 * uint32(b.N) // b.N in days
 	for t := uint32(1); t < maxT; t += 10 {
@@ -182,7 +183,6 @@ func BenchmarkAggMetrics1000Metrics1Day(b *testing.B) {
 }
 
 func BenchmarkAggMetrics1kSeries2Chunks1kQueueSize(b *testing.B) {
-
 	chunkSpan := uint32(600)
 	numChunks := uint32(5)
 	chunkMaxStale := uint32(3600)
@@ -204,7 +204,7 @@ func BenchmarkAggMetrics1kSeries2Chunks1kQueueSize(b *testing.B) {
 		keys[i] = fmt.Sprintf("hello.this.is.a.test.key.%d", i)
 	}
 
-	metrics := NewAggMetrics(dnstore, chunkSpan, numChunks, chunkMaxStale, metricMaxStale, ttl, 0, aggSettings)
+	metrics := NewAggMetrics(dnstore, &cache.MockCache{}, chunkSpan, numChunks, chunkMaxStale, metricMaxStale, ttl, 0, aggSettings)
 
 	maxT := uint32(1200)
 	for t := uint32(1); t < maxT; t += 10 {
@@ -237,7 +237,7 @@ func BenchmarkAggMetrics10kSeries2Chunks10kQueueSize(b *testing.B) {
 		keys[i] = fmt.Sprintf("hello.this.is.a.test.key.%d", i)
 	}
 
-	metrics := NewAggMetrics(dnstore, chunkSpan, numChunks, chunkMaxStale, metricMaxStale, ttl, 0, aggSettings)
+	metrics := NewAggMetrics(dnstore, &cache.MockCache{}, chunkSpan, numChunks, chunkMaxStale, metricMaxStale, ttl, 0, aggSettings)
 
 	maxT := uint32(1200)
 	for t := uint32(1); t < maxT; t += 10 {
@@ -270,7 +270,7 @@ func BenchmarkAggMetrics100kSeries2Chunks100kQueueSize(b *testing.B) {
 		keys[i] = fmt.Sprintf("hello.this.is.a.test.key.%d", i)
 	}
 
-	metrics := NewAggMetrics(dnstore, chunkSpan, numChunks, chunkMaxStale, metricMaxStale, ttl, 0, aggSettings)
+	metrics := NewAggMetrics(dnstore, &cache.MockCache{}, chunkSpan, numChunks, chunkMaxStale, metricMaxStale, ttl, 0, aggSettings)
 
 	maxT := uint32(1200)
 	for t := uint32(1); t < maxT; t += 10 {

--- a/mdata/aggmetrics.go
+++ b/mdata/aggmetrics.go
@@ -4,11 +4,13 @@ import (
 	"sync"
 	"time"
 
+	"github.com/raintank/metrictank/mdata/cache"
 	"github.com/raintank/worldping-api/pkg/log"
 )
 
 type AggMetrics struct {
-	store Store
+	store       Store
+	cachePusher cache.CachePusher
 	sync.RWMutex
 	Metrics        map[string]*AggMetric
 	chunkSpan      uint32
@@ -20,9 +22,10 @@ type AggMetrics struct {
 	gcInterval     time.Duration
 }
 
-func NewAggMetrics(store Store, chunkSpan, numChunks, chunkMaxStale, metricMaxStale uint32, ttl uint32, gcInterval time.Duration, aggSettings []AggSetting) *AggMetrics {
+func NewAggMetrics(store Store, cachePusher cache.CachePusher, chunkSpan, numChunks, chunkMaxStale, metricMaxStale uint32, ttl uint32, gcInterval time.Duration, aggSettings []AggSetting) *AggMetrics {
 	ms := AggMetrics{
 		store:          store,
+		cachePusher:    cachePusher,
 		Metrics:        make(map[string]*AggMetric),
 		chunkSpan:      chunkSpan,
 		numChunks:      numChunks,
@@ -88,7 +91,7 @@ func (ms *AggMetrics) GetOrCreate(key string) Metric {
 	ms.Lock()
 	m, ok := ms.Metrics[key]
 	if !ok {
-		m = NewAggMetric(ms.store, key, ms.chunkSpan, ms.numChunks, ms.ttl, ms.aggSettings...)
+		m = NewAggMetric(ms.store, ms.cachePusher, key, ms.chunkSpan, ms.numChunks, ms.ttl, ms.aggSettings...)
 		ms.Metrics[key] = m
 		metricsActive.Set(len(ms.Metrics))
 	}

--- a/mdata/aggregator.go
+++ b/mdata/aggregator.go
@@ -1,6 +1,9 @@
 package mdata
 
-import "fmt"
+import (
+	"fmt"
+	"github.com/raintank/metrictank/mdata/cache"
+)
 
 type AggSetting struct {
 	Span      uint32 // in seconds, controls how many input points go into an aggregated point.
@@ -49,15 +52,15 @@ type Aggregator struct {
 	cntMetric       *AggMetric
 }
 
-func NewAggregator(store Store, key string, aggSpan, aggChunkSpan, aggNumChunks uint32, ttl uint32) *Aggregator {
+func NewAggregator(store Store, cachePusher cache.CachePusher, key string, aggSpan, aggChunkSpan, aggNumChunks uint32, ttl uint32) *Aggregator {
 	return &Aggregator{
 		key:       key,
 		span:      aggSpan,
 		agg:       NewAggregation(),
-		minMetric: NewAggMetric(store, fmt.Sprintf("%s_min_%d", key, aggSpan), aggChunkSpan, aggNumChunks, ttl),
-		maxMetric: NewAggMetric(store, fmt.Sprintf("%s_max_%d", key, aggSpan), aggChunkSpan, aggNumChunks, ttl),
-		sumMetric: NewAggMetric(store, fmt.Sprintf("%s_sum_%d", key, aggSpan), aggChunkSpan, aggNumChunks, ttl),
-		cntMetric: NewAggMetric(store, fmt.Sprintf("%s_cnt_%d", key, aggSpan), aggChunkSpan, aggNumChunks, ttl),
+		minMetric: NewAggMetric(store, cachePusher, fmt.Sprintf("%s_min_%d", key, aggSpan), aggChunkSpan, aggNumChunks, ttl),
+		maxMetric: NewAggMetric(store, cachePusher, fmt.Sprintf("%s_max_%d", key, aggSpan), aggChunkSpan, aggNumChunks, ttl),
+		sumMetric: NewAggMetric(store, cachePusher, fmt.Sprintf("%s_sum_%d", key, aggSpan), aggChunkSpan, aggNumChunks, ttl),
+		cntMetric: NewAggMetric(store, cachePusher, fmt.Sprintf("%s_cnt_%d", key, aggSpan), aggChunkSpan, aggNumChunks, ttl),
 	}
 }
 func (agg *Aggregator) flush() {

--- a/mdata/aggregator_test.go
+++ b/mdata/aggregator_test.go
@@ -2,6 +2,7 @@ package mdata
 
 import (
 	"github.com/raintank/metrictank/cluster"
+	"github.com/raintank/metrictank/mdata/cache"
 	"gopkg.in/raintank/schema.v1"
 	"testing"
 	"time"
@@ -62,13 +63,13 @@ func TestAggregator(t *testing.T) {
 		}
 		cluster.Manager.SetPrimary(false)
 	}
-	agg := NewAggregator(dnstore, "test", 60, 120, 10, 86400)
+	agg := NewAggregator(dnstore, &cache.MockCache{}, "test", 60, 120, 10, 86400)
 	agg.Add(100, 123.4)
 	agg.Add(110, 5)
 	expected := []schema.Point{}
 	compare("simple-min-unfinished", agg.minMetric, expected)
 
-	agg = NewAggregator(dnstore, "test", 60, 120, 10, 86400)
+	agg = NewAggregator(dnstore, &cache.MockCache{}, "test", 60, 120, 10, 86400)
 	agg.Add(100, 123.4)
 	agg.Add(110, 5)
 	agg.Add(130, 130)
@@ -77,7 +78,7 @@ func TestAggregator(t *testing.T) {
 	}
 	compare("simple-min-one-block", agg.minMetric, expected)
 
-	agg = NewAggregator(dnstore, "test", 60, 120, 10, 86400)
+	agg = NewAggregator(dnstore, &cache.MockCache{}, "test", 60, 120, 10, 86400)
 	agg.Add(100, 123.4)
 	agg.Add(110, 5)
 	agg.Add(120, 4)
@@ -86,7 +87,7 @@ func TestAggregator(t *testing.T) {
 	}
 	compare("simple-min-one-block-done-cause-last-point-just-right", agg.minMetric, expected)
 
-	agg = NewAggregator(dnstore, "test", 60, 120, 10, 86400)
+	agg = NewAggregator(dnstore, &cache.MockCache{}, "test", 60, 120, 10, 86400)
 	agg.Add(100, 123.4)
 	agg.Add(110, 5)
 	agg.Add(150, 1.123)
@@ -97,7 +98,7 @@ func TestAggregator(t *testing.T) {
 	}
 	compare("simple-min-two-blocks-done-cause-last-point-just-right", agg.minMetric, expected)
 
-	agg = NewAggregator(dnstore, "test", 60, 120, 10, 86400)
+	agg = NewAggregator(dnstore, &cache.MockCache{}, "test", 60, 120, 10, 86400)
 	agg.Add(100, 123.4)
 	agg.Add(110, 5)
 	agg.Add(190, 2451.123)

--- a/mdata/cache/accnt/stats.go
+++ b/mdata/cache/accnt/stats.go
@@ -22,6 +22,9 @@ var (
 	// metric cache.ops.chunk.hit is how many chunks were hit
 	CacheChunkHit = stats.NewCounter32("cache.ops.chunk.hit")
 
+	// metric cache.ops.chunk.push-hot is how many chunks have been pushed into the cache because their metric is hot
+	CacheChunkPushHot = stats.NewCounter32("cache.ops.chunk.push-hot")
+
 	// metric cache.ops.chunk.add is how many chunks were added to the cache
 	cacheChunkAdd = stats.NewCounter32("cache.ops.chunk.add")
 

--- a/mdata/cache/cache_mock.go
+++ b/mdata/cache/cache_mock.go
@@ -1,0 +1,43 @@
+package cache
+
+import (
+	"github.com/raintank/metrictank/mdata/chunk"
+	"sync"
+)
+
+type MockCache struct {
+	sync.Mutex
+	AddCount        int
+	CacheIfHotCount int
+	CacheIfHotCb    func()
+	StopCount       int
+	SearchCount     int
+}
+
+func (mc *MockCache) Add(m string, t uint32, i chunk.IterGen) {
+	mc.Lock()
+	defer mc.Unlock()
+	mc.AddCount++
+}
+
+func (mc *MockCache) CacheIfHot(m string, t uint32, i chunk.IterGen) {
+	mc.Lock()
+	defer mc.Unlock()
+	mc.CacheIfHotCount++
+	if mc.CacheIfHotCb != nil {
+		mc.CacheIfHotCb()
+	}
+}
+
+func (mc *MockCache) Stop() {
+	mc.Lock()
+	defer mc.Unlock()
+	mc.StopCount++
+}
+
+func (mc *MockCache) Search(m string, f uint32, u uint32) *CCSearchResult {
+	mc.Lock()
+	defer mc.Unlock()
+	mc.SearchCount++
+	return nil
+}

--- a/mdata/cache/ccache_metric.go
+++ b/mdata/cache/ccache_metric.go
@@ -143,6 +143,14 @@ func (mc *CCacheMetric) nextTs(ts uint32) uint32 {
 	}
 }
 
+// returns the last Ts of this metric cache
+// since ranges are exclusive at the end this is actually the first Ts that is not cached
+func (mc *CCacheMetric) lastTs() uint32 {
+	mc.RLock()
+	defer mc.RUnlock()
+	return mc.nextTs(mc.keys[len(mc.keys)-1])
+}
+
 // seekAsc finds the t0 of the chunk that contains ts, by searching from old to recent
 // if not found or can't be sure returns 0, false
 // assumes we already have at least a read lock

--- a/mdata/cache/if.go
+++ b/mdata/cache/if.go
@@ -6,8 +6,13 @@ import (
 
 type Cache interface {
 	Add(string, uint32, chunk.IterGen)
+	CacheIfHot(string, uint32, chunk.IterGen)
 	Stop()
 	Search(string, uint32, uint32) *CCSearchResult
+}
+
+type CachePusher interface {
+	CacheIfHot(string, uint32, chunk.IterGen)
 }
 
 type CCSearchResult struct {

--- a/mdata/store_devnull.go
+++ b/mdata/store_devnull.go
@@ -3,6 +3,7 @@ package mdata
 import "github.com/raintank/metrictank/mdata/chunk"
 
 type devnullStore struct {
+	AddCount uint32
 }
 
 func NewDevnullStore() *devnullStore {
@@ -11,6 +12,11 @@ func NewDevnullStore() *devnullStore {
 }
 
 func (c *devnullStore) Add(cwr *ChunkWriteRequest) {
+	c.AddCount++
+}
+
+func (c *devnullStore) Reset() {
+	c.AddCount = 0
 }
 
 func (c *devnullStore) Search(key string, start, end uint32) ([]chunk.IterGen, error) {

--- a/metrictank.go
+++ b/metrictank.go
@@ -307,9 +307,14 @@ func main() {
 	}
 
 	/***********************************
+		Initialize the Chunk Cache
+	***********************************/
+	ccache := cache.NewCCache()
+
+	/***********************************
 		Initialize our MemoryStore
 	***********************************/
-	metrics = mdata.NewAggMetrics(store, chunkSpan, numChunks, chunkMaxStale, metricMaxStale, ttl, gcInterval, finalSettings)
+	metrics = mdata.NewAggMetrics(store, ccache, chunkSpan, numChunks, chunkMaxStale, metricMaxStale, ttl, gcInterval, finalSettings)
 
 	/***********************************
 		Initialize our Inputs
@@ -337,7 +342,6 @@ func main() {
 	/***********************************
 		Initialize our MetricIdx
 	***********************************/
-	ccache := cache.NewCCache()
 	pre := time.Now()
 
 	if memory.Enabled {


### PR DESCRIPTION
- When `AggMetric` completes a chunk it will now get passed into a callback that refers to `Cache.CacheIfHot`. This happens in any case, no matter if the node is cluster primary or not.
- The chunk cache gets a new export method `Cache.CacheIfHot` which takes an `IterGen` that should be cached only if it's metric is hot. In this context "hot" means that the previous chunk within that metric is currently cached.
- Unit tests for everything that changed.