### PR TITLE
support multiple raw intervals per storage schema.

### DIFF
--- a/conf/aggregations.go
+++ b/conf/aggregations.go
@@ -9,16 +9,10 @@ import (
 	"github.com/alyu/configparser"
 )
 
-var DefaultAggregation = Aggregation{
-	Name:              "default",
-	Pattern:           nil,
-	XFilesFactor:      0.5,
-	AggregationMethod: []Method{Avg},
-}
-
 // Aggregations holds the aggregation definitions
 type Aggregations struct {
-	Data []Aggregation
+	Data               []Aggregation
+	DefaultAggregation Aggregation
 }
 
 type Aggregation struct {
@@ -32,6 +26,12 @@ type Aggregation struct {
 func NewAggregations() Aggregations {
 	return Aggregations{
 		Data: make([]Aggregation, 0),
+		DefaultAggregation: Aggregation{
+			Name:              "default",
+			Pattern:           regexp.MustCompile(".*"),
+			XFilesFactor:      0.5,
+			AggregationMethod: []Method{Avg},
+		},
 	}
 }
 
@@ -100,13 +100,13 @@ func (a Aggregations) Match(metric string) (uint16, Aggregation) {
 			return uint16(i), s
 		}
 	}
-	return uint16(len(a.Data)), DefaultAggregation
+	return uint16(len(a.Data)), a.DefaultAggregation
 }
 
 // Get returns the aggregation setting corresponding to the given index
 func (a Aggregations) Get(i uint16) Aggregation {
 	if i+1 > uint16(len(a.Data)) {
-		return DefaultAggregation
+		return a.DefaultAggregation
 	}
 	return a.Data[i]
 }

--- a/conf/schemas.go
+++ b/conf/schemas.go
@@ -8,20 +8,21 @@ import (
 	"strings"
 
 	"github.com/alyu/configparser"
+	"github.com/raintank/metrictank/util"
 )
 
