### PR TITLE
add metricdefs to cassandra if memory idx DID succeed

### DIFF
--- a/idx/cassandra/cassandra.go
+++ b/idx/cassandra/cassandra.go
@@ -233,7 +233,7 @@ func (c *CasIdx) AddOrUpdate(data *schema.MetricData, partition int32) error {
 				def := schema.MetricDefinitionFromMetricData(data)
 				def.Partition = partition
 				err := c.MemoryIdx.AddOrUpdateDef(def)
-				if err != nil {
+				if err == nil {
 					c.writeQueue <- writeReq{recvTime: time.Now(), def: def}
 				}
 				statUpdateDuration.Value(time.Since(pre))


### PR DESCRIPTION
we have 3 cases where we update cassandra idx after attempting to
update memory idx.
A) in memory && same partition, but old lastUpdate
B) in memory but different partition
C) not in memory yet

B and C were correct, but in A, via
40c2f15e458e46f91387bc83880b192686332174 in #504 
the following bug was introduced:

1) we saved defs to cassandra when the update in memory did *not* succeed.
With the current code MemoryIdx.AddOrUpdateDef always returns error=nil,
so this case could not manifest itself, although until recently
(008737c0276c05e7fd433a3da84df0d3faf4c17c) we returned
idx.BranchUnderLeaf and idx.BothBranchAndLeaf errors.
So for a while we saved defs with those errors to the cassandra index

2) we did not update cassandra when the memory AddOrUpdate did succeed.
The consequence here is that the lastUpdate field in cassandra was out
of date, so that when new instances start from scratch, loading the
index, they may have excluded metrics from render requests when they
were supposed to be included, but only for inactive series for which it
did not receive any new points (since when it receives points, it'll
update the LastUpdate in memory)