### PR TITLE
update idx handling

### DIFF
--- a/docker/docker-cluster/metrictank.ini
+++ b/docker/docker-cluster/metrictank.ini
@@ -248,10 +248,8 @@ max-stale = 0
 prune-interval = 3h
 # synchronize index changes to cassandra. not all your nodes need to do this.
 update-cassandra-index = true
-#frequency at which we should update the metricDef lastUpdate field, use 0s for instant updates
+#frequency at which we should update flush changes to cassandra. only relevant if update-cassandra-index is true.
 update-interval = 4h
-#fuzzyness factor for update-interval. should be in the range 0 > fuzzyness <= 1. With an updateInterval of 4hours and fuzzyness of 0.5, metricDefs will be updated every 4-6hours.
-update-fuzzyness = 0.5
 # enable SSL connection to cassandra
 ssl = false
 # cassandra CA certficate path when using SSL

--- a/docker/docker-dev-custom-cfg-kafka/metrictank.ini
+++ b/docker/docker-dev-custom-cfg-kafka/metrictank.ini
@@ -248,10 +248,8 @@ max-stale = 0
 prune-interval = 3h
 # synchronize index changes to cassandra. not all your nodes need to do this.
 update-cassandra-index = true
-#frequency at which we should update the metricDef lastUpdate field, use 0s for instant updates
+#frequency at which we should update flush changes to cassandra. only relevant if update-cassandra-index is true.
 update-interval = 4h
-#fuzzyness factor for update-interval. should be in the range 0 > fuzzyness <= 1. With an updateInterval of 4hours and fuzzyness of 0.5, metricDefs will be updated every 4-6hours.
-update-fuzzyness = 0.5
 # enable SSL connection to cassandra
 ssl = false
 # cassandra CA certficate path when using SSL

--- a/docs/config.md
+++ b/docs/config.md
@@ -297,10 +297,8 @@ max-stale = 0
 prune-interval = 3h
 # synchronize index changes to cassandra. not all your nodes need to do this.
 update-cassandra-index = true
-#frequency at which we should update the metricDef lastUpdate field, use 0s for instant updates
+#frequency at which we should update flush changes to cassandra. only relevant if update-cassandra-index is true.
 update-interval = 4h
-#fuzzyness factor for update-interval. should be in the range 0 > fuzzyness <= 1. With an updateInterval of 4hours and fuzzyness of 0.5, metricDefs will be updated every 4-6hours.
-update-fuzzyness = 0.5
 # enable SSL connection to cassandra
 ssl = false
 # cassandra CA certficate path when using SSL

--- a/docs/metadata.md
+++ b/docs/metadata.md
@@ -25,7 +25,7 @@ enabled = true
 This is the recommended option because it persists.
 
 * type: Memory-Idx for search queries, backed by Cassandra for persistence
-* persistence:  persists new metricDefinitions as they are seen.  At startup, the internal memory index is rebuilt from all metricDefinitions that have been stored in Cassandra.  Metrictank won’t be considered ready (be able to ingest metrics or handle searches) until the index has been completely rebuilt.
+* persistence:  persists new metricDefinitions as they are seen and every update-interval.  At startup, the internal memory index is rebuilt from all metricDefinitions that have been stored in Cassandra.  Metrictank won’t be considered ready (be able to ingest metrics or handle searches) until the index has been completely rebuilt.
 * efficiency: On low end hardware the index rebuilds at about 70000 metricDefinitions per second. Saving new metrics works pretty fast.
 
 Metrictank will initialize Cassandra with the needed keyspace and tabe.  However if you are running a Cassandra cluster then you should tune the keyspace to suit your deployment.
