### PR TITLE
add benchmarks for msgp data responses

### DIFF
--- a/api/response/msgp_test.go
+++ b/api/response/msgp_test.go
@@ -1,0 +1,113 @@
+package response
+
+import (
+	"math"
+	"testing"
+
+	"github.com/raintank/metrictank/api/models"
+	"gopkg.in/raintank/schema.v1"
+)
+
+func BenchmarkHttpRespMsgpEmptySeries(b *testing.B) {
+	data := []models.Series{
+		{
+			Target:     "an.empty.series",
+			Datapoints: make([]schema.Point, 0),
+			Interval:   10,
+		},
+	}
+	var resp *Msgp
+	for n := 0; n < b.N; n++ {
+		resp = NewMsgp(200, models.SeriesByTarget(data))
+		resp.Body()
+		resp.Close()
+	}
+}
+
+func BenchmarkHttpRespMsgpEmptySeriesNeedsEscaping(b *testing.B) {
+	data := []models.Series{
+		{
+			Target:     `an.empty\series`,
+			Datapoints: make([]schema.Point, 0),
+			Interval:   10,
+		},
+	}
+	var resp *Msgp
+	for n := 0; n < b.N; n++ {
+		resp = NewMsgp(200, models.SeriesByTarget(data))
+		resp.Body()
+		resp.Close()
+	}
+}
+
+func BenchmarkHttpRespMsgpIntegers(b *testing.B) {
+	points := make([]schema.Point, 1000, 1000)
+	baseTs := 1500000000
+	for i := 0; i < 1000; i++ {
+		points[i] = schema.Point{Val: float64(10000 * i), Ts: uint32(baseTs + 10*i)}
+	}
+	data := []models.Series{
+		{
+			Target:     "some.metric.with.a-whole-bunch-of.integers",
+			Datapoints: points,
+			Interval:   10,
+		},
+	}
+	b.SetBytes(int64(len(points) * 12))
+
+	b.ResetTimer()
+	var resp *Msgp
+	for n := 0; n < b.N; n++ {
+		resp = NewMsgp(200, models.SeriesByTarget(data))
+		resp.Body()
+		resp.Close()
+	}
+}
+
+func BenchmarkHttpRespMsgpFloats(b *testing.B) {
+	points := make([]schema.Point, 1000, 1000)
+	baseTs := 1500000000
+	for i := 0; i < 1000; i++ {
+		points[i] = schema.Point{Val: 12.34 * float64(i), Ts: uint32(baseTs + 10*i)}
+	}
+	data := []models.Series{
+		{
+			Target:     "some.metric.with.a-whole-bunch-of.floats",
+			Datapoints: points,
+			Interval:   10,
+		},
+	}
+	b.SetBytes(int64(len(points) * 12))
+
+	b.ResetTimer()
+	var resp *Msgp
+	for n := 0; n < b.N; n++ {
+		resp = NewMsgp(200, models.SeriesByTarget(data))
+		resp.Body()
+		resp.Close()
+	}
+}
+
+func BenchmarkHttpRespMsgpNulls(b *testing.B) {
+	points := make([]schema.Point, 1000, 1000)
+	baseTs := 1500000000
+	for i := 0; i < 1000; i++ {
+		points[i] = schema.Point{Val: math.NaN(), Ts: uint32(baseTs + 10*i)}
+	}
+	data := []models.Series{
+		{
+			Target:     "some.metric.with.a-whole-bunch-of.nulls",
+			Datapoints: points,
+			Interval:   10,
+		},
+	}
+	b.SetBytes(int64(len(points) * 12))
+
+	b.ResetTimer()
+	var resp *Msgp
+	for n := 0; n < b.N; n++ {
+		resp = NewMsgp(200, models.SeriesByTarget(data))
+		resp.Body()
+		resp.Close()
+	}
+}


### PR DESCRIPTION
very similar to the json/fast json ones.
except no bench for listing of metric names, just data responses
because that's all we support.
This helps in validating that msgp encoding is faster.