### PR TITLE
559 deterministic update distribution

### DIFF
--- a/Godeps/Godeps.json
+++ b/Godeps/Godeps.json
@@ -1,0 +1,14 @@
+{
+	"ImportPath": "github.com/raintank/metrictank",
+	"GoVersion": "go1.7",
+	"GodepVersion": "v79",
+	"Packages": [
+		"github.com/huichen/murmur"
+	],
+	"Deps": [
+		{
+			"ImportPath": "github.com/huichen/murmur",
+			"Rev": "e0489551cf5116e27d7cc69d97a53cdbdd028acf"
+		}
+	]
+}

--- a/Godeps/Readme
+++ b/Godeps/Readme
@@ -1,0 +1,5 @@
+This directory tree is generated automatically by godep.
+
+Please do not edit.
+
+See https://github.com/tools/godep for more information.

--- a/vendor/github.com/huichen/murmur/README.md
+++ b/vendor/github.com/huichen/murmur/README.md
@@ -1,0 +1,8 @@
+murmur
+======
+
+Go Murmur3 hash implementation
+
+Based on
+
+http://en.wikipedia.org/wiki/MurmurHash

--- a/vendor/github.com/huichen/murmur/license.txt
+++ b/vendor/github.com/huichen/murmur/license.txt
@@ -1,0 +1,13 @@
+Copyright 2013 Hui Chen
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.

--- a/vendor/github.com/huichen/murmur/murmur.go
+++ b/vendor/github.com/huichen/murmur/murmur.go
@@ -1,0 +1,58 @@
+// Murmur3 32bit hash function based on
+// http://en.wikipedia.org/wiki/MurmurHash
+package murmur
+
+const (
+	c1 = 0xcc9e2d51
+	c2 = 0x1b873593
+	c3 = 0x85ebca6b
+	c4 = 0xc2b2ae35
+	r1 = 15
+	r2 = 13
+	m  = 5
+	n  = 0xe6546b64
+)
+
+var (
+	Seed = uint32(1)
+)
+
+func Murmur3(key []byte) (hash uint32) {
+	hash = Seed
+	iByte := 0
+	for ; iByte+4 <= len(key); iByte += 4 {
+		k := uint32(key[iByte]) | uint32(key[iByte+1])<<8 | uint32(key[iByte+2])<<16 | uint32(key[iByte+3])<<24
+		k *= c1
+		k = (k << r1) | (k >> (32 - r1))
+		k *= c2
+		hash ^= k
+		hash = (hash << r2) | (hash >> (32 - r2))
+		hash = hash*m + n
+	}
+
+	var remainingBytes uint32
+	switch len(key) - iByte {
+	case 3:
+		remainingBytes += uint32(key[iByte+2]) << 16
+		fallthrough
+	case 2:
+		remainingBytes += uint32(key[iByte+1]) << 8
+		fallthrough
+	case 1:
+		remainingBytes += uint32(key[iByte])
+		remainingBytes *= c1
+		remainingBytes = (remainingBytes << r1) | (remainingBytes >> (32 - r1))
+		remainingBytes = remainingBytes * c2
+		hash ^= remainingBytes
+	}
+
+	hash ^= uint32(len(key))
+	hash ^= hash >> 16
+	hash *= c3
+	hash ^= hash >> 13
+	hash *= c4
+	hash ^= hash >> 16
+	
+	// 出发吧，狗嬷嬷！
+	return
+}


### PR DESCRIPTION
Changes who Cassandra Idx decides whether the `LastUpdate` property of an index entry needs to be updated or not.
The decision is now based around a hash that's using a given metric's `Id` as input, so if multiple nodes receive the same metric point they should all reach the same conclusion.

fixes #559 