### PR TITLE
reset cache instead of reinstantiating it in tests

### DIFF
--- a/mdata/cache/accnt/flat_accnt.go
+++ b/mdata/cache/accnt/flat_accnt.go
@@ -52,6 +52,7 @@ type FlatAccntMet struct {
 const evnt_hit_chnk uint8 = 4
 const evnt_add_chnk uint8 = 5
 const evnt_stop uint8 = 100
+const evnt_reset uint8 = 101
 
 type FlatAccntEvent struct {
 	t  uint8       // event type
@@ -97,6 +98,10 @@ func (a *FlatAccnt) Stop() {
 	a.act(evnt_stop, nil)
 }
 
+func (a *FlatAccnt) Reset() {
+	a.act(evnt_reset, nil)
+}
+
 func (a *FlatAccnt) act(t uint8, payload interface{}) {
 	event := FlatAccntEvent{
 		t:  t,
@@ -136,6 +141,10 @@ func (a *FlatAccnt) eventLoop() {
 				)
 			case evnt_stop:
 				return
+			case evnt_reset:
+				a.metrics = make(map[string]*FlatAccntMet)
+				a.total = 0
+				a.lru.reset()
 			}
 
 			// evict until we're below the max

--- a/mdata/cache/accnt/if.go
+++ b/mdata/cache/accnt/if.go
@@ -9,6 +9,7 @@ type Accnt interface {
 	AddChunk(string, uint32, uint64)
 	HitChunk(string, uint32)
 	Stop()
+	Reset()
 }
 
 // EvictTarget is the definition of a chunk that should be evicted.

--- a/mdata/cache/accnt/lru.go
+++ b/mdata/cache/accnt/lru.go
@@ -35,3 +35,11 @@ func (l *LRU) pop() interface{} {
 	delete(l.items, e)
 	return e
 }
+
+func (l *LRU) reset() {
+	for {
+		if l.pop() == nil {
+			break
+		}
+	}
+}

--- a/mdata/cache/ccache.go
+++ b/mdata/cache/ccache.go
@@ -73,6 +73,13 @@ func (c *CCache) Add(metric string, prev uint32, itergen chunk.IterGen) {
 	c.accnt.AddChunk(metric, itergen.Ts(), itergen.Size())
 }
 
+func (cc *CCache) Reset() {
+	cc.accnt.Reset()
+	cc.Lock()
+	cc.metricCache = make(map[string]*CCacheMetric)
+	cc.Unlock()
+}
+
 func (c *CCache) Stop() {
 	c.accnt.Stop()
 	c.stop <- nil

--- a/mdata/cache/ccache_test.go
+++ b/mdata/cache/ccache_test.go
@@ -251,11 +251,12 @@ func testSearchDisconnectedStartEnd(t *testing.T, spanaware, ascending bool) {
 	itgen4 := getItgen(t, values, 1030, spanaware)
 	itgen5 := getItgen(t, values, 1040, spanaware)
 	itgen6 := getItgen(t, values, 1050, spanaware)
+	cc = NewCCache()
 
 	for from := uint32(1000); from < 1010; from++ {
 		// the end of ranges is exclusive, so we go up to 1060
 		for until := uint32(1051); until < 1061; until++ {
-			cc = NewCCache()
+			cc.Reset()
 
 			if ascending {
 				cc.Add(metric, 0, *itgen1)
@@ -326,11 +327,12 @@ func testSearchDisconnectedWithGapStartEnd(t *testing.T, spanaware, ascending bo
 	itgen4 := getItgen(t, values, 1040, spanaware)
 	itgen5 := getItgen(t, values, 1050, spanaware)
 	itgen6 := getItgen(t, values, 1060, spanaware)
+	cc = NewCCache()
 
 	for from := uint32(1000); from < 1010; from++ {
 		// the end of ranges is exclusive, so we go up to 1060
 		for until := uint32(1061); until < 1071; until++ {
-			cc = NewCCache()
+			cc.Reset()
 
 			if ascending {
 				cc.Add(metric, 0, *itgen1)


### PR DESCRIPTION
previously some of the cache tests reinstantiated the chunk cache and
it's accounting many times per run. this consumed large amounts of
memory, especially with the `-race` flag, and made circle ci hit the 4G
limit.
this change adds a reset method and uses it in the unit test, which
leads to a drastic reduction in memory usage in the test.