### PR TITLE
build with go1.8 rc2

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -6,7 +6,7 @@ machine:
   environment:
     GOPATH: "/home/ubuntu/.go_workspace"
     IMPORTPATH: "/home/ubuntu/.go_workspace/src/github.com/raintank/metrictank"
-    GODIST: "go1.7.3.linux-amd64.tar.gz"
+    GODIST: "go1.8rc2.linux-amd64.tar.gz"
   post:
     - mkdir -p download
     - test -e download/$GODIST || curl -o download/$GODIST https://storage.googleapis.com/golang/$GODIST


### PR DESCRIPTION
why?
1) go team asks feedback *BEFORE* stable release, so they can make
   changes if problems are discovered, instead of waiting to next release
   cycle
2) for us too, it's in our advantage to test it now so we can report
   feedback should we run into showstoppers.
   especially now that we're testing the new stack for a while and not
   yet rolling the MT out to current prod deployments.