### PR TITLE
set proper exit code when tool building fails

### DIFF
--- a/scripts/build_tools.sh
+++ b/scripts/build_tools.sh
@@ -14,15 +14,20 @@ mkdir -p $BUILDDIR
 # disable cgo
 export CGO_ENABLED=0
 
+function fail () {
+	echo "Aborting due to failure." >&2
+	exit 2
+}
+
 # Build binary
 cd $GOPATH/src/github.com/raintank/metrictank/cmd
 for tool in *; do
   cd $tool
   if [ "$1" == "-race" ]
   then
-    CGO_ENABLED=1 go build -race -ldflags "-X main.GitHash=$GITVERSION" -o $BUILDDIR/$tool
+    CGO_ENABLED=1 go build -race -ldflags "-X main.GitHash=$GITVERSION" -o $BUILDDIR/$tool || fail
   else
-    go build -ldflags "-X main.GitHash=$GITVERSION" -o $BUILDDIR/$tool
+    go build -ldflags "-X main.GitHash=$GITVERSION" -o $BUILDDIR/$tool || fail
   fi
   cd ..
 done


### PR DESCRIPTION
previously it would just skip failing tool builds and proceed,
and exit(0).
Now it will block the CI flow and make the failure more obvious.