-var DefaultSchema = Schema{
-	Name:       "default",
-	Pattern:    nil,
-	Retentions: Retentions([]Retention{NewRetentionMT(60, 3600*24*7, 120*60, 2, true)}),
+// Schemas contains schema settings
+type Schemas struct {
+	raw           []Schema
+	index         []Schema
+	DefaultSchema Schema
 }
 
-// Schemas contains schema settings
-type Schemas []Schema
+type SchemaSlice []Schema
 
-func (s Schemas) Len() int           { return len(s) }
-func (s Schemas) Swap(i, j int)      { s[i], s[j] = s[j], s[i] }
-func (s Schemas) Less(i, j int) bool { return s[i].Priority >= s[j].Priority }
+func (s SchemaSlice) Len() int           { return len(s) }
+func (s SchemaSlice) Swap(i, j int)      { s[i], s[j] = s[j], s[i] }
+func (s SchemaSlice) Less(i, j int) bool { return s[i].Priority >= s[j].Priority }
 
 // Schema represents one schema setting
 type Schema struct {
@@ -31,8 +32,40 @@ type Schema struct {
 	Priority   int64
 }
 
-func NewSchemas() []Schema {
-	return nil
+func NewSchemas(schemas []Schema) Schemas {
+	s := Schemas{
+		raw: schemas,
+		DefaultSchema: Schema{
+			Name:       "default",
+			Pattern:    regexp.MustCompile(".*"),
+			Retentions: Retentions([]Retention{NewRetentionMT(1, 3600*24*1, 600, 2, true)}), // 1s:1day:10mim:2:true
+		},
+	}
+	s.BuildIndex()
+	return s
+}
+
+func (s *Schemas) BuildIndex() {
+	s.index = make([]Schema, 0)
+	for _, schema := range s.raw {
+		for pos := range schema.Retentions {
+			s.index = append(s.index, Schema{
+				Name:       schema.Name,
+				Pattern:    schema.Pattern,
+				Retentions: schema.Retentions[pos:],
+				Priority:   schema.Priority,
+			})
+		}
+	}
+	// add the default schema
+	for pos := range s.DefaultSchema.Retentions {
+		s.index = append(s.index, Schema{
+			Name:       s.DefaultSchema.Name,
+			Pattern:    s.DefaultSchema.Pattern,
+			Retentions: s.DefaultSchema.Retentions[pos:],
+			Priority:   s.DefaultSchema.Priority,
+		})
+	}
 }
 
 // ReadSchemas reads and parses a storage-schemas.conf file and returns a sorted schemas structure
@@ -40,15 +73,15 @@ func NewSchemas() []Schema {
 func ReadSchemas(file string) (Schemas, error) {
 	config, err := configparser.Read(file)
 	if err != nil {
-		return nil, err
+		return Schemas{}, err
 	}
 
 	sections, err := config.AllSections()
 	if err != nil {
-		return nil, err
+		return Schemas{}, err
 	}
 
-	var schemas Schemas
+	var schemas []Schema
 
 	for i, sec := range sections {
 		schema := Schema{}
@@ -58,23 +91,23 @@ func ReadSchemas(file string) (Schemas, error) {
 		}
 
 		if sec.ValueOf("pattern") == "" {
-			return nil, fmt.Errorf("[%s]: empty pattern", schema.Name)
+			return Schemas{}, fmt.Errorf("[%s]: empty pattern", schema.Name)
 		}
 		schema.Pattern, err = regexp.Compile(sec.ValueOf("pattern"))
 		if err != nil {
-			return nil, fmt.Errorf("[%s]: failed to parse pattern %q: %s", schema.Name, sec.ValueOf("pattern"), err.Error())
+			return Schemas{}, fmt.Errorf("[%s]: failed to parse pattern %q: %s", schema.Name, sec.ValueOf("pattern"), err.Error())
 		}
 
 		schema.Retentions, err = ParseRetentions(sec.ValueOf("retentions"))
 		if err != nil {
-			return nil, fmt.Errorf("[%s]: failed to parse retentions %q: %s", schema.Name, sec.ValueOf("retentions"), err.Error())
+			return Schemas{}, fmt.Errorf("[%s]: failed to parse retentions %q: %s", schema.Name, sec.ValueOf("retentions"), err.Error())
 		}
 
 		p := int64(0)
 		if sec.ValueOf("priority") != "" {
 			p, err = strconv.ParseInt(sec.ValueOf("priority"), 10, 0)
 			if err != nil {
-				return nil, fmt.Errorf("Failed to parse priority %q for [%s]: %s", sec.ValueOf("priority"), schema.Name, err)
+				return Schemas{}, fmt.Errorf("Failed to parse priority %q for [%s]: %s", sec.ValueOf("priority"), schema.Name, err)
 			}
 		}
 		schema.Priority = int64(p)<<32 - int64(i) // to sort records with same priority by position in file
@@ -82,26 +115,119 @@ func ReadSchemas(file string) (Schemas, error) {
 		schemas = append(schemas, schema)
 	}
 
-	sort.Sort(schemas)
-	return schemas, nil
+	sort.Sort(SchemaSlice(schemas))
+
+	return NewSchemas(schemas), nil
 }
 
 // Match returns the correct schema setting for the given metric
 // it can always find a valid setting, because there's a default catch all
-// also returns the index of the setting, to efficiently reference it
-func (s Schemas) Match(metric string) (uint16, Schema) {
-	for i, schema := range s {
+// also returns the index of the setting, to efficiently reference it.
+//
+// A schema is just a pattern + retention policy. A retention policy is
+// just a list of retentions. The s.index slice contains a schema for each
+// sublist of an original schemas retentions. So if an original
+// schema had a retention policy of 1s:1d,1m:7d,1h:1y then 3 schemas would
+// be added to the index with same pattern as the original but retention policies
+// of "1s:1d,1m:7d,1h:1y", "1m:7d,1h:1y" and "1h:1y".
+//
+// |---------------------------------------------------------------------|
+// |     pattern 1     |        pattern 2            |    pattern 3      |
+// |---------------------------------------------------------------------|
+// |   ret0  |  ret1   |  ret0   |  ret1   |  ret2   |  ret0   |  ret1   |
+// |---------------------------------------------------------------------|
+// | schema0 | schema1 | schema2 | schema3 | schema4 | schema5 | schema6 |
+// |---------------------------------------------------------------------|
+//
+// When evaluating a match we start with the first schema in the index and
+// compare the regex pattern.
+// - If it matches we then just find the retention set with the best fit. The
+//   best fit is when the interval is >= the rawInterval (first retention) and
+//   less then the interval of the next rollup.
+// - If the pattern doesnt match, then we skip ahead to the next pattern.
+//
+// eg. from the above diagram we would compare the pattern for schame0
+//     (pattern1), if it doesnt match we will then compare the pattern of
+//     schema2 (pattern2) and if that doesnt match we would try schema5
+//     (pattern3).
+func (s Schemas) Match(metric string, interval int) (uint16, Schema) {
+	i := 0
+	for i < len(s.index) {
+		schema := s.index[i]
 		if schema.Pattern.MatchString(metric) {
-			return uint16(i), schema
+			// no interval passed,use the raw retentions.
+			// This is primarily used by the carbon input plugin.
+			if interval == 0 {
+				return uint16(i), schema
+			}
+			// search through the retentions to find the first one where
+			// the metric interval is < SecondsPerPoint of the retention.
+			// The schema is then the previous retention.
+			for j, ret := range schema.Retentions {
+				if interval < ret.SecondsPerPoint {
+					// if there are no retentions with SecondsPerPoint >= interval (j==0)
+					// then we need to use the first retention. Otherwise, the retention
+					// we want to use is the previous one.
+					if j > 0 {
+						j--
+					}
+					// the position in the index (schemaId) is the position of the schema we used for the
+					// regex match + the position of the retention.
+					pos := i + j
+					return uint16(pos), s.index[pos]
+				}
+			}
+			// no retentions found with SecondsPerPoint > interval. So lets just use the retention
+			// with the largest secondsPerPoint.
+			pos := i + len(schema.Retentions) - 1
+			return uint16(pos), s.index[pos]
 		}
+		// the next len(schema.Retentions) schemas in the index all have the
+		// same schema pattern, so we can skip over them.
+		i = i + len(schema.Retentions)
 	}
-	return uint16(len(s)), DefaultSchema
+
+	// as the DefaultSchema is in the schemas.index, this should typically never be reached.
+	// Though as the user can modify schemas.DefaultSchema we keep this for safety.
+	return uint16(len(s.index)), s.DefaultSchema
 }
 
 // Get returns the schema setting corresponding to the given index
 func (s Schemas) Get(i uint16) Schema {
-	if i+1 > uint16(len(s)) {
-		return DefaultSchema
+	if i+1 > uint16(len(s.index)) {
+		return s.DefaultSchema
 	}
-	return s[i]
+	return s.index[i]
+}
+
+// TTLs returns a slice of all TTL's seen amongst all archives of all schemas
+func (schemas Schemas) TTLs() []uint32 {
+	ttls := make(map[uint32]struct{})
+	for _, s := range schemas.raw {
+		for _, r := range s.Retentions {
+			ttls[uint32(r.MaxRetention())] = struct{}{}
+		}
+	}
+	for _, r := range schemas.DefaultSchema.Retentions {
+		ttls[uint32(r.MaxRetention())] = struct{}{}
+	}
+	var ttlSlice []uint32
+	for ttl := range ttls {
+		ttlSlice = append(ttlSlice, ttl)
+	}
+	return ttlSlice
+}
+
+// MaxChunkSpan returns the largest chunkspan seen amongst all archives of all schemas
+func (schemas Schemas) MaxChunkSpan() uint32 {
+	max := uint32(0)
+	for _, s := range schemas.raw {
+		for _, r := range s.Retentions {
+			max = util.Max(max, r.ChunkSpan)
+		}
+	}
+	for _, r := range schemas.DefaultSchema.Retentions {
+		max = util.Max(max, r.ChunkSpan)
+	}
+	return max
 }

--- a/conf/schemas_test.go
+++ b/conf/schemas_test.go
@@ -1,0 +1,166 @@
+package conf
+
+import (
+	. "github.com/smartystreets/goconvey/convey"
+	"regexp"
+	"testing"
+)
+
+func schemasForTest() Schemas {
+	return NewSchemas([]Schema{
+		{
+			Name:    "a",
+			Pattern: regexp.MustCompile("^a\\..*"),
+			Retentions: []Retention{
+				NewRetentionMT(10, 3600, 60*10, 0, true),
+				NewRetentionMT(3600, 86400, 60*60*6, 0, true),
+			},
+		},
+		{
+			Name:    "b",
+			Pattern: regexp.MustCompile("^b\\..*"),
+			Retentions: []Retention{
+				NewRetentionMT(1, 60, 60*10, 0, true),
+				NewRetentionMT(30, 120, 60*30, 0, true),
+				NewRetentionMT(600, 86400, 60*60*6, 0, true),
+			},
+		},
+		{
+			Name:    "default",
+			Pattern: regexp.MustCompile(".*"),
+			Retentions: []Retention{
+				NewRetentionMT(1, 60, 60*10, 0, true),
+				NewRetentionMT(60, 3600, 60*60*2, 0, true),
+				NewRetentionMT(600, 86400, 60*60*6, 0, true),
+				NewRetentionMT(3600, 86400*7, 60*60*6, 0, true),
+			},
+		},
+	})
+}
+
+func TestMatch(t *testing.T) {
+	schemas := schemasForTest()
+	Convey("When matching against first schema", t, func() {
+		Convey("When metric has 1s raw interval", func() {
+			id, schema := schemas.Match("a.foo", 1)
+			So(id, ShouldEqual, 0)
+			So(schema.Name, ShouldEqual, "a")
+			So(schema.Retentions[0].SecondsPerPoint, ShouldEqual, 10)
+		})
+		Convey("When metric has 10s raw interval", func() {
+			id, schema := schemas.Match("a.foo", 10)
+			So(id, ShouldEqual, 0)
+			So(schema.Name, ShouldEqual, "a")
+			So(schema.Retentions[0].SecondsPerPoint, ShouldEqual, 10)
+		})
+		Convey("When metric has 30s raw interval", func() {
+			id, schema := schemas.Match("a.foo", 30)
+			So(id, ShouldEqual, 0)
+			So(schema.Name, ShouldEqual, "a")
+			So(schema.Retentions[0].SecondsPerPoint, ShouldEqual, 10)
+		})
+		Convey("When metric has 2h raw interval", func() {
+			id, schema := schemas.Match("a.foo", 7200)
+			So(id, ShouldEqual, 1)
+			So(schema.Name, ShouldEqual, "a")
+			So(schema.Retentions[0].SecondsPerPoint, ShouldEqual, 3600)
+		})
+	})
+	Convey("When matching against second schema", t, func() {
+		Convey("When metric has 1s raw interval", func() {
+			id, schema := schemas.Match("b.foo", 1)
+			So(id, ShouldEqual, 2)
+			So(schema.Name, ShouldEqual, "b")
+			So(schema.Retentions[0].SecondsPerPoint, ShouldEqual, 1)
+		})
+		Convey("When metric has 10s raw interval", func() {
+			id, schema := schemas.Match("b.foo", 10)
+			So(id, ShouldEqual, 2)
+			So(schema.Name, ShouldEqual, "b")
+			So(schema.Retentions[0].SecondsPerPoint, ShouldEqual, 1)
+		})
+		Convey("When metric has 30s raw interval", func() {
+			id, schema := schemas.Match("b.foo", 30)
+			So(id, ShouldEqual, 3)
+			So(schema.Name, ShouldEqual, "b")
+			So(schema.Retentions[0].SecondsPerPoint, ShouldEqual, 30)
+		})
+		Convey("When metric has 2h raw interval", func() {
+			id, schema := schemas.Match("b.foo", 7200)
+			So(id, ShouldEqual, 4)
+			So(schema.Name, ShouldEqual, "b")
+			So(schema.Retentions[0].SecondsPerPoint, ShouldEqual, 600)
+		})
+	})
+	Convey("When matching against default schema", t, func() {
+		Convey("When metric has 1s raw interval", func() {
+			id, schema := schemas.Match("c.foo", 1)
+			So(id, ShouldEqual, 5)
+			So(schema.Name, ShouldEqual, "default")
+			So(schema.Retentions[0].SecondsPerPoint, ShouldEqual, 1)
+		})
+		Convey("When metric has 10s raw interval", func() {
+			id, schema := schemas.Match("c.foo", 10)
+			So(id, ShouldEqual, 5)
+			So(schema.Name, ShouldEqual, "default")
+			So(schema.Retentions[0].SecondsPerPoint, ShouldEqual, 1)
+		})
+		Convey("When metric has 30s raw interval", func() {
+			id, schema := schemas.Match("c.foo", 60)
+			So(id, ShouldEqual, 6)
+			So(schema.Name, ShouldEqual, "default")
+			So(schema.Retentions[0].SecondsPerPoint, ShouldEqual, 60)
+		})
+		Convey("When metric has 2h raw interval", func() {
+			id, schema := schemas.Match("c.foo", 7200)
+			So(id, ShouldEqual, 8)
+			So(schema.Name, ShouldEqual, "default")
+			So(schema.Retentions[0].SecondsPerPoint, ShouldEqual, 3600)
+		})
+	})
+}
+
+func TestDefaultSchema(t *testing.T) {
+	schemas := NewSchemas([]Schema{
+		{
+			Name:    "a",
+			Pattern: regexp.MustCompile("^a\\..*"),
+			Retentions: []Retention{
+				NewRetentionMT(10, 3600, 60*10, 0, true),
+				NewRetentionMT(3600, 86400, 60*60*6, 0, true),
+			},
+		},
+	})
+
+	Convey("When matching against first schema", t, func() {
+		Convey("When metric has 1s raw interval", func() {
+			id, schema := schemas.Match("a.foo", 1)
+			So(id, ShouldEqual, 0)
+			So(schema.Name, ShouldEqual, "a")
+			So(schema.Retentions[0].SecondsPerPoint, ShouldEqual, 10)
+		})
+	})
+	Convey("When series doesnt match any schema", t, func() {
+		Convey("When metric has 10s raw interval", func() {
+			id, schema := schemas.Match("d.foo", 10)
+			So(id, ShouldEqual, 2)
+			So(schema.Name, ShouldEqual, "default")
+			So(schema.Retentions[0].SecondsPerPoint, ShouldEqual, 1)
+		})
+	})
+}
+
+func TestTTLs(t *testing.T) {
+	schemas := schemasForTest()
+	Convey("When getting list of TTLS", t, func() {
+		ttls := schemas.TTLs()
+		So(len(ttls), ShouldEqual, 5)
+	})
+}
+func TestMaxChunkSpan(t *testing.T) {
+	schemas := schemasForTest()
+	Convey("When getting maxChunkSpan", t, func() {
+		max := schemas.MaxChunkSpan()
+		So(max, ShouldEqual, 60*60*6)
+	})
+}

--- a/idx/memory/memory.go
+++ b/idx/memory/memory.go
@@ -158,7 +158,7 @@ func (m *MemoryIdx) Load(defs []schema.MetricDefinition) int {
 
 func (m *MemoryIdx) add(def *schema.MetricDefinition) idx.Archive {
 	path := def.Name
-	schemaId, _ := mdata.MatchSchema(def.Name)
+	schemaId, _ := mdata.MatchSchema(def.Name, def.Interval)
 	aggId, _ := mdata.MatchAgg(def.Name)
 	archive := &idx.Archive{
 		MetricDefinition: *def,

--- a/input/carbon/intervalgetter.go
+++ b/input/carbon/intervalgetter.go
@@ -29,6 +29,6 @@ func (i IndexIntervalGetter) GetInterval(name string) int {
 	}
 	// if it's the first time we're seeing this series, do the more expensive matching
 	// note that the index will also do this matching again first time it sees the metric
-	_, schema := mdata.MatchSchema(name)
+	_, schema := mdata.MatchSchema(name, 0)
 	return schema.Retentions[0].SecondsPerPoint
 }

--- a/mdata/notifierKafka/notifierKafka.go
+++ b/mdata/notifierKafka/notifierKafka.go
@@ -17,19 +17,21 @@ import (
 )
 
 type NotifierKafka struct {
+	instance  string
 	in        chan mdata.SavedChunk
 	buf       []mdata.SavedChunk
 	wg        sync.WaitGroup
-	instance  string
-	consumer  sarama.Consumer
+	idx       idx.MetricIndex
+	metrics   mdata.Metrics
+	bPool     *util.BufferPool
 	client    sarama.Client
+	consumer  sarama.Consumer
 	producer  sarama.SyncProducer
 	offsetMgr *kafka.OffsetMgr
 	StopChan  chan int
+
 	// signal to PartitionConsumers to shutdown
 	stopConsuming chan struct{}
-	mdata.Notifier
-	bPool *util.BufferPool
 }
 
 func New(instance string, metrics mdata.Metrics, idx idx.MetricIndex) *NotifierKafka {
@@ -54,21 +56,18 @@ func New(instance string, metrics mdata.Metrics, idx idx.MetricIndex) *NotifierK
 	}
 
 	c := NotifierKafka{
+		instance:  instance,
 		in:        make(chan mdata.SavedChunk),
-		offsetMgr: offsetMgr,
+		idx:       idx,
+		metrics:   metrics,
+		bPool:     util.NewBufferPool(),
 		client:    client,
 		consumer:  consumer,
 		producer:  producer,
-		instance:  instance,
-		Notifier: mdata.Notifier{
-			Instance:             instance,
-			Metrics:              metrics,
-			CreateMissingMetrics: true,
-			Idx:                  idx,
-		},
+		offsetMgr: offsetMgr,
+
 		StopChan:      make(chan int),
 		stopConsuming: make(chan struct{}),
-		bPool:         util.NewBufferPool(),
 	}
 	c.start()
 	go c.produce()
@@ -148,7 +147,7 @@ func (c *NotifierKafka) consumePartition(topic string, partition int32, currentO
 			if mdata.LogLevel < 2 {
 				log.Debug("kafka-cluster received message: Topic %s, Partition: %d, Offset: %d, Key: %x", msg.Topic, msg.Partition, msg.Offset, msg.Key)
 			}
-			c.Handle(msg.Value)
+			mdata.Handle(c.metrics, msg.Value, c.idx)
 			currentOffset = msg.Offset
 		case <-ticker.C:
 			if err := c.offsetMgr.Commit(topic, partition, currentOffset); err != nil {
@@ -229,7 +228,7 @@ func (c *NotifierKafka) flush() {
 	payload := make([]*sarama.ProducerMessage, 0, len(c.buf))
 	var pMsg mdata.PersistMessageBatch
 	for i, msg := range c.buf {
-		def, ok := c.Idx.Get(strings.SplitN(msg.Key, "_", 2)[0])
+		def, ok := c.idx.Get(strings.SplitN(msg.Key, "_", 2)[0])
 		if !ok {
 			log.Error(3, "kafka-cluster: failed to lookup metricDef with id %s", msg.Key)
 			continue
@@ -237,8 +236,6 @@ func (c *NotifierKafka) flush() {
 		buf := bytes.NewBuffer(c.bPool.Get())
 		binary.Write(buf, binary.LittleEndian, uint8(mdata.PersistMessageBatchV1))
 		encoder := json.NewEncoder(buf)
-		c.buf[i].Name = def.Name
-		c.buf[i].Interval = def.Interval
 		pMsg = mdata.PersistMessageBatch{Instance: c.instance, SavedChunks: c.buf[i : i+1]}
 		err := encoder.Encode(&pMsg)
 		if err != nil {

--- a/mdata/notifierNsq/notifierNsq.go
+++ b/mdata/notifierNsq/notifierNsq.go
@@ -26,7 +26,6 @@ type NotifierNSQ struct {
 	buf      []mdata.SavedChunk
 	instance string
 	mdata.Notifier
-	idx idx.MetricIndex
 }
 
 func New(instance string, metrics mdata.Metrics, idx idx.MetricIndex) *NotifierNSQ {
@@ -57,8 +56,8 @@ func New(instance string, metrics mdata.Metrics, idx idx.MetricIndex) *NotifierN
 		Notifier: mdata.Notifier{
 			Instance: instance,
 			Metrics:  metrics,
+			Idx:      idx,
 		},
-		idx: idx,
 	}
 	consumer.AddConcurrentHandlers(c, 2)
 
@@ -82,7 +81,7 @@ func (c *NotifierNSQ) HandleMessage(m *nsq.Message) error {
 }
 
 func (c *NotifierNSQ) Send(sc mdata.SavedChunk) {
-	def, ok := c.idx.Get(strings.SplitN(sc.Key, "_", 2)[0])
+	def, ok := c.Idx.Get(strings.SplitN(sc.Key, "_", 2)[0])
 	if !ok {
 		log.Error(3, "nsq-cluster: failed to lookup metricDef with id %s", sc.Key)
 		return

--- a/mdata/notifierNsq/notifierNsq.go
+++ b/mdata/notifierNsq/notifierNsq.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"encoding/binary"
 	"encoding/json"
-	"strings"
 	"time"
 
 	"github.com/bitly/go-hostpool"
@@ -22,10 +21,11 @@ var (
 )
 
 type NotifierNSQ struct {
+	instance string
 	in       chan mdata.SavedChunk
 	buf      []mdata.SavedChunk
-	instance string
-	mdata.Notifier
+	metrics  mdata.Metrics
+	idx      idx.MetricIndex
 }
 
 func New(instance string, metrics mdata.Metrics, idx idx.MetricIndex) *NotifierNSQ {
@@ -51,13 +51,10 @@ func New(instance string, metrics mdata.Metrics, idx idx.MetricIndex) *NotifierN
 		log.Fatal(4, "nsq-cluster failed to create NSQ consumer. %s", err)
 	}
 	c := &NotifierNSQ{
-		in:       make(chan mdata.SavedChunk),
 		instance: instance,
-		Notifier: mdata.Notifier{
-			Instance: instance,
-			Metrics:  metrics,
-			Idx:      idx,
-		},
+		in:       make(chan mdata.SavedChunk),
+		metrics:  metrics,
+		idx:      idx,
 	}
 	consumer.AddConcurrentHandlers(c, 2)
 
@@ -76,17 +73,11 @@ func New(instance string, metrics mdata.Metrics, idx idx.MetricIndex) *NotifierN
 }
 
 func (c *NotifierNSQ) HandleMessage(m *nsq.Message) error {
-	c.Handle(m.Body)
+	mdata.Handle(c.metrics, m.Body, c.idx)
 	return nil
 }
 
 func (c *NotifierNSQ) Send(sc mdata.SavedChunk) {
-	def, ok := c.Idx.Get(strings.SplitN(sc.Key, "_", 2)[0])
-	if !ok {
-		log.Error(3, "nsq-cluster: failed to lookup metricDef with id %s", sc.Key)
-		return
-	}
-	sc.Name = def.Name
 	c.in <- sc
 }
 


### PR DESCRIPTION
- closes #579
- expand storage schemas into all permutations of the retentions.
eg, a schema with
        retentions=1s:1d,1min:7d,10min:30day
 becomes 3 schemas:
        1 - retentions=1s:1d,1min:7d,10min:30day
        2 - retentions=1min:7d,10min:30day
        3 - retentions=10min:30day
- when calling schemas.Match() pass in the series name and interval.
  We find the schema with a matching pattern and then find
  the sub-schema with the best retention fit. The best fit is when
  the metric interval is >= the rawInterval and less then the interval
  of the next rollup.
  Using our above retention policy, the following matches would occur
  interval=1s:  1s:1d,1min:7d,10min:30day
  interval=10s: 1s:1d,1min:7d,10min:30day
  interval=60s: 1min:7d,10min:30day
  interval=300s: 1min:7d,10min:30day
  interval=3600: 10min:30day