### PR TITLE
set mode by string

### DIFF
--- a/api/cluster.go
+++ b/api/cluster.go
@@ -2,7 +2,9 @@ package api
 
 import (
 	"errors"
+	"fmt"
 	"net/http"
+	"strconv"
 
 	"github.com/raintank/metrictank/api/middleware"
 	"github.com/raintank/metrictank/api/models"
@@ -19,7 +21,15 @@ func (s *Server) getNodeStatus(ctx *middleware.Context) {
 }
 
 func (s *Server) setNodeStatus(ctx *middleware.Context, status models.NodeStatus) {
-	cluster.Manager.SetPrimary(status.Primary)
+	primary, err := strconv.ParseBool(status.Primary)
+	if err != nil {
+		response.Write(ctx, response.NewError(http.StatusBadRequest, fmt.Sprintf(
+			"could not parse status to bool. %s",
+			err.Error())),
+		)
+		return
+	}
+	cluster.Manager.SetPrimary(primary)
 	ctx.PlainText(200, []byte("OK"))
 }
 

--- a/api/models/node.go
+++ b/api/models/node.go
@@ -5,7 +5,7 @@ import (
 )
 
 type NodeStatus struct {
-	Primary bool `json:"primary" form:"primary" binding:"Required"`
+	Primary string `json:"mode" form:"mode" binding:"Required"`
 }
 
 type ClusterStatus struct {


### PR DESCRIPTION
when using a bool to set a node to primary/secondary we run into the
problem that the `0` value of bool is `false` so when specifying
`false` the parsing library errors saying that a required parameter
has not been passed.
now we're taking the value as a string instead and then parse it into
a bool.
    
fixes #431
