### PR TITLE
use node priority for routing requests

### DIFF
--- a/cluster/cluster.go
+++ b/cluster/cluster.go
@@ -79,9 +79,18 @@ func Start() {
 	log.Info("CLU Start: joined to %d nodes in cluster", n)
 }
 
+type partitionCandidates struct {
+	priority int
+	nodes    []Node
+}
+
 // return the list of nodes to broadcast requests to
-// Only 1 member per partition is returned. This list includes
-// ThisNode if it is capable of handling queries.
+// If partitions are assinged to nodes in groups
+// (a[0,1], b[0,1], c[2,3], d[2,3] as opposed to a[0,1], b[0,2], c[1,3], d[2,3]),
+// only 1 member per partition is returned.
+// The nodes are selected based on priority, prefering thisNode if it
+// has the lowest prio, otherwise using a random selection from all
+// nodes with the lowest prio.
 func MembersForQuery() []Node {
 	thisNode := Manager.ThisNode()
 	// If we are running in single mode, just return thisNode
@@ -89,10 +98,15 @@ func MembersForQuery() []Node {
 		return []Node{thisNode}
 	}
 
-	membersMap := make(map[int32][]Node)
+	// store the available nodes for each partition, grouped by
+	// priority
+	membersMap := make(map[int32]*partitionCandidates)
 	if thisNode.IsReady() {
 		for _, part := range thisNode.Partitions {
-			membersMap[part] = []Node{thisNode}
+			membersMap[part] = &partitionCandidates{
+				priority: thisNode.Priority,
+				nodes:    []Node{thisNode},
+			}
 		}
 	}
 
@@ -101,7 +115,22 @@ func MembersForQuery() []Node {
 			continue
 		}
 		for _, part := range member.Partitions {
-			membersMap[part] = append(membersMap[part], member)
+			if _, ok := membersMap[part]; !ok {
+				membersMap[part] = &partitionCandidates{
+					priority: member.Priority,
+					nodes:    []Node{member},
+				}
+				continue
+			}
+			if membersMap[part].priority == member.Priority {
+				membersMap[part].nodes = append(membersMap[part].nodes, member)
+			} else if membersMap[part].priority > member.Priority {
+				// this node has higher priority (lower number) then previously seen candidates
+				membersMap[part] = &partitionCandidates{
+					priority: member.Priority,
+					nodes:    []Node{member},
+				}
+			}
 		}
 	}
 
