### PR TITLE
split off cluster partitioner to separate package

### DIFF
--- a/cmd/mt-index-migrate-06-to-07/main.go
+++ b/cmd/mt-index-migrate-06-to-07/main.go
@@ -8,7 +8,7 @@ import (
 	"time"
 
 	"github.com/gocql/gocql"
-	"github.com/raintank/metrictank/cluster"
+	part "github.com/raintank/metrictank/cluster/partitioner"
 	"github.com/raintank/metrictank/idx/cassandra"
 	"github.com/raintank/worldping-api/pkg/log"
 	"gopkg.in/raintank/schema.v1"
@@ -129,7 +129,7 @@ func getDefs(session *gocql.Session, defsChan chan *schema.MetricDefinition) {
 	log.Info("starting read thread")
 	defer wg.Done()
 	defer close(defsChan)
-	partitioner, err := cluster.NewKafkaPartitioner(*partitionScheme)
+	partitioner, err := part.NewKafka(*partitionScheme)
 	if err != nil {
 		log.Fatal(4, "failed to initialize partitioner. %s", err)
 	}

--- a/cmd/mt-replicator/publish.go
+++ b/cmd/mt-replicator/publish.go
@@ -2,7 +2,7 @@ package main
 
 import (
 	"github.com/Shopify/sarama"
-	"github.com/raintank/metrictank/cluster"
+	part "github.com/raintank/metrictank/cluster/partitioner"
 	"github.com/raintank/worldping-api/pkg/log"
 	"gopkg.in/raintank/schema.v1"
 )
@@ -10,7 +10,7 @@ import (
 type Publisher struct {
 	topic       string
 	producer    sarama.SyncProducer
-	partitioner *cluster.KafkaPartitioner
+	partitioner *part.Kafka
 }
 
 func GetCompression(codec string) sarama.CompressionCodec {
@@ -44,7 +44,7 @@ func NewPublisher(brokers []string, topic string, compression string, partitionS
 	if err != nil {
 		return nil, err
 	}
-	partitioner, err := cluster.NewKafkaPartitioner(partitionScheme)
+	partitioner, err := part.NewKafka(partitionScheme)
 	if err != nil {
 		return nil, err
 	}

--- a/mdata/notifierKafka/cfg.go
+++ b/mdata/notifierKafka/cfg.go
@@ -8,7 +8,7 @@ import (
 	"time"
 
 	"github.com/Shopify/sarama"
-	"github.com/raintank/metrictank/cluster"
+	part "github.com/raintank/metrictank/cluster/partitioner"
 	"github.com/raintank/metrictank/kafka"
 	"github.com/raintank/metrictank/stats"
 	"github.com/raintank/worldping-api/pkg/log"
@@ -26,7 +26,7 @@ var offsetDuration time.Duration
 var offsetCommitInterval time.Duration
 var partitionStr string
 var partitions []int32
-var partitioner *cluster.KafkaPartitioner
+var partitioner *part.Kafka
 var partitionScheme string
 var bootTimeOffsets map[int32]int64
 var backlogProcessTimeout time.Duration
@@ -89,7 +89,7 @@ func ConfigProcess(instance string) {
 		log.Fatal(4, "kafka-cluster: unable to parse backlog-process-timeout. %s", err)
 	}
 
-	partitioner, err = cluster.NewKafkaPartitioner(partitionScheme)
+	partitioner, err = part.NewKafka(partitionScheme)
 	if err != nil {
 		log.Fatal(4, "kafka-cluster: failed to initialize partitioner. %s", err)
 	}


### PR DESCRIPTION
the cluster package is largely the "guts" of the clustering system of
metrictank, which depends on logging and stats packages, memberlist,
etc. Those packages also come with their own dependencies.
The partitioner stuff however is more self contained, and it is
also more commonly imported by other software:
Both tsdb-gw and carbon-relay use the partitioner to send data to kafka,
but use none of the other cluster stuff, so by splitting off the
partitioner we can avoid that they have to pull in a whole bunch of
packages they don't need.

thoughts @woodsaj ?