### PR TITLE
fix metricDef fuzzy formula

### DIFF
--- a/idx/cassandra/cassandra.go
+++ b/idx/cassandra/cassandra.go
@@ -227,7 +227,7 @@ func (c *CasIdx) AddOrUpdate(data *schema.MetricData, partition int32) error {
 
 	if inMemory {
 		if existing.Partition == partition {
-			oldest := time.Now().Add(-1 * updateInterval).Add(-1 * time.Duration(rand.Int63n(updateInterval.Nanoseconds()*int64(updateFuzzyness*100))))
+			oldest := time.Now().Add(-1 * updateInterval).Add(-1 * time.Duration(rand.Int63n(updateInterval.Nanoseconds()*int64(updateFuzzyness*100)/100)))
 			if existing.LastUpdate < oldest.Unix() {
 				log.Debug("cassandra-idx def hasn't been seen for a while, updating index.")
 				def := schema.MetricDefinitionFromMetricData(data)


### PR DESCRIPTION
due to the multiplication by 100, it was subtracting way too much,
so that metricdefs are less likely to be updated.
However the multiplication is good to turn the float value into a useful
factor, but then we have to divide again to compensate.

With this fix applied, we will update the metricdef more frequently like
we were supposed to.