### PR TITLE
mt-update-ttl

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,4 +3,5 @@
 build/
 /metrictank
 /cmd/mt-split-metrics-by-ttl/mt-split-metrics-by-ttl
+/cmd/mt-update-ttl/mt-update-ttl
 /cmd/mt-store-cat/mt-store-cat

--- a/cmd/mt-index-migrate-050-to-054/main.go
+++ b/cmd/mt-index-migrate-050-to-054/main.go
@@ -26,7 +26,7 @@ var (
 
 func main() {
 	flag.Usage = func() {
-		fmt.Fprintln(os.Stderr, "mt-index-migrate-050-to054")
+		fmt.Fprintln(os.Stderr, "mt-index-migrate-050-to-054")
 		fmt.Fprintln(os.Stderr)
 		fmt.Fprintln(os.Stderr, "Converts a metrictank index to the new 0.5.4 (and beyond) format, using cassandra instead of elasticsearch")
 		fmt.Fprintln(os.Stderr, "differences:")

--- a/cmd/mt-update-ttl/main.go
+++ b/cmd/mt-update-ttl/main.go
@@ -1,0 +1,167 @@
+package main
+
+import (
+	"flag"
+	"fmt"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/gocql/gocql"
+	hostpool "github.com/hailocab/go-hostpool"
+	"github.com/raintank/dur"
+)
+
+var (
+	cassandraAddrs               = flag.String("cassandra-addrs", "localhost", "cassandra host (may be given multiple times as comma-separated list)")
+	cassandraKeyspace            = flag.String("cassandra-keyspace", "metrictank", "cassandra keyspace to use for storing the metric data table")
+	cassandraConsistency         = flag.String("cassandra-consistency", "one", "write consistency (any|one|two|three|quorum|all|local_quorum|each_quorum|local_one")
+	cassandraHostSelectionPolicy = flag.String("cassandra-host-selection-policy", "roundrobin", "")
+	cassandraTimeout             = flag.Int("cassandra-timeout", 1000, "cassandra timeout in milliseconds")
+	cassandraConcurrency         = flag.Int("cassandra-concurrency", 20, "max number of concurrent reads to cassandra.")
+	cassandraRetries             = flag.Int("cassandra-retries", 0, "how many times to retry a query before failing it")
+	cqlProtocolVersion           = flag.Int("cql-protocol-version", 4, "cql protocol version to use")
+
+	cassandraSSL              = flag.Bool("cassandra-ssl", false, "enable SSL connection to cassandra")
+	cassandraCaPath           = flag.String("cassandra-ca-path", "/etc/raintank/ca.pem", "cassandra CA certificate path when using SSL")
+	cassandraHostVerification = flag.Bool("cassandra-host-verification", true, "host (hostname and server cert) verification when using SSL")
+
+	cassandraAuth     = flag.Bool("cassandra-auth", false, "enable cassandra authentication")
+	cassandraUsername = flag.String("cassandra-username", "cassandra", "username for authentication")
+	cassandraPassword = flag.String("cassandra-password", "cassandra", "password for authentication")
+
+	verbose = flag.Bool("verbose", false, "show every record being processed")
+)
+
+func main() {
+	flag.Usage = func() {
+		fmt.Fprintln(os.Stderr, "mt-update-ttl [flags] ttl table-in [table-out]")
+		fmt.Fprintln(os.Stderr)
+		fmt.Fprintln(os.Stderr, "Adjusts the data in Cassandra to use a new TTL value. The TTL is applied counting from the timestamp of the data")
+		fmt.Fprintln(os.Stderr, "If table-out not specified or same as table-in, will update in place. Otherwise will not touch input table and store results in table-out")
+		fmt.Fprintln(os.Stderr, "In that case, it is up to you to assure table-out exists before running this tool")
+		fmt.Fprintln(os.Stderr, "Not supported yet: for the per-ttl tables as of 0.7, automatically putting data in the right table")
+		fmt.Println("Flags:")
+		flag.PrintDefaults()
+		os.Exit(-1)
+	}
+	flag.Parse()
+
+	if flag.NArg() < 2 {
+		flag.Usage()
+	}
+
+	ttl := int(dur.MustParseUNsec("ttl", flag.Arg(0)))
+	tableIn, tableOut := flag.Arg(1), flag.Arg(1)
+	if flag.NArg() == 3 {
+		tableOut = flag.Arg(2)
+	}
+
+	session, err := NewCassandraStore(*cassandraAddrs, *cassandraKeyspace, *cassandraConsistency, *cassandraCaPath, *cassandraUsername, *cassandraPassword, *cassandraHostSelectionPolicy, *cassandraTimeout, *cassandraConcurrency, *cassandraRetries, *cqlProtocolVersion, *cassandraSSL, *cassandraAuth, *cassandraHostVerification)
+
+	if err != nil {
+		panic(fmt.Sprintf("Failed to instantiate cassandra: %s", err))
+	}
+
+	update(session, ttl, tableIn, tableOut)
+}
+
+func NewCassandraStore(addrs, keyspace, consistency, CaPath, Username, Password, hostSelectionPolicy string, timeout, concurrency, retries, protoVer int, ssl, auth, hostVerification bool) (*gocql.Session, error) {
+
+	cluster := gocql.NewCluster(strings.Split(addrs, ",")...)
+	if ssl {
+		cluster.SslOpts = &gocql.SslOptions{
+			CaPath:                 CaPath,
+			EnableHostVerification: hostVerification,
+		}
+	}
+	if auth {
+		cluster.Authenticator = gocql.PasswordAuthenticator{
+			Username: Username,
+			Password: Password,
+		}
+	}
+	cluster.Consistency = gocql.ParseConsistency(consistency)
+	cluster.Timeout = time.Duration(timeout) * time.Millisecond
+	cluster.NumConns = concurrency
+	cluster.ProtoVersion = protoVer
+	cluster.Keyspace = keyspace
+	cluster.RetryPolicy = &gocql.SimpleRetryPolicy{NumRetries: retries}
+
+	switch hostSelectionPolicy {
+	case "roundrobin":
+		cluster.PoolConfig.HostSelectionPolicy = gocql.RoundRobinHostPolicy()
+	case "hostpool-simple":
+		cluster.PoolConfig.HostSelectionPolicy = gocql.HostPoolHostPolicy(hostpool.New(nil))
+	case "hostpool-epsilon-greedy":
+		cluster.PoolConfig.HostSelectionPolicy = gocql.HostPoolHostPolicy(
+			hostpool.NewEpsilonGreedy(nil, 0, &hostpool.LinearEpsilonValueCalculator{}),
+		)
+	case "tokenaware,roundrobin":
+		cluster.PoolConfig.HostSelectionPolicy = gocql.TokenAwareHostPolicy(
+			gocql.RoundRobinHostPolicy(),
+		)
+	case "tokenaware,hostpool-simple":
+		cluster.PoolConfig.HostSelectionPolicy = gocql.TokenAwareHostPolicy(
+			gocql.HostPoolHostPolicy(hostpool.New(nil)),
+		)
+	case "tokenaware,hostpool-epsilon-greedy":
+		cluster.PoolConfig.HostSelectionPolicy = gocql.TokenAwareHostPolicy(
+			gocql.HostPoolHostPolicy(
+				hostpool.NewEpsilonGreedy(nil, 0, &hostpool.LinearEpsilonValueCalculator{}),
+			),
+		)
+	default:
+		return nil, fmt.Errorf("unknown HostSelectionPolicy '%q'", hostSelectionPolicy)
+	}
+
+	return cluster.CreateSession()
+}
+
+func getTTL(now, ts, ttl int) int {
+	newTTL := ttl - (now - ts)
+
+	// setting a TTL of 0 or negative, is equivalent to no TTL = keep forever.
+	// we wouldn't want that to happen by accident.
+	// this can happen when setting or shortening a TTL for already very old data.
+	if newTTL < 1 {
+		return 1
+	}
+	return newTTL
+}
+
+func update(session *gocql.Session, ttl int, tableIn, tableOut string) {
+	var key string
+	var ts int
+	var data []byte
+	var query string
+	iter := session.Query(fmt.Sprintf("SELECT key, ts, data FROM %s", tableIn)).Iter()
+	rownum := 0
+	for iter.Scan(&key, &ts, &data) {
+		newTTL := getTTL(int(time.Now().Unix()), ts, ttl)
+		if tableIn == tableOut {
+			query = fmt.Sprintf("UPDATE %s USING TTL %d SET data = ? WHERE key = ? AND ts = ?", tableIn, newTTL)
+		} else {
+			query = fmt.Sprintf("INSERT INTO %s (data, key, ts) values(?,?,?) USING TTL %d", tableOut, newTTL)
+		}
+		if *verbose {
+			fmt.Printf("processing rownum=%d table=%q key=%q ts=%d data='%x'\n", rownum, tableIn, key, ts, data)
+			fmt.Println("Query:", query)
+
+		}
+
+		err := session.Query(query, data, key, ts).Exec()
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "ERROR: failed updating %s %s %d: %q", tableOut, key, ts, err)
+			iter.Close()
+			os.Exit(2)
+		}
+		rownum++
+	}
+	err := iter.Close()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "ERROR: failed querying %s: %q. processed %d rows", tableIn, err, rownum)
+		os.Exit(2)
+	}
+	fmt.Println("processed", rownum, "rows")
+}

