### PR TITLE
use the raw interval metrics are sent at

### DIFF
--- a/api/query_engine.go
+++ b/api/query_engine.go
@@ -51,8 +51,12 @@ func alignRequests(now uint32, reqs []models.Req) ([]models.Req, error) {
 
 			req.Archive = i
 			req.TTL = uint32(ret.MaxRetention())
-			req.ArchInterval = uint32(ret.SecondsPerPoint)
-
+			if i == 0 {
+				// The first retention is raw data, so use its native interval
+				req.ArchInterval = req.RawInterval
+			} else {
+				req.ArchInterval = uint32(ret.SecondsPerPoint)
+			}
 			if now-req.TTL <= req.From {
 				break
 			}


### PR DESCRIPTION
- when the raw archive is selected, use the raw interval that the
data is sent at, rather then the archive interval defined in the
storage-schemas file