### PR TITLE
Make kafka-cluster chunk save messages partition aware.

### DIFF
--- a/docker/docker-cluster/docker-compose.yml
+++ b/docker/docker-cluster/docker-compose.yml
@@ -13,6 +13,7 @@ services:
       WAIT_HOSTS: kafka:9092,cassandra:9042
       WAIT_TIMEOUT: 30
       MT_KAFKA_MDM_IN_PARTITIONS: 0,1,2,3
+      MT_KAFKA_CLUSTER_PARTITIONS: 0,1,2,3
       MT_INSTANCE: metrictank0
       MT_LOG_LEVEL: 2
       MT_CLUSTER_MODE: multi
@@ -33,6 +34,7 @@ services:
       WAIT_HOSTS: kafka:9092,cassandra:9042,metrictank0:6060
       WAIT_TIMEOUT: 30
       MT_KAFKA_MDM_IN_PARTITIONS: 0,1,2,3
+      MT_KAFKA_CLUSTER_PARTITIONS: 0,1,2,3
       MT_INSTANCE: metrictank1
       MT_LOG_LEVEL: 2
       MT_CLUSTER_MODE: multi
@@ -54,6 +56,7 @@ services:
       WAIT_HOSTS: kafka:9092,cassandra:9042,metrictank0:6060
       WAIT_TIMEOUT: 30
       MT_KAFKA_MDM_IN_PARTITIONS: 4,5,6,7
+      MT_KAFKA_CLUSTER_PARTITIONS: 4,5,6,7
       MT_INSTANCE: metrictank2
       MT_LOG_LEVEL: 2
       MT_CLUSTER_MODE: multi
@@ -76,6 +79,7 @@ services:
       WAIT_HOSTS: kafka:9092,cassandra:9042,metrictank0:6060
       WAIT_TIMEOUT: 30
       MT_KAFKA_MDM_IN_PARTITIONS: 4,5,6,7
+      MT_KAFKA_CLUSTER_PARTITIONS: 4,5,6,7
       MT_INSTANCE: metrictank3
       MT_LOG_LEVEL: 2
       MT_CLUSTER_MODE: multi

--- a/docker/docker-cluster/metrictank.ini
+++ b/docker/docker-cluster/metrictank.ini
@@ -184,6 +184,8 @@ enabled = true
 brokers = kafka:9092
 # kafka topic (only one)
 topic = metricpersist
+# method used for paritioning metrics. This should match the settings of tsdb-gw. One of byOrg|bySeries
+partition-scheme = bySeries
 # offset to start consuming from. Can be one of newest, oldest,last or a time duration
 offset = last
 # save interval for offsets

--- a/docker/docker-dev-custom-cfg-kafka/metrictank.ini
+++ b/docker/docker-dev-custom-cfg-kafka/metrictank.ini
@@ -200,6 +200,10 @@ enabled = true
 brokers = kafka:9092
 # kafka topic (only one)
 topic = metricpersist
+# kafka partitions to consume. use '*' or a comma separated list of id's. Should match kafka-mdm-in's partitions.
+partitions = *
+# method used for paritioning metrics. This should match the settings of tsdb-gw. One of byOrg|bySeries
+partition-scheme = bySeries
 # offset to start consuming from. Can be one of newest, oldest,last or a time duration
 offset = last
 # save interval for offsets

--- a/docs/config.md
+++ b/docs/config.md
@@ -237,6 +237,10 @@ enabled = false
 brokers = kafka:9092
 # kafka topic (only one)
 topic = metricpersist
+# kafka partitions to consume. use '*' or a comma separated list of id's. Should match kafka-mdm-in's partitions.
+partitions = *
+# method used for paritioning metrics. This should match the settings of tsdb-gw. One of byOrg|bySeries
+partition-scheme = bySeries
 # offset to start consuming from. Can be one of newest, oldest,last or a time duration
 offset = last
 # save interval for offsets