--- a/cmd/mt-update-ttl/main_test.go
+++ b/cmd/mt-update-ttl/main_test.go
@@ -1,0 +1,26 @@
+package main
+
+import "testing"
+
+type testCase struct {
+	now    int
+	ts     int
+	ttl    int // amount of seconds to retain in general
+	newTTL int // amount of seconds to retain *as of now*
+}
+
+func TestGetTTL(t *testing.T) {
+	cases := []testCase{
+		{120, 100, 10, 1}, // should have expired 10s ago. set ttl to 1 to expire as soon as we can.
+		{120, 110, 10, 1}, // time to expire it right now. set ttl to 1 to expire as soon as we can.
+		{120, 115, 10, 5}, // data is 5s old, so expire 5s from now
+		{120, 120, 10, 10},
+		{120, 130, 10, 20}, // future data with a TS > now should expire 10s after its TS, aka 20s after now
+	}
+	for i, c := range cases {
+		newTTL := getTTL(c.now, c.ts, c.ttl)
+		if newTTL != c.newTTL {
+			t.Errorf("case %d: expected %d got %d", i, c.newTTL, newTTL)
+		}
+	}
+}

--- a/docs/tools.md
+++ b/docs/tools.md
@@ -90,7 +90,7 @@ mt-index-cat -from 60min cass -hosts cassandra:9042 list
 ## mt-index-migrate-050-to-054
 
 ```
-mt-index-migrate-050-to054
+mt-index-migrate-050-to-054
 
 Converts a metrictank index to the new 0.5.4 (and beyond) format, using cassandra instead of elasticsearch
 differences:
@@ -153,7 +153,7 @@ Flags:
   -config string
     	configuration file path (default "/etc/raintank/metrictank.ini")
   -format string
-    	template to render the data with (default "{{.Part .OrgId .Id .Name .Metric .Interval .Value .Time .Unit .Mtype .Tags}}")
+    	template to render the data with (default "{{.Part}} {{.OrgId}} {{.Id}} {{.Name}} {{.Metric}} {{.Interval}} {{.Value}} {{.Time}} {{.Unit}} {{.Mtype}} {{.Tags}}")
 ```
 
 