@@ -111,10 +140,8 @@ func MembersForQuery() []Node {
 	// needed to cover all partitions
 
 LOOP:
-	for _, nodes := range membersMap {
-		// always prefer the local node which will be nodes[0]
-		// if it has this partition
-		if nodes[0].Name == thisNode.Name {
+	for _, candidates := range membersMap {
+		if candidates.nodes[0].Name == thisNode.Name {
 			if _, ok := selectedMembers[thisNode.Name]; !ok {
 				selectedMembers[thisNode.Name] = struct{}{}
 				answer = append(answer, thisNode)
@@ -122,14 +149,14 @@ LOOP:
 			continue LOOP
 		}
 
-		for _, n := range nodes {
+		for _, n := range candidates.nodes {
 			if _, ok := selectedMembers[n.Name]; ok {
 				continue LOOP
 			}
 		}
 		// if no nodes have been selected yet then grab a
 		// random node from the set of available nodes
-		selected := nodes[rand.Intn(len(nodes))]
+		selected := candidates.nodes[rand.Intn(len(candidates.nodes))]
 		selectedMembers[selected.Name] = struct{}{}
 		answer = append(answer, selected)
 	}

--- a/cluster/config.go
+++ b/cluster/config.go
@@ -15,6 +15,7 @@ var (
 	primary         bool
 	peersStr        string
 	mode            string
+	maxPrio         int
 	clusterPort     int
 	clusterHost     net.IP
 	clusterBindAddr string
@@ -30,6 +31,7 @@ func ConfigSetup() {
 	clusterCfg.StringVar(&peersStr, "peers", "", "TCP addresses of other nodes, comma separated. use this if you shard your data and want to query other instances")
 	clusterCfg.StringVar(&mode, "mode", "single", "Operating mode of cluster. (single|multi)")
 	clusterCfg.DurationVar(&httpTimeout, "http-timeout", time.Second*60, "How long to wait before aborting http requests to cluster peers and returning a http 503 service unavailable")
+	clusterCfg.IntVar(&maxPrio, "max-priority", 10, "maximum priority before a node should be considered not-ready.")
 	globalconf.Register("cluster", clusterCfg)
 }
 

--- a/cluster/node.go
+++ b/cluster/node.go
@@ -62,6 +62,7 @@ type Node struct {
 	Primary       bool      `json:"primary"`
 	PrimaryChange time.Time `json:"primaryChange"`
 	State         NodeState `json:"state"`
+	Priority      int       `json:"priority"`
 	Started       time.Time `json:"started"`
 	StateChange   time.Time `json:"stateChange"`
 	Partitions    []int32   `json:"partitions"`

--- a/cluster/node.go
+++ b/cluster/node.go
@@ -78,7 +78,7 @@ func (n Node) RemoteURL() string {
 }
 
 func (n Node) IsReady() bool {
-	return n.State == NodeReady
+	return n.State == NodeReady && n.Priority <= maxPrio
 }
 
 func (n Node) IsLocal() bool {

--- a/docker/docker-cluster/metrictank.ini
+++ b/docker/docker-cluster/metrictank.ini
@@ -195,6 +195,8 @@ net-max-open-requests = 100
 [cluster]
 # The primary node writes data to cassandra. There should only be 1 primary node per shardGroup.
 primary-node = true
+# maximum priority before a node should be considered not-ready.
+max-priority = 10
 # the TCP/UDP address to listen on for the gossip protocol.
 bind-addr = 0.0.0.0:7946
 # TCP addresses of other nodes, comma separated. use this if you shard your data and want to query other instances.

--- a/docker/docker-dev-custom-cfg-kafka/metrictank.ini
+++ b/docker/docker-dev-custom-cfg-kafka/metrictank.ini
@@ -195,6 +195,8 @@ net-max-open-requests = 100
 [cluster]
 # The primary node writes data to cassandra. There should only be 1 primary node per shardGroup.
 primary-node = true
+# maximum priority before a node should be considered not-ready.
+max-priority = 10
 # the TCP/UDP address to listen on for the gossip protocol.
 bind-addr = 0.0.0.0:7946
 # TCP addresses of other nodes, comma separated. use this if you shard your data and want to query other instances.

--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -62,6 +62,9 @@ how long a candidate (secondary node) has to wait until it can become a primary
 When the timer becomes 0 it means the in-memory buffer has been able to fully populate so that if you stop a primary
 and it was able to save its complete chunks, this node will be able to take over without dataloss.
 You can upgrade a candidate to primary while the timer is not 0 yet, it just means it may have missing data in the chunks that it will save.
+* `cluster.self.priority`:   
+The priority of the node. A lower number gives higher priority.  When using the kafkamdm input plugin this will be set to the number of seconds
+the node is lagging by.
 * `cluster.self.state.primary`:  
 whether this instance is a primary
 * `cluster.self.state.ready`:  

--- a/input/kafkamdm/kafkamdm.go
+++ b/input/kafkamdm/kafkamdm.go
@@ -27,10 +27,10 @@ var metricsDecodeErr = stats.NewCounter32("input.kafka-mdm.metrics_decode_err")
 
 type KafkaMdm struct {
 	input.Handler
-	consumer sarama.Consumer
-	client   sarama.Client
-
-	wg sync.WaitGroup
+	consumer   sarama.Consumer
+	client     sarama.Client
+	lagMonitor *LagMonitor
+	wg         sync.WaitGroup
 
 	// signal to PartitionConsumers to shutdown
 	stopConsuming chan struct{}
@@ -187,6 +187,7 @@ func New() *KafkaMdm {
 	k := KafkaMdm{
 		consumer:      consumer,
 		client:        client,
+		lagMonitor:    NewLagMonitor(10, partitions),
 		stopConsuming: make(chan struct{}),
 	}
 
@@ -215,6 +216,8 @@ func (k *KafkaMdm) Start(handler input.Handler) {
 			go k.consumePartition(topic, partition, offset)
 		}
 	}
+
+	go k.setClusterPrio()
 }
 
 // this will continually consume from the topic until k.stopConsuming is triggered.
@@ -248,7 +251,6 @@ func (k *KafkaMdm) consumePartition(topic string, partition int32, currentOffset
 	log.Info("kafka-mdm: consuming from %s:%d from offset %d", topic, partition, currentOffset)
 	messages := pc.Messages()
 	ticker := time.NewTicker(offsetCommitInterval)
-
 	for {
 		select {
 		case msg := <-messages:
@@ -273,7 +275,9 @@ func (k *KafkaMdm) consumePartition(topic string, partition int32, currentOffset
 			}
 			partitionOffsetMetric.Set(int(currentOffset))
 			if err == nil {
-				partitionLagMetric.Set(int(offset - currentOffset))
+				lag := int(offset - currentOffset)
+				partitionLagMetric.Set(lag)
+				k.lagMonitor.Store(partition, lag)
 			}
 		case <-k.stopConsuming:
 			pc.Close()
@@ -306,4 +310,16 @@ func (k *KafkaMdm) Stop() {
 	k.wg.Wait()
 	k.client.Close()
 	offsetMgr.Close()
+}
+
+func (k *KafkaMdm) setClusterPrio() {
+	ticker := time.NewTicker(time.Second * 10)
+	for {
+		select {
+		case <-k.stopConsuming:
+			return
+		case <-ticker.C:
+			cluster.Manager.SetPriority(k.lagMonitor.Metric())
+		}
+	}
 }

--- a/input/kafkamdm/lag_monitor.go
+++ b/input/kafkamdm/lag_monitor.go
@@ -2,6 +2,7 @@ package kafkamdm
 
 import (
 	"sync"
+	"time"
 )
 
 type lagLogger struct {
@@ -47,36 +48,96 @@ func (l *lagLogger) Min() int {
 	return min
 }
 
+type rateLogger struct {
+	sync.Mutex
+	lastOffset int64
+	lastTs     time.Time
+	rate       int64
+}
+
+func (o *rateLogger) Store(offset int64, ts time.Time) {
+	o.Lock()
+	defer o.Unlock()
+	if o.lastTs.IsZero() {
+		// first measurement
+		o.lastOffset = offset
+		o.lastTs = ts
+		return
+	}
+	metrics := offset - o.lastOffset
+
+	o.lastOffset = offset
+
+	duration := int64(ts.Sub(o.lastTs) / time.Second)
+	o.lastTs = ts
+	if duration <= 0 {
+		// current ts is > last ts. This would only happen if our clock
+		// suddenly changes, in which case we cant reliably work out how
+		// low it has really been since we last took a measurement.
+		return
+	}
+	rate := metrics / duration
+	if rate < 0 {
+		// this is possible if our offset counter rolls over or is reset.
+		// If it was a rollover we could compute the rate, but it is safer
+		// to just keep using the last computed rate, and wait for the next
+		// measurement to compute a new rate.
+		return
+	}
+	o.rate = rate
+	return
+}
+
+func (o *rateLogger) Rate() int64 {
+	o.Lock()
+	defer o.Unlock()
+	return o.rate
+}
+
+func newRateLogger() *rateLogger {
+	return &rateLogger{}
+}
+
 /*
    LagMonitor is used to determine how upToDate this node is.
    We periodically collect the lag for each partition, keeping the last N
-   measurements in a moving window.  Using those measurements we can then
-   compute a overall score for this node. The score is just the maximum minimum
-   lag of all partitions.
+   measurements in a moving window. We also collect the ingest rate of each
+   partition. Using these measurements we can then compute a overall score
+   for this each parition. The score is just the minimum  lag seen in the last
+   N measurements divided by the ingest rate. So if the ingest rate is 1k/second
+   and the lag is 10000 messages. Then our reported lag is 10, meaning 10seconds.
+   If the rate is 1k/second and the lag is 200 then our lag is reported as 0, meaning
+   the node is less then 1second behind.
 
-   For each partition we get the minimum lag seen in the last N measurements.
-   Using minimum ensures that transient issues dont affect the health score.
-   From each of those per-partition values, we then get the maximum.  This
-   ensures that overall health is based on the worst performing partition.
+   The node's overall lag is then the highest lag of all paritions.
 */
 type LagMonitor struct {
-	lag map[int32]*lagLogger
+	lag  map[int32]*lagLogger
+	rate map[int32]*rateLogger
 }
 
 func NewLagMonitor(size int, partitions []int32) *LagMonitor {
 	m := &LagMonitor{
-		lag: make(map[int32]*lagLogger),
+		lag:  make(map[int32]*lagLogger),
+		rate: make(map[int32]*rateLogger),
 	}
 	for _, p := range partitions {
 		m.lag[p] = newLagLogger(size)
+		m.rate[p] = newRateLogger()
 	}
 	return m
 }
 
 func (l *LagMonitor) Metric() int {
 	max := 0
-	for _, lag := range l.lag {
-		val := lag.Min()
+	for p, lag := range l.lag {
+		rate := l.rate[p]
+		l := lag.Min()
+		r := rate.Rate()
+		if r == 0 {
+			r = 1
+		}
+		val := l / int(r)
 		if val > max {
 			max = val
 		}
@@ -84,6 +145,10 @@ func (l *LagMonitor) Metric() int {
 	return max
 }
 
-func (l *LagMonitor) Store(partition int32, val int) {
+func (l *LagMonitor) StoreLag(partition int32, val int) {
 	l.lag[partition].Store(val)
+}
+
+func (l *LagMonitor) StoreOffset(partition int32, offset int64, ts time.Time) {
+	l.rate[partition].Store(offset, ts)
 }

--- a/input/kafkamdm/lag_monitor.go
+++ b/input/kafkamdm/lag_monitor.go
@@ -65,25 +65,23 @@ func (o *rateLogger) Store(offset int64, ts time.Time) {
 		return
 	}
 	metrics := offset - o.lastOffset
-
 	o.lastOffset = offset
-
 	duration := int64(ts.Sub(o.lastTs) / time.Second)
 	o.lastTs = ts
 	if duration <= 0 {
-		// current ts is > last ts. This would only happen if our clock
+		// current ts is <= last ts. This would only happen if our clock
 		// suddenly changes, in which case we cant reliably work out how
-		// low it has really been since we last took a measurement.
+		// long it has really been since we last took a measurement.
 		return
 	}
-	rate := metrics / duration
-	if rate < 0 {
+	if metrics < 0 {
 		// this is possible if our offset counter rolls over or is reset.
 		// If it was a rollover we could compute the rate, but it is safer
 		// to just keep using the last computed rate, and wait for the next
 		// measurement to compute a new rate.
 		return
 	}
+	rate := metrics / duration
 	o.rate = rate
 	return
 }

--- a/input/kafkamdm/lag_monitor.go
+++ b/input/kafkamdm/lag_monitor.go
@@ -1,0 +1,89 @@
+package kafkamdm
+
+import (
+	"sync"
+)
+
+type lagLogger struct {
+	sync.Mutex
+	pos          int
+	measurements []int
+}
+
+func newLagLogger(size int) *lagLogger {
+	return &lagLogger{
+		pos:          0,
+		measurements: make([]int, 0, size),
+	}
+}
+
+func (l *lagLogger) Store(lag int) {
+	l.Lock()
+	defer l.Unlock()
+	l.pos++
+	if len(l.measurements) < cap(l.measurements) {
+		l.measurements = append(l.measurements, lag)
+		return
+	}
+
+	if l.pos >= cap(l.measurements) {
+		l.pos = 0
+	}
+	l.measurements[l.pos] = lag
+}
+
+func (l *lagLogger) Min() int {
+	l.Lock()
+	defer l.Unlock()
+	min := -1
+	for _, m := range l.measurements {
+		if min < 0 || m < min {
+			min = m
+		}
+	}
+	if min < 0 {
+		min = 0
+	}
+	return min
+}
+
+/*
+   LagMonitor is used to determine how upToDate this node is.
+   We periodically collect the lag for each partition, keeping the last N
+   measurements in a moving window.  Using those measurements we can then
+   compute a overall score for this node. The score is just the maximum minimum
+   lag of all partitions.
+
+   For each partition we get the minimum lag seen in the last N measurements.
+   Using minimum ensures that transient issues dont affect the health score.
+   From each of those per-partition values, we then get the maximum.  This
+   ensures that overall health is based on the worst performing partition.
+*/
+type LagMonitor struct {
+	lag map[int32]*lagLogger
+}
+
+func NewLagMonitor(size int, partitions []int32) *LagMonitor {
+	m := &LagMonitor{
+		lag: make(map[int32]*lagLogger),
+	}
+	for _, p := range partitions {
+		m.lag[p] = newLagLogger(size)
+	}
+	return m
+}
+
+func (l *LagMonitor) Metric() int {
+	max := 0
+	for _, lag := range l.lag {
+		val := lag.Min()
+		if val > max {
+			max = val
+		}
+	}
+	return max
+}
+
+func (l *LagMonitor) Store(partition int32, val int) {
+	l.lag[partition].Store(val)
+}

--- a/input/kafkamdm/lag_monitor_test.go
+++ b/input/kafkamdm/lag_monitor_test.go
@@ -2,6 +2,7 @@ package kafkamdm
 
 import (
 	"testing"
+	"time"
 
 	. "github.com/smartystreets/goconvey/convey"
 )
@@ -27,22 +28,48 @@ func TestLagLogger(t *testing.T) {
 	})
 }
 
+func TestRateLogger(t *testing.T) {
+	logger := newRateLogger()
+	now := time.Now()
+	Convey("with 0 measurements", t, func() {
+		So(logger.Rate(), ShouldEqual, 0)
+	})
+	Convey("after 1st measurements", t, func() {
+		logger.Store(10, now)
+		So(logger.Rate(), ShouldEqual, 0)
+	})
+	Convey("with 2nd measurements", t, func() {
+		logger.Store(15, now.Add(time.Second))
+		So(logger.Rate(), ShouldEqual, 5)
+	})
+	Convey("with old ts", t, func() {
+		logger.Store(25, now)
+		So(logger.Rate(), ShouldEqual, 5)
+	})
+	Convey("with less then 1per second", t, func() {
+		logger.Store(30, now.Add(time.Second*10))
+		So(logger.Rate(), ShouldEqual, 0)
+	})
+}
+
 func TestLagMonitor(t *testing.T) {
 	mon := NewLagMonitor(10, []int32{0, 1, 2, 3})
 	Convey("with 0 measurements", t, func() {
 		So(mon.Metric(), ShouldEqual, 0)
 	})
 	Convey("with lots of measurements", t, func() {
+		now := time.Now()
 		for part := range mon.lag {
 			for i := 0; i < 100; i++ {
-				mon.Store(part, i)
+				mon.StoreLag(part, i)
+				mon.StoreOffset(part, int64(i), now.Add(time.Second*time.Duration(i)))
 			}
 		}
 		So(mon.Metric(), ShouldEqual, 90)
 	})
 	Convey("metric should be worst partition", t, func() {
 		for part := range mon.lag {
-			mon.Store(part, 10+int(part))
+			mon.StoreLag(part, 10+int(part))
 		}
 		So(mon.Metric(), ShouldEqual, 13)
 	})

--- a/input/kafkamdm/lag_monitor_test.go
+++ b/input/kafkamdm/lag_monitor_test.go
@@ -1,0 +1,49 @@
+package kafkamdm
+
+import (
+	"testing"
+
+	. "github.com/smartystreets/goconvey/convey"
+)
+
+func TestLagLogger(t *testing.T) {
+	logger := newLagLogger(5)
+	Convey("with 0 measurements", t, func() {
+		So(logger.Min(), ShouldEqual, 0)
+	})
+	Convey("with 1 measurements", t, func() {
+		logger.Store(10)
+		So(logger.Min(), ShouldEqual, 10)
+	})
+	Convey("with 2 measurements", t, func() {
+		logger.Store(5)
+		So(logger.Min(), ShouldEqual, 5)
+	})
+	Convey("with lots of measurements", t, func() {
+		for i := 0; i < 100; i++ {
+			logger.Store(i)
+		}
+		So(logger.Min(), ShouldEqual, 95)
+	})
+}
+
+func TestLagMonitor(t *testing.T) {
+	mon := NewLagMonitor(10, []int32{0, 1, 2, 3})
+	Convey("with 0 measurements", t, func() {
+		So(mon.Metric(), ShouldEqual, 0)
+	})
+	Convey("with lots of measurements", t, func() {
+		for part := range mon.lag {
+			for i := 0; i < 100; i++ {
+				mon.Store(part, i)
+			}
+		}
+		So(mon.Metric(), ShouldEqual, 90)
+	})
+	Convey("metric should be worst partition", t, func() {
+		for part := range mon.lag {
+			mon.Store(part, 10+int(part))
+		}
+		So(mon.Metric(), ShouldEqual, 13)
+	})
+}

--- a/metrictank-sample.ini
+++ b/metrictank-sample.ini
@@ -198,6 +198,8 @@ net-max-open-requests = 100
 [cluster]
 # The primary node writes data to cassandra. There should only be 1 primary node per shardGroup.
 primary-node = true
+# maximum priority before a node should be considered not-ready.
+max-priority = 10
 # the TCP/UDP address to listen on for the gossip protocol.
 bind-addr = 0.0.0.0:7946
 # TCP addresses of other nodes, comma separated. use this if you shard your data and want to query other instances.

--- a/scripts/config/metrictank-docker.ini
+++ b/scripts/config/metrictank-docker.ini
@@ -195,6 +195,8 @@ net-max-open-requests = 100
 [cluster]
 # The primary node writes data to cassandra. There should only be 1 primary node per shardGroup.
 primary-node = true
+# maximum priority before a node should be considered not-ready.
+max-priority = 10
 # the TCP/UDP address to listen on for the gossip protocol.
 bind-addr = 0.0.0.0:7946
 # TCP addresses of other nodes, comma separated. use this if you shard your data and want to query other instances.

--- a/scripts/config/metrictank-package.ini
+++ b/scripts/config/metrictank-package.ini
@@ -195,6 +195,8 @@ net-max-open-requests = 100
 [cluster]
 # The primary node writes data to cassandra. There should only be 1 primary node per shardGroup.
 primary-node = true
+# maximum priority before a node should be considered not-ready.
+max-priority = 10
 # the TCP/UDP address to listen on for the gossip protocol.
 bind-addr = 0.0.0.0:7946
 # TCP addresses of other nodes, comma separated. use this if you shard your data and want to query other instances.


### PR DESCRIPTION
- add a priority attribute to the cluster nodes
- when getting peers needed to handle a query, use the nodes
  with the lowest priority.
- update kafkamdm to track kafka lag, and use this lag as the
  node priority.  So if a node has a large lag (either due to
  proecessing the backlog at startup, or because of a fault) it
  will stop recieving queries.  But if all nodes in the cluster
  have high lag, then queries will still be processed and the user
  will get all of the data available.
- closes #519