### PR TITLE
Max datapoints per target

### DIFF
--- a/api/config.go
+++ b/api/config.go
@@ -10,10 +10,11 @@ import (
 )
 
 var (
-	maxPointsPerReq int
-	maxDaysPerReq   int
-	logMinDurStr    string
-	logMinDur       uint32
+	maxPointsPerReq    int
+	maxPointsPerTarget int
+	maxDaysPerReq      int
+	logMinDurStr       string
+	logMinDur          uint32
 
 	Addr     string
 	UseSSL   bool
@@ -25,6 +26,7 @@ var (
 func ConfigSetup() {
 	apiCfg := flag.NewFlagSet("http", flag.ExitOnError)
 	apiCfg.IntVar(&maxDaysPerReq, "max-days-per-req", 365000, "max number of days range for one request. the default allows 500 series of 2 year each. (0 disables limit")
+	apiCfg.IntVar(&maxPointsPerTarget, "max-points-per-target", 60*60*24, "max number of data points to be returned per target")
 	apiCfg.IntVar(&maxPointsPerReq, "max-points-per-req", 1000000, "max points could be requested in one request. 1M allows 500 series at a MaxDataPoints of 2000. (0 disables limit)")
 	apiCfg.StringVar(&logMinDurStr, "log-min-dur", "5min", "only log incoming requests if their timerange is at least this duration. Use 0 to disable")
 

--- a/api/config.go
+++ b/api/config.go
@@ -10,11 +10,10 @@ import (
 )
 
 var (
-	maxPointsPerReq    int
-	maxPointsPerTarget int
-	maxDaysPerReq      int
-	logMinDurStr       string
-	logMinDur          uint32
+	maxPointsPerReqSoft int
+	maxPointsPerReqHard int
+	logMinDurStr        string
+	logMinDur           uint32
 
 	Addr     string
 	UseSSL   bool
@@ -25,9 +24,8 @@ var (
 
 func ConfigSetup() {
 	apiCfg := flag.NewFlagSet("http", flag.ExitOnError)
-	apiCfg.IntVar(&maxDaysPerReq, "max-days-per-req", 365000, "max number of days range for one request. the default allows 500 series of 2 year each. (0 disables limit")
-	apiCfg.IntVar(&maxPointsPerTarget, "max-points-per-target", 60*60*24, "max number of data points to be returned per target")
-	apiCfg.IntVar(&maxPointsPerReq, "max-points-per-req", 1000000, "max points could be requested in one request. 1M allows 500 series at a MaxDataPoints of 2000. (0 disables limit)")
+	apiCfg.IntVar(&maxPointsPerReqSoft, "max-points-per-req-soft", 1000000, "lower resolution rollups will be used to try and keep requests below this number of datapoints. (0 disables limit)")
+	apiCfg.IntVar(&maxPointsPerReqHard, "max-points-per-req-hard", 20000000, "limit of number of datapoints a request can return. Requests that exceed this limit will be rejected. (0 disables limit)")
 	apiCfg.StringVar(&logMinDurStr, "log-min-dur", "5min", "only log incoming requests if their timerange is at least this duration. Use 0 to disable")
 
 	apiCfg.StringVar(&Addr, "listen", ":6060", "http listener address.")

--- a/api/graphite.go
+++ b/api/graphite.go
@@ -23,8 +23,6 @@ import (
 var MissingOrgHeaderErr = errors.New("orgId not set in headers")
 var MissingQueryErr = errors.New("missing query param")
 var InvalidFormatErr = errors.New("invalid format specified")
-var MaxPointsPerReqErr = errors.New("request exceeds max-points-per-req limit. Reduce the number of series and or maxDataPoints requested or ask your admin to increase the limit.")
-var MaxDaysPerReqErr = errors.New("request exceeds max-days-per-req limit. Reduce the number of series and or time range requested or ask your admin to increase the limit.")
 var InvalidTimeRangeErr = errors.New("invalid time range requested")
 
 var (
@@ -164,11 +162,6 @@ func (s *Server) findSeriesRemote(orgId int, patterns []string, seenAfter int64,
 
 func (s *Server) renderMetrics(ctx *middleware.Context, request models.GraphiteRender) {
 	targets := request.Targets
-	if maxPointsPerReq != 0 && len(targets)*int(request.MaxDataPoints) > maxPointsPerReq {
-		response.Write(ctx, response.NewError(http.StatusForbidden, MaxPointsPerReqErr.Error()))
-		return
-	}
-
 	now := time.Now()
 
 	from := request.From
@@ -200,10 +193,6 @@ func (s *Server) renderMetrics(ctx *middleware.Context, request models.GraphiteR
 
 	if fromUnix >= toUnix {
 		response.Write(ctx, response.NewError(http.StatusBadRequest, InvalidTimeRangeErr.Error()))
-		return
-	}
-	if maxDaysPerReq != 0 && len(targets)*int(toUnix-fromUnix) > maxDaysPerReq*(3600*24) {
-		response.Write(ctx, response.NewError(http.StatusForbidden, MaxDaysPerReqErr.Error()))
 		return
 	}
 

--- a/api/query_engine.go
+++ b/api/query_engine.go
@@ -1,9 +1,10 @@
 package api
 
 import (
-	"errors"
+	"math"
 
 	"github.com/raintank/metrictank/api/models"
+	"github.com/raintank/metrictank/api/response"
 	"github.com/raintank/metrictank/mdata"
 	"github.com/raintank/metrictank/stats"
 	"github.com/raintank/metrictank/util"
@@ -18,58 +19,65 @@ var (
 	// metric api.request.render.series is the number of points the request will return.
 	reqRenderPointsReturned = stats.NewMeter32("api.request.render.points_returned", false)
 
-	errUnSatisfiable      = errors.New("request cannot be satisfied due to lack of available retentions")
-	errMaxPointsPerTarget = errors.New("request exceeds max-points-per-target limit. Reduce the time range or ask your admin to increase the limit.")
+	errUnSatisfiable   = response.NewError(404, "request cannot be satisfied due to lack of available retentions")
+	errMaxPointsPerReq = response.NewError(413, "request exceeds max-points-per-req-hard limit. Reduce the time range or number of targets or ask your admin to increase the limit.")
 )
 
 // alignRequests updates the requests with all details for fetching, making sure all metrics are in the same, optimal interval
 // note: it is assumed that all requests have the same from & to.
 // also takes a "now" value which we compare the TTL against
 func alignRequests(now uint32, reqs []models.Req) ([]models.Req, error) {
-
 	tsRange := (reqs[0].To - reqs[0].From)
 
 	var listIntervals []uint32
 	var seenIntervals = make(map[uint32]struct{})
+	var targets = make(map[string]struct{})
+
+	for i := range reqs {
+		req := &reqs[i]
+		req.Archive = -1
+		targets[req.Target] = struct{}{}
+	}
+	numTargets := uint32(len(targets))
+	minTTL := now - reqs[0].From
+
+	minIntervalSoft := uint32(0)
+	minIntervalHard := uint32(0)
+
+	if maxPointsPerReqSoft > 0 {
+		minIntervalSoft = uint32(math.Ceil(float64(tsRange) / (float64(maxPointsPerReqSoft) / float64(numTargets))))
+	}
+	if maxPointsPerReqHard > 0 {
+		minIntervalHard = uint32(math.Ceil(float64(tsRange) / (float64(maxPointsPerReqHard) / float64(numTargets))))
+	}
 
 	// set preliminary settings. may be adjusted further down
 	// but for now:
 	// for each req, find the highest res archive
 	// (starting with raw, then rollups in decreasing precision)
-	// that retains all the data we need.
+	// that retains all the data we need and does not exceed minIntervalSoft.
 	// fallback to lowest res option (which *should* have the longest TTL)
-
 	for i := range reqs {
 		req := &reqs[i]
 		retentions := mdata.Schemas.Get(req.SchemaId).Retentions
-		req.Archive = -1
-		var points int
-
 		for i, ret := range retentions {
 			// skip non-ready option.
 			if !ret.Ready {
 				continue
 			}
-
 			req.Archive = i
 			req.TTL = uint32(ret.MaxRetention())
 			if i == 0 {
 				// The first retention is raw data, so use its native interval
 				req.ArchInterval = req.RawInterval
-				points = int(tsRange) / int(req.RawInterval)
 			} else {
 				req.ArchInterval = uint32(ret.SecondsPerPoint)
-				points = int(tsRange) / ret.SecondsPerPoint
 			}
 
-			if now-req.TTL <= req.From && points <= maxPointsPerTarget {
+			if req.TTL >= minTTL && req.ArchInterval >= minIntervalSoft {
 				break
 			}
 		}
-		if points > maxPointsPerTarget {
-			return nil, errMaxPointsPerTarget
-		}
-
 		if req.Archive == -1 {
 			return nil, errUnSatisfiable
 		}
@@ -82,8 +90,11 @@ func alignRequests(now uint32, reqs []models.Req) ([]models.Req, error) {
 
 	// due to different retentions coming into play, different requests may end up with different resolutions
 	// we all need to emit them at the same interval, the LCM interval >= interval of the req
-
 	interval := util.Lcm(listIntervals)
+
+	if interval < minIntervalHard {
+		return nil, errMaxPointsPerReq
+	}
 
 	// now, for all our requests, set all their properties.  we may have to apply runtime consolidation to get the
 	// correct output interval if out interval != native.  In that case, we also check whether we can fulfill

--- a/docker/docker-cluster/metrictank.ini
+++ b/docker/docker-cluster/metrictank.ini
@@ -128,12 +128,10 @@ ssl = false
 cert-file = /etc/ssl/certs/ssl-cert-snakeoil.pem
 # SSL key file
 key-file = /etc/ssl/private/ssl-cert-snakeoil.key
-# limit on how many points could be requested in one request. 1M allows 500 series at a MaxDataPoints of 2000. (0 disables limit)
-max-points-per-req = 1000000
-# max number of data points to be returned per target
-max-points-per-target = 86400
-# limit on what kind of time range can be requested in one request. the default allows 500 series of 2 years. (0 disables limit)
-max-days-per-req = 365000
+# lower resolution rollups will be used to try and keep requests below this number of datapoints. (0 disables limit)
+max-points-per-req-soft = 1000000
+# limit of number of datapoints a request can return. Requests that exceed this limit will be rejected. (0 disables limit)
+max-points-per-req-hard = 20000000
 # only log incoming requests if their timerange is at least this duration. Use 0 to disable
 log-min-dur = 5min
 

--- a/docker/docker-cluster/metrictank.ini
+++ b/docker/docker-cluster/metrictank.ini
@@ -130,6 +130,8 @@ cert-file = /etc/ssl/certs/ssl-cert-snakeoil.pem
 key-file = /etc/ssl/private/ssl-cert-snakeoil.key
 # limit on how many points could be requested in one request. 1M allows 500 series at a MaxDataPoints of 2000. (0 disables limit)
 max-points-per-req = 1000000
+# max number of data points to be returned per target
+max-points-per-target = 86400
 # limit on what kind of time range can be requested in one request. the default allows 500 series of 2 years. (0 disables limit)
 max-days-per-req = 365000
 # only log incoming requests if their timerange is at least this duration. Use 0 to disable

--- a/docker/docker-dev-custom-cfg-kafka/metrictank.ini
+++ b/docker/docker-dev-custom-cfg-kafka/metrictank.ini
@@ -128,12 +128,10 @@ ssl = false
 cert-file = /etc/ssl/certs/ssl-cert-snakeoil.pem
 # SSL key file
 key-file = /etc/ssl/private/ssl-cert-snakeoil.key
-# limit on how many points could be requested in one request. 1M allows 500 series at a MaxDataPoints of 2000. (0 disables limit)
-max-points-per-req = 1000000
-# max number of data points to be returned per target
-max-points-per-target = 86400
-# limit on what kind of time range can be requested in one request. the default allows 500 series of 2 years. (0 disables limit)
-max-days-per-req = 365000
+# lower resolution rollups will be used to try and keep requests below this number of datapoints. (0 disables limit)
+max-points-per-req-soft = 1000000
+# limit of number of datapoints a request can return. Requests that exceed this limit will be rejected. (0 disables limit)
+max-points-per-req-hard = 20000000
 # only log incoming requests if their timerange is at least this duration. Use 0 to disable
 log-min-dur = 5min
 

--- a/docker/docker-dev-custom-cfg-kafka/metrictank.ini
+++ b/docker/docker-dev-custom-cfg-kafka/metrictank.ini
@@ -130,6 +130,8 @@ cert-file = /etc/ssl/certs/ssl-cert-snakeoil.pem
 key-file = /etc/ssl/private/ssl-cert-snakeoil.key
 # limit on how many points could be requested in one request. 1M allows 500 series at a MaxDataPoints of 2000. (0 disables limit)
 max-points-per-req = 1000000
+# max number of data points to be returned per target
+max-points-per-target = 86400
 # limit on what kind of time range can be requested in one request. the default allows 500 series of 2 years. (0 disables limit)
 max-days-per-req = 365000
 # only log incoming requests if their timerange is at least this duration. Use 0 to disable

--- a/docs/config.md
+++ b/docs/config.md
@@ -169,12 +169,10 @@ ssl = false
 cert-file = /etc/ssl/certs/ssl-cert-snakeoil.pem
 # SSL key file
 key-file = /etc/ssl/private/ssl-cert-snakeoil.key
-# limit on how many points could be requested in one request. 1M allows 500 series at a MaxDataPoints of 2000. (0 disables limit)
-max-points-per-req = 1000000
-# max number of data points to be returned per target
-max-points-per-target = 86400
-# limit on what kind of time range can be requested in one request. the default allows 500 series of 2 years. (0 disables limit)
-max-days-per-req = 365000
+# lower resolution rollups will be used to try and keep requests below this number of datapoints. (0 disables limit)
+max-points-per-req-soft = 1000000
+# limit of number of datapoints a request can return. Requests that exceed this limit will be rejected. (0 disables limit)
+max-points-per-req-hard = 20000000
 # only log incoming requests if their timerange is at least this duration. Use 0 to disable
 log-min-dur = 5min
 ```

--- a/docs/config.md
+++ b/docs/config.md
@@ -171,6 +171,8 @@ cert-file = /etc/ssl/certs/ssl-cert-snakeoil.pem
 key-file = /etc/ssl/private/ssl-cert-snakeoil.key
 # limit on how many points could be requested in one request. 1M allows 500 series at a MaxDataPoints of 2000. (0 disables limit)
 max-points-per-req = 1000000
+# max number of data points to be returned per target
+max-points-per-target = 86400
 # limit on what kind of time range can be requested in one request. the default allows 500 series of 2 years. (0 disables limit)
 max-days-per-req = 365000
 # only log incoming requests if their timerange is at least this duration. Use 0 to disable

--- a/metrictank-sample.ini
+++ b/metrictank-sample.ini
@@ -131,12 +131,10 @@ ssl = false
 cert-file = /etc/ssl/certs/ssl-cert-snakeoil.pem
 # SSL key file
 key-file = /etc/ssl/private/ssl-cert-snakeoil.key
-# limit on how many points could be requested in one request. 1M allows 500 series at a MaxDataPoints of 2000. (0 disables limit)
-max-points-per-req = 1000000
-# max number of data points to be returned per target
-max-points-per-target = 86400
-# limit on what kind of time range can be requested in one request. the default allows 500 series of 2 years. (0 disables limit)
-max-days-per-req = 365000
+# lower resolution rollups will be used to try and keep requests below this number of datapoints. (0 disables limit)
+max-points-per-req-soft = 1000000
+# limit of number of datapoints a request can return. Requests that exceed this limit will be rejected. (0 disables limit)
+max-points-per-req-hard = 20000000
 # only log incoming requests if their timerange is at least this duration. Use 0 to disable
 log-min-dur = 5min
 

--- a/metrictank-sample.ini
+++ b/metrictank-sample.ini
@@ -133,6 +133,8 @@ cert-file = /etc/ssl/certs/ssl-cert-snakeoil.pem
 key-file = /etc/ssl/private/ssl-cert-snakeoil.key
 # limit on how many points could be requested in one request. 1M allows 500 series at a MaxDataPoints of 2000. (0 disables limit)
 max-points-per-req = 1000000
+# max number of data points to be returned per target
+max-points-per-target = 86400
 # limit on what kind of time range can be requested in one request. the default allows 500 series of 2 years. (0 disables limit)
 max-days-per-req = 365000
 # only log incoming requests if their timerange is at least this duration. Use 0 to disable

--- a/scripts/config/metrictank-docker.ini
+++ b/scripts/config/metrictank-docker.ini
@@ -128,12 +128,10 @@ ssl = false
 cert-file = /etc/ssl/certs/ssl-cert-snakeoil.pem
 # SSL key file
 key-file = /etc/ssl/private/ssl-cert-snakeoil.key
-# limit on how many points could be requested in one request. 1M allows 500 series at a MaxDataPoints of 2000. (0 disables limit)
-max-points-per-req = 1000000
-# max number of data points to be returned per target
-max-points-per-target = 86400
-# limit on what kind of time range can be requested in one request. the default allows 500 series of 2 years. (0 disables limit)
-max-days-per-req = 365000
+# lower resolution rollups will be used to try and keep requests below this number of datapoints. (0 disables limit)
+max-points-per-req-soft = 1000000
+# limit of number of datapoints a request can return. Requests that exceed this limit will be rejected. (0 disables limit)
+max-points-per-req-hard = 20000000
 # only log incoming requests if their timerange is at least this duration. Use 0 to disable
 log-min-dur = 5min
 

--- a/scripts/config/metrictank-docker.ini
+++ b/scripts/config/metrictank-docker.ini
@@ -130,6 +130,8 @@ cert-file = /etc/ssl/certs/ssl-cert-snakeoil.pem
 key-file = /etc/ssl/private/ssl-cert-snakeoil.key
 # limit on how many points could be requested in one request. 1M allows 500 series at a MaxDataPoints of 2000. (0 disables limit)
 max-points-per-req = 1000000
+# max number of data points to be returned per target
+max-points-per-target = 86400
 # limit on what kind of time range can be requested in one request. the default allows 500 series of 2 years. (0 disables limit)
 max-days-per-req = 365000
 # only log incoming requests if their timerange is at least this duration. Use 0 to disable

--- a/scripts/config/metrictank-package.ini
+++ b/scripts/config/metrictank-package.ini
@@ -128,12 +128,10 @@ ssl = false
 cert-file = /etc/ssl/certs/ssl-cert-snakeoil.pem
 # SSL key file
 key-file = /etc/ssl/private/ssl-cert-snakeoil.key
-# limit on how many points could be requested in one request. 1M allows 500 series at a MaxDataPoints of 2000. (0 disables limit)
-max-points-per-req = 1000000
-# max number of data points to be returned per target
-max-points-per-target = 86400
-# limit on what kind of time range can be requested in one request. the default allows 500 series of 2 years. (0 disables limit)
-max-days-per-req = 365000
+# lower resolution rollups will be used to try and keep requests below this number of datapoints. (0 disables limit)
+max-points-per-req-soft = 1000000
+# limit of number of datapoints a request can return. Requests that exceed this limit will be rejected. (0 disables limit)
+max-points-per-req-hard = 20000000
 # only log incoming requests if their timerange is at least this duration. Use 0 to disable
 log-min-dur = 5min
 

--- a/scripts/config/metrictank-package.ini
+++ b/scripts/config/metrictank-package.ini
@@ -130,6 +130,8 @@ cert-file = /etc/ssl/certs/ssl-cert-snakeoil.pem
 key-file = /etc/ssl/private/ssl-cert-snakeoil.key
 # limit on how many points could be requested in one request. 1M allows 500 series at a MaxDataPoints of 2000. (0 disables limit)
 max-points-per-req = 1000000
+# max number of data points to be returned per target
+max-points-per-target = 86400
 # limit on what kind of time range can be requested in one request. the default allows 500 series of 2 years. (0 disables limit)
 max-days-per-req = 365000
 # only log incoming requests if their timerange is at least this duration. Use 0 to disable


### PR DESCRIPTION
This can be used to limit the amount of data that gets sent out by Metrictank, to prevent the receiver from flooding it's memory when parsing the reply.

fixes #573 