@@ -187,6 +187,49 @@ Flags:
 ```
 
 
+## mt-split-metrics-by-ttl
+
+```
+mt-split-metrics-by-ttl [flags] ttl [ttl...]
+
+Creates schema of metric tables split by TTLs and
+assists in migrating the data to new tables.
+Flags:
+  -cassandra-addrs string
+    	cassandra host (may be given multiple times as comma-separated list) (default "localhost")
+  -cassandra-auth
+    	enable cassandra authentication
+  -cassandra-ca-path string
+    	cassandra CA certificate path when using SSL (default "/etc/raintank/ca.pem")
+  -cassandra-consistency string
+    	write consistency (any|one|two|three|quorum|all|local_quorum|each_quorum|local_one (default "one")
+  -cassandra-host-selection-policy string
+    	 (default "roundrobin")
+  -cassandra-host-verification
+    	host (hostname and server cert) verification when using SSL (default true)
+  -cassandra-keyspace string
+    	cassandra keyspace to use for storing the metric data table (default "metrictank")
+  -cassandra-password string
+    	password for authentication (default "cassandra")
+  -cassandra-read-concurrency int
+    	max number of concurrent reads to cassandra. (default 20)
+  -cassandra-read-queue-size int
+    	max number of outstanding reads before blocking. value doesn't matter much (default 100)
+  -cassandra-retries int
+    	how many times to retry a query before failing it
+  -cassandra-ssl
+    	enable SSL connection to cassandra
+  -cassandra-timeout int
+    	cassandra timeout in milliseconds (default 1000)
+  -cassandra-username string
+    	username for authentication (default "cassandra")
+  -cql-protocol-version int
+    	cql protocol version to use (default 4)
+  -window-factor int
+    	the window factor be used when creating the metric table schema (default 20)
+```
+
+
 ## mt-store-cat
 
 ```
@@ -195,7 +238,7 @@ mt-store-cat
 Retrieves timeseries data from the cassandra store. Either raw or with minimal processing
 
 Usage:
-	mt-store-cat [flags] <normal|summary> id <metric-id>
+	mt-store-cat [flags] <normal|summary> id <metric-id> <ttl>
 	mt-store-cat [flags] <normal|summary> query <org-id> <graphite query> (not supported yet)
 Flags:
   -cassandra-addrs string
@@ -240,8 +283,53 @@ Flags:
     	get data until (exclusive) (default "now")
   -version
     	print version string
+  -window-factor int
+    	the window factor be used when creating the metric table schema (default 20)
 Notes:
  * points that are not in the `from <= ts < to` range, are prefixed with `-`. In range has prefix of '>`
+```
+
+
+## mt-update-ttl
+
+```
+mt-update-ttl [flags] ttl table-in [table-out]
+
+Adjusts the data in Cassandra to use a new TTL value. The TTL is applied counting from the timestamp of the data
+If table-out not specified or same as table-in, will update in place. Otherwise will not touch input table and store results in table-out
+In that case, it is up to you to assure table-out exists before running this tool
+Not supported yet: for the per-ttl tables as of 0.7, automatically putting data in the right table
+Flags:
+  -cassandra-addrs string
+    	cassandra host (may be given multiple times as comma-separated list) (default "localhost")
+  -cassandra-auth
+    	enable cassandra authentication
+  -cassandra-ca-path string
+    	cassandra CA certificate path when using SSL (default "/etc/raintank/ca.pem")
+  -cassandra-concurrency int
+    	max number of concurrent reads to cassandra. (default 20)
+  -cassandra-consistency string
+    	write consistency (any|one|two|three|quorum|all|local_quorum|each_quorum|local_one (default "one")
+  -cassandra-host-selection-policy string
+    	 (default "roundrobin")
+  -cassandra-host-verification
+    	host (hostname and server cert) verification when using SSL (default true)
+  -cassandra-keyspace string
+    	cassandra keyspace to use for storing the metric data table (default "metrictank")
+  -cassandra-password string
+    	password for authentication (default "cassandra")
+  -cassandra-retries int
+    	how many times to retry a query before failing it
+  -cassandra-ssl
+    	enable SSL connection to cassandra
+  -cassandra-timeout int
+    	cassandra timeout in milliseconds (default 1000)
+  -cassandra-username string
+    	username for authentication (default "cassandra")
+  -cql-protocol-version int
+    	cql protocol version to use (default 4)
+  -verbose
+    	show every record being processed
 ```
 
 


### PR DESCRIPTION
I've tried both in-place ttl adjustments as well as with a different table-out.

seems to work, by running commands like
```
./mt-update-ttl -verbose 5y metric_512;
./mt-update-ttl -verbose 2y metric_512 metric_512n
```
and queries like
```
select key, ts, data, ttl(data) from metric_512 limit 10;
select key, ts, data, ttl(data) from metric_512n limit 10;
```

show correct TTL values.

I want to do some more testing though. would be nice if i can prove that data did not somehow corrupt. maybe by taking a dump before and after, or something.