--- a/kafka/partitions.go
+++ b/kafka/partitions.go
@@ -1,0 +1,45 @@
+package kafka
+
+import (
+	"fmt"
+
+	"github.com/Shopify/sarama"
+)
+
+// returns elements that are in a but not in b
+func DiffPartitions(a []int32, b []int32) []int32 {
+	var diff []int32
+Iter:
+	for _, eA := range a {
+		for _, eB := range b {
+			if eA == eB {
+				continue Iter
+			}
+		}
+		diff = append(diff, eA)
+	}
+	return diff
+}
+
+func GetPartitions(client sarama.Client, topics []string) ([]int32, error) {
+	partitionCount := 0
+	partitions := make([]int32, 0)
+    var err error
+	for i, topic := range topics {
+		partitions, err = client.Partitions(topic)
+		if err != nil {
+			return nil, fmt.Errorf("Failed to get partitions for topic %s. %s", topic, err)
+		}
+		if len(partitions) == 0 {
+			return nil, fmt.Errorf("No partitions returned for topic %s", topic)
+		}
+		if i > 0 {
+			if len(partitions) != partitionCount {
+				return nil, fmt.Errorf("Configured topics have different partition counts, this is not supported")
+			}
+			continue
+		}
+		partitionCount = len(partitions)
+	}
+	return partitions, nil
+}

--- a/mdata/notifierKafka/cfg.go
+++ b/mdata/notifierKafka/cfg.go
@@ -3,10 +3,13 @@ package notifierKafka
 import (
 	"flag"
 	"log"
+	"strconv"
 	"strings"
 	"time"
 
 	"github.com/Shopify/sarama"
+	"github.com/raintank/metrictank/cluster"
+	"github.com/raintank/metrictank/kafka"
 	"github.com/raintank/metrictank/stats"
 	"github.com/rakyll/globalconf"
 )
@@ -20,15 +23,24 @@ var dataDir string
 var config *sarama.Config
 var offsetDuration time.Duration
 var offsetCommitInterval time.Duration
+var partitionStr string
+var partitions []int32
+var partitioner *cluster.KafkaPartitioner
+var partitionScheme string
 
-var messagesPublished *stats.Counter32
-var messagesSize *stats.Meter32
+// metric cluster.notifier.kafka.messages-published is a counter of messages published to the kafka cluster notifier
+var messagesPublished = stats.NewCounter32("cluster.notifier.kafka.messages-published")
 