@@ -51,8 +51,6 @@ num-conns = 10
 write-queue-size = 100000
 ```
 
-Note:
-* All metrictanks write to Cassandra.  this is not very efficient.
 
 ## The anatomy of a metricdef
 
@@ -65,16 +63,15 @@ The schema is as follows:
 ```
 type MetricDefinition struct {
 	Id         string            
-	OrgId      int               
+	OrgId      int       
+	Partition  int        
 	Name       string            // graphite format
 	Metric     string            // kairosdb format (like graphite, but not including some tags)
 	Interval   int               
 	Unit       string            
 	Mtype      string            
 	Tags       []string          
-	LastUpdate int64             
-	Nodes      map[string]string 
-	NodeCount  int               
+	LastUpdate int64                        
 }
 ```
 

--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -132,6 +132,8 @@ how many insert queries for a metric failed (triggered by an add or an update)
 time inserts spent in queue before being executed
 * `idx.cassandra.update`:  
 the duration of an update of one metric to the cassandra idx, including the update to the in-memory index, excluding any insert/delete queries
+* `idx.cassandra.save.skipped`:  
+how many saves have been skipped due to the writeQueue being full
 * `idx.memory.add`:  
 the duration of an add of a metric to the memory idx
 * `idx.memory.ops.add`:  

--- a/idx/cassandra/cassandra_test.go
+++ b/idx/cassandra/cassandra_test.go
@@ -22,8 +22,16 @@ func init() {
 	numConns = 1
 	writeQueueSize = 1000
 	protoVer = 4
+	updateCassIdx = false
 
 	cluster.Init("default", "test", time.Now(), "http", 6060)
+}
+
+func initForTests(c *CasIdx) error {
+	if err := c.MemoryIdx.Init(); err != nil {
+		return err
+	}
+	return nil
 }
 
 func getSeriesNames(depth, count int, prefix string) []string {
@@ -71,7 +79,7 @@ func getMetricData(orgId, depth, count, interval int, prefix string) []*schema.M
 
 func TestGetAddKey(t *testing.T) {
 	ix := New()
-	ix.Init()
+	initForTests(ix)
 
 	publicSeries := getMetricData(-1, 2, 5, 10, "metric.public")
 	org1Series := getMetricData(1, 2, 5, 10, "metric.org1")
@@ -108,9 +116,104 @@ func TestGetAddKey(t *testing.T) {
 	})
 }
 
+func TestAddToWriteQueue(t *testing.T) {
+	originalUpdateCassIdx := updateCassIdx
+	originalUpdateInterval := updateInterval
+	originalWriteQSize := writeQueueSize
+
+	defer func() {
+		updateCassIdx = originalUpdateCassIdx
+		updateInterval = originalUpdateInterval
+		writeQueueSize = originalWriteQSize
+	}()
+
+	updateCassIdx = true
+	updateInterval = 10
+	writeQueueSize = 5
+	ix := New()
+	initForTests(ix)
+	metrics := getMetricData(1, 2, 5, 10, "metric.demo")
+	Convey("When writeQueue is enabled", t, func() {
+		Convey("When new metrics being added", func() {
+			for _, s := range metrics {
+				ix.AddOrUpdate(s, 1)
+				select {
+				case wr := <-ix.writeQueue:
+					So(wr.def.Id, ShouldEqual, s.Id)
+					archive, inMem := ix.Get(wr.def.Id)
+					So(inMem, ShouldBeTrue)
+					now := uint32(time.Now().Unix())
+					So(archive.LastSave, ShouldBeBetweenOrEqual, now-1, now+1)
+				case <-time.After(time.Second):
+					t.Fail()
+				}
+			}
+		})
+		Convey("When existing metrics are added and lastSave is recent", func() {
+			for _, s := range metrics {
+				s.Time = time.Now().Unix()
+				ix.AddOrUpdate(s, 1)
+			}
+			wrCount := 0
+
+		LOOP_WR:
+			for {
+				select {
+				case <-ix.writeQueue:
+					wrCount++
+				default:
+					break LOOP_WR
+				}
+			}
+			So(wrCount, ShouldEqual, 0)
+		})
+		Convey("When existing metrics are added and lastSave is old", func() {
+			for _, s := range metrics {
+				s.Time = time.Now().Unix()
+				archive, _ := ix.Get(s.Id)
+				archive.LastSave = uint32(time.Now().Unix() - 100)
+				ix.Update(archive)
+			}
+			for _, s := range metrics {
+				ix.AddOrUpdate(s, 1)
+				select {
+				case wr := <-ix.writeQueue:
+					So(wr.def.Id, ShouldEqual, s.Id)
+					archive, inMem := ix.Get(wr.def.Id)
+					So(inMem, ShouldBeTrue)
+					now := uint32(time.Now().Unix())
+					So(archive.LastSave, ShouldBeBetweenOrEqual, now-1, now+1)
+				case <-time.After(time.Second):
+					t.Fail()
+				}
+			}
+		})
+		Convey("When new metrics are added and writeQueue is full", func() {
+			newMetrics := getMetricData(1, 2, 6, 10, "metric.demo2")
+			pre := time.Now()
+			go func() {
+				time.Sleep(time.Second)
+				//drain the writeQueue
+				for range ix.writeQueue {
+					continue
+				}
+			}()
+
+			for _, s := range newMetrics {
+				ix.AddOrUpdate(s, 1)
+			}
+			//it should take at least 1 second to add the defs, as the queue will be full
+			// until the above goroutine empties it, leading to a blocking write.
+			So(time.Now(), ShouldHappenAfter, pre.Add(time.Second))
+		})
+	})
+	ix.MemoryIdx.Stop()
+	close(ix.writeQueue)
+}
+
 func TestFind(t *testing.T) {
 	ix := New()
-	ix.Init()
+	initForTests(ix)
 	for _, s := range getMetricData(-1, 2, 5, 10, "metric.demo") {
 		ix.AddOrUpdate(s, 1)
 	}
@@ -217,7 +320,7 @@ func BenchmarkIndexing(b *testing.B) {
 	writeQueueSize = 10
 	protoVer = 4
 	updateInterval = time.Hour
-	updateFuzzyness = 1.0
+	updateCassIdx = true
 	ix := New()
 	tmpSession, err := ix.cluster.CreateSession()
 	if err != nil {
@@ -262,7 +365,7 @@ func BenchmarkLoad(b *testing.B) {
 	writeQueueSize = 10
 	protoVer = 4
 	updateInterval = time.Hour
-	updateFuzzyness = 1.0
+	updateCassIdx = true
 	ix := New()
 
 	tmpSession, err := ix.cluster.CreateSession()
@@ -275,7 +378,6 @@ func BenchmarkLoad(b *testing.B) {
 	if err != nil {
 		b.Skipf("can't initialize cassandra: %s", err)
 	}
-
 	insertDefs(ix, b.N)
 	ix.Stop()
 
@@ -283,5 +385,48 @@ func BenchmarkLoad(b *testing.B) {
 	b.ResetTimer()
 	ix = New()
 	ix.Init()
+	ix.Stop()
+}
+
+func BenchmarkIndexingWithUpdates(b *testing.B) {
+	cluster.Manager.SetPartitions([]int32{1})
+	keyspace = "metrictank"
+	hosts = "localhost:9042"
+	consistency = "one"
+	timeout = time.Second
+	numConns = 10
+	writeQueueSize = 10
+	protoVer = 4
+	updateInterval = time.Hour
+	updateCassIdx = true
+	ix := New()
+	tmpSession, err := ix.cluster.CreateSession()
+	if err != nil {
+		b.Skipf("can't connect to cassandra: %s", err)
+	}
+	tmpSession.Query("TRUNCATE metrictank.metric_idx").Exec()
+	tmpSession.Close()
+	if err != nil {
+		b.Skipf("can't connect to cassandra: %s", err)
+	}
+	ix.Init()
+	insertDefs(ix, b.N)
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	var series string
+	var data *schema.MetricData
+	for n := 0; n < b.N; n++ {
+		series = "some.metric." + strconv.Itoa(n)
+		data = &schema.MetricData{
+			Name:     series,
+			Metric:   series,
+			Interval: 10,
+			OrgId:    1,
+			Time:     10,
+		}
+		data.SetId()
+		ix.AddOrUpdate(data, 1)
+	}
 	ix.Stop()
 }

--- a/idx/cassandra/cassandra_test.go
+++ b/idx/cassandra/cassandra_test.go
@@ -411,9 +411,7 @@ func BenchmarkIndexingWithUpdates(b *testing.B) {
 	}
 	ix.Init()
 	insertDefs(ix, b.N)
-
-	b.ReportAllocs()
-	b.ResetTimer()
+	updates := make([]*schema.MetricData, b.N)
 	var series string
 	var data *schema.MetricData
 	for n := 0; n < b.N; n++ {
@@ -426,7 +424,13 @@ func BenchmarkIndexingWithUpdates(b *testing.B) {
 			Time:     10,
 		}
 		data.SetId()
-		ix.AddOrUpdate(data, 1)
+		updates[n] = data
+	}
+	b.ReportAllocs()
+	b.ResetTimer()
+
+	for n := 0; n < b.N; n++ {
+		ix.AddOrUpdate(updates[n], 1)
 	}
 	ix.Stop()
 }

--- a/idx/idx.go
+++ b/idx/idx.go
@@ -26,16 +26,15 @@ type Archive struct {
 	schema.MetricDefinition
 	SchemaId uint16 // index in mdata.schemas (not persisted)
 	AggId    uint16 // index in mdata.aggregations (not persisted)
+	LastSave uint32 // last time the metricDefinition was saved to a backend store (cassandra)
 }
 
 // used primarily by tests, for convenience
 func NewArchiveBare(name string) Archive {
 	return Archive{
-		schema.MetricDefinition{
+		MetricDefinition: schema.MetricDefinition{
 			Name: name,
 		},
-		0,
-		0,
 	}
 }
 

--- a/idx/memory/memory.go
+++ b/idx/memory/memory.go
@@ -143,7 +143,10 @@ func (m *MemoryIdx) Load(defs []schema.MetricDefinition) int {
 		}
 		m.add(def)
 		// as we are loading the metricDefs from a persistant store, set the lastSave
-		// to the lastUpdate timestamp.
+		// to the lastUpdate timestamp.  This wont exactly match the true lastSave Timstamp,
+		// but it will be close enough and it will always be true that the lastSave was at
+		// or after this time.  For metrics that are sent at or close to real time (the typical
+		// use case), then the value will be within a couple of seconds of the true lastSave.
 		m.DefById[def.Id].LastSave = uint32(def.LastUpdate)
 		num++
 		statMetricsActive.Inc()

--- a/metrictank-sample.ini
+++ b/metrictank-sample.ini
@@ -251,10 +251,8 @@ max-stale = 0
 prune-interval = 3h
 # synchronize index changes to cassandra. not all your nodes need to do this.
 update-cassandra-index = true
-#frequency at which we should update the metricDef lastUpdate field, use 0s for instant updates
+#frequency at which we should update flush changes to cassandra. only relevant if update-cassandra-index is true.
 update-interval = 4h
-#fuzzyness factor for update-interval. should be in the range 0 > fuzzyness <= 1. With an updateInterval of 4hours and fuzzyness of 0.5, metricDefs will be updated every 4-6hours.
-update-fuzzyness = 0.5
 # enable SSL connection to cassandra
 ssl = false
 # cassandra CA certficate path when using SSL

--- a/scripts/config/metrictank-docker.ini
+++ b/scripts/config/metrictank-docker.ini
@@ -248,10 +248,8 @@ max-stale = 0
 prune-interval = 3h
 # synchronize index changes to cassandra. not all your nodes need to do this.
 update-cassandra-index = true
-#frequency at which we should update the metricDef lastUpdate field, use 0s for instant updates
+#frequency at which we should update flush changes to cassandra. only relevant if update-cassandra-index is true.
 update-interval = 4h
-#fuzzyness factor for update-interval. should be in the range 0 > fuzzyness <= 1. With an updateInterval of 4hours and fuzzyness of 0.5, metricDefs will be updated every 4-6hours.
-update-fuzzyness = 0.5
 # enable SSL connection to cassandra
 ssl = false
 # cassandra CA certficate path when using SSL

--- a/scripts/config/metrictank-package.ini
+++ b/scripts/config/metrictank-package.ini
@@ -248,10 +248,8 @@ max-stale = 0
 prune-interval = 3h
 # synchronize index changes to cassandra. not all your nodes need to do this.
 update-cassandra-index = true
-#frequency at which we should update the metricDef lastUpdate field, use 0s for instant updates
+#frequency at which we should update flush changes to cassandra. only relevant if update-cassandra-index is true.
 update-interval = 4h
-#fuzzyness factor for update-interval. should be in the range 0 > fuzzyness <= 1. With an updateInterval of 4hours and fuzzyness of 0.5, metricDefs will be updated every 4-6hours.
-update-fuzzyness = 0.5
 # enable SSL connection to cassandra
 ssl = false
 # cassandra CA certficate path when using SSL


### PR DESCRIPTION
- support LastSave property, so we only periodically save to cassandra.
- make adding to the writeQueue a non-blocking operation, unless the
  def has not been updated for 1.5x the updateInterval.

replaces PR #569  and PR #571 