### PR TITLE
ensure nodes can only connect to clusters with the same clusterName

### DIFF
--- a/api/cluster.go
+++ b/api/cluster.go
@@ -44,8 +44,9 @@ func (s *Server) appStatus(ctx *middleware.Context) {
 
 func (s *Server) getClusterStatus(ctx *middleware.Context) {
 	status := models.ClusterStatus{
-		NodeName: cluster.Manager.ThisNode().Name,
-		Members:  cluster.Manager.MemberList(),
+		ClusterName: cluster.ClusterName,
+		NodeName:    cluster.Manager.ThisNode().Name,
+		Members:     cluster.Manager.MemberList(),
 	}
 	response.Write(ctx, response.NewJson(200, status, ""))
 }

--- a/api/models/node.go
+++ b/api/models/node.go
@@ -9,8 +9,9 @@ type NodeStatus struct {
 }
 
 type ClusterStatus struct {
-	NodeName string         `json:"nodeName"`
-	Members  []cluster.Node `json:"members"`
+	ClusterName string         `json:"clusterName"`
+	NodeName    string         `json:"nodeName"`
+	Members     []cluster.Node `json:"members"`
 }
 
 type IndexList struct {

--- a/cluster/cluster.go
+++ b/cluster/cluster.go
@@ -1,6 +1,7 @@
 package cluster
 
 import (
+	"crypto/sha256"
 	"math/rand"
 	"strings"
 	"time"
@@ -55,6 +56,9 @@ func Init(name, version string, started time.Time, apiScheme string, apiPort int
 	cfg.AdvertisePort = clusterPort
 	cfg.Events = Manager
 	cfg.Delegate = Manager
+	h := sha256.New()
+	h.Write([]byte(ClusterName))
+	cfg.SecretKey = h.Sum(nil)
 }
 
 func Stop() {

--- a/cluster/config.go
+++ b/cluster/config.go
@@ -12,6 +12,7 @@ import (
 )
 
 var (
+	ClusterName     string
 	primary         bool
 	peersStr        string
 	mode            string
@@ -26,6 +27,7 @@ var (
 
 func ConfigSetup() {
 	clusterCfg := flag.NewFlagSet("cluster", flag.ExitOnError)
+	clusterCfg.StringVar(&ClusterName, "name", "metrictank", "Unique name of the cluster.")
 	clusterCfg.BoolVar(&primary, "primary-node", false, "the primary node writes data to cassandra. There should only be 1 primary node per shardGroup.")
 	clusterCfg.StringVar(&clusterBindAddr, "bind-addr", "0.0.0.0:7946", "TCP Address to listen on for cluster communication")
 	clusterCfg.StringVar(&peersStr, "peers", "", "TCP addresses of other nodes, comma separated. use this if you shard your data and want to query other instances")

--- a/docker/docker-cluster/metrictank.ini
+++ b/docker/docker-cluster/metrictank.ini
@@ -177,6 +177,8 @@ net-max-open-requests = 100
 
 ## basic clustering settings ##
 [cluster]
+# Unique name of the cluster.  This node will only be able to join clusters with the same name.
+name = metrictank
 # The primary node writes data to cassandra. There should only be 1 primary node per shardGroup.
 primary-node = true
 # maximum priority before a node should be considered not-ready.

--- a/docker/docker-dev-custom-cfg-kafka/metrictank.ini
+++ b/docker/docker-dev-custom-cfg-kafka/metrictank.ini
@@ -177,6 +177,8 @@ net-max-open-requests = 100
 
 ## basic clustering settings ##
 [cluster]
+# Unique name of the cluster.  This node will only be able to join clusters with the same name.
+name = metrictank
 # The primary node writes data to cassandra. There should only be 1 primary node per shardGroup.
 primary-node = true
 # maximum priority before a node should be considered not-ready.

--- a/docs/config.md
+++ b/docs/config.md
@@ -226,6 +226,8 @@ net-max-open-requests = 100
 
 ```
 [cluster]
+# Unique name of the cluster.  This node will only be able to join clusters with the same name.
+name = metrictank
 # The primary node writes data to cassandra. There should only be 1 primary node per shardGroup.
 primary-node = true
 # maximum priority before a node should be considered not-ready.

--- a/metrictank-sample.ini
+++ b/metrictank-sample.ini
@@ -180,6 +180,8 @@ net-max-open-requests = 100
 
 ## basic clustering settings ##
 [cluster]
+# Unique name of the cluster.  This node will only be able to join clusters with the same name.
+name = metrictank
 # The primary node writes data to cassandra. There should only be 1 primary node per shardGroup.
 primary-node = true
 # maximum priority before a node should be considered not-ready.

--- a/scripts/config/metrictank-docker.ini
+++ b/scripts/config/metrictank-docker.ini
@@ -177,6 +177,8 @@ net-max-open-requests = 100
 
 ## basic clustering settings ##
 [cluster]
+# Unique name of the cluster.  This node will only be able to join clusters with the same name.
+name = metrictank
 # The primary node writes data to cassandra. There should only be 1 primary node per shardGroup.
 primary-node = true
 # maximum priority before a node should be considered not-ready.

--- a/scripts/config/metrictank-package.ini
+++ b/scripts/config/metrictank-package.ini
@@ -177,6 +177,8 @@ net-max-open-requests = 100
 
 ## basic clustering settings ##
 [cluster]
+# Unique name of the cluster.  This node will only be able to join clusters with the same name.
+name = metrictank
 # The primary node writes data to cassandra. There should only be 1 primary node per shardGroup.
 primary-node = true
 # maximum priority before a node should be considered not-ready.


### PR DESCRIPTION
- fixes #596
- add cluster "name" setting to the config
- use the clusterName as the security key with memberlist. This
  will prevent nodes from other clusters from connecting.
- expose the cluster name in the /cluster api method.