-func ConfigSetup() {
+// metric cluster.notifier.kafka.message_size is the sizes seen of messages through the kafka cluster notifier
+var messagesSize = stats.NewMeter32("cluster.notifier.kafka.message_size", false)
+
+func init() {
 	fs := flag.NewFlagSet("kafka-cluster", flag.ExitOnError)
 	fs.BoolVar(&Enabled, "enabled", false, "")
 	fs.StringVar(&brokerStr, "brokers", "kafka:9092", "tcp address for kafka (may be given multiple times as comma separated list)")
 	fs.StringVar(&topic, "topic", "metricpersist", "kafka topic")
+	fs.StringVar(&partitionStr, "partitions", "*", "kafka partitions to consume. use '*' or a comma separated list of id's. This should match the partitions used for kafka-mdm-in")
+	fs.StringVar(&partitionScheme, "partition-scheme", "bySeries", "method used for paritioning metrics. (byOrg|bySeries)")
 	fs.StringVar(&offsetStr, "offset", "last", "Set the offset to start consuming from. Can be one of newest, oldest,last or a time duration")
 	fs.StringVar(&dataDir, "data-dir", "", "Directory to store partition offsets index")
 	fs.DurationVar(&offsetCommitInterval, "offset-commit-interval", time.Second*5, "Interval at which offsets should be saved.")
@@ -57,9 +69,45 @@ func ConfigProcess(instance string) {
 	config.Version = sarama.V0_10_0_0
 	config.Producer.RequiredAcks = sarama.WaitForAll // Wait for all in-sync replicas to ack the message
 	config.Producer.Retry.Max = 10                   // Retry up to 10 times to produce the message
-	config.Producer.Compression = sarama.CompressionNone
+	config.Producer.Compression = sarama.CompressionSnappy
+	config.Producer.Return.Successes = true
 	err = config.Validate()
 	if err != nil {
 		log.Fatal(2, "kafka-cluster invalid consumer config: %s", err)
+	}
+
+	partitioner, err = cluster.NewKafkaPartitioner(partitionScheme)
+	if err != nil {
+		log.Fatal(4, "kafka-cluster: failed to initialize partitioner. %s", err)
+	}
+
+	if partitionStr != "*" {
+		parts := strings.Split(partitionStr, ",")
+		for _, part := range parts {
+			i, err := strconv.Atoi(part)
+			if err != nil {
+				log.Fatal(4, "kafka-cluster: could not parse partition %q. partitions must be '*' or a comma separated list of id's", part)
+			}
+			partitions = append(partitions, int32(i))
+		}
+	}
+	// validate our partitions
+	client, err := sarama.NewClient(brokers, config)
+	if err != nil {
+		log.Fatal(4, "kafka-cluster failed to create client. %s", err)
+	}
+	defer client.Close()
+
+	availParts, err := kafka.GetPartitions(client, []string{topic})
+	if err != nil {
+		log.Fatal(4, "kafka-cluster: %s", err.Error())
+	}
+	if partitionStr == "*" {
+		partitions = availParts
+	} else {
+		missing := kafka.DiffPartitions(partitions, availParts)
+		if len(missing) > 0 {
+			log.Fatal(4, "kafka-cluster: configured partitions not in list of available partitions. missing %v", missing)
+		}
 	}
 }

--- a/metrictank-sample.ini
+++ b/metrictank-sample.ini
@@ -204,6 +204,10 @@ enabled = false
 brokers = kafka:9092
 # kafka topic (only one)
 topic = metricpersist
+# kafka partitions to consume. use '*' or a comma separated list of id's. Should match kafka-mdm-in's partitions.
+partitions = *
+# method used for paritioning metrics. This should match the settings of tsdb-gw. One of byOrg|bySeries
+partition-scheme = bySeries
 # offset to start consuming from. Can be one of newest, oldest,last or a time duration
 offset = last
 # save interval for offsets

--- a/metrictank.go
+++ b/metrictank.go
@@ -137,7 +137,6 @@ func main() {
 
 	// load config for cluster handlers
 	notifierNsq.ConfigSetup()
-	notifierKafka.ConfigSetup()
 
 	// load config for metricIndexers
 	memory.ConfigSetup()
@@ -331,20 +330,6 @@ func main() {
 	}
 
 	/***********************************
-		Initialize MetricPerrist notifiers
-	***********************************/
-	handlers := make([]mdata.NotifierHandler, 0)
-	if notifierKafka.Enabled {
-		handlers = append(handlers, notifierKafka.New(*instance, metrics))
-	}
-
-	if notifierNsq.Enabled {
-		handlers = append(handlers, notifierNsq.New(*instance, metrics))
-	}
-
-	mdata.InitPersistNotifier(handlers...)
-
-	/***********************************
 	    Start the ClusterManager
 	***********************************/
 	cluster.Start()
@@ -400,6 +385,20 @@ func main() {
 		log.Fatal(4, "failed to initialize metricIndex: %s", err)
 	}
 	log.Info("metricIndex initialized in %s. starting data consumption", time.Now().Sub(pre))
+
+	/***********************************
+		Initialize MetricPerrist notifiers
+	***********************************/
+	handlers := make([]mdata.NotifierHandler, 0)
+	if notifierKafka.Enabled {
+		handlers = append(handlers, notifierKafka.New(*instance, metrics, metricIndex))
+	}
+
+	if notifierNsq.Enabled {
+		handlers = append(handlers, notifierNsq.New(*instance, metrics))
+	}
+
+	mdata.InitPersistNotifier(handlers...)
 
 	/***********************************
 		Initialize usage Reporting

--- a/scripts/config/metrictank-docker.ini
+++ b/scripts/config/metrictank-docker.ini
@@ -199,6 +199,10 @@ enabled = false
 brokers = kafka:9092
 # kafka topic (only one)
 topic = metricpersist
+# kafka partitions to consume. use '*' or a comma separated list of id's. Should match kafka-mdm-in's partitions.
+partitions = *
+# method used for paritioning metrics. This should match the settings of tsdb-gw. One of byOrg|bySeries
+partition-scheme = bySeries
 # offset to start consuming from. Can be one of newest, oldest,last or a time duration
 offset = last
 # save interval for offsets

--- a/scripts/config/metrictank-package.ini
+++ b/scripts/config/metrictank-package.ini
@@ -187,6 +187,10 @@ enabled = false
 brokers = localhost:9092
 # kafka topic (only one)
 topic = metricpersist
+# kafka partitions to consume. use '*' or a comma separated list of id's. Should match kafka-mdm-in's partitions.
+partitions = *
+# method used for paritioning metrics. This should match the settings of tsdb-gw. One of byOrg|bySeries
+partition-scheme = bySeries
 # offset to start consuming from. Can be one of newest, oldest,last or a time duration
 offset = last
 # save interval for offsets


### PR DESCRIPTION
- Move partition fetching/validation to shared kafka lib
- Refactor sending MetricPersist messages to set the correct
  PartitionKey.
- Update consumer to only consume from configured partitions

Issue #452