### PR TITLE
fix mt-schemas-explain

### DIFF
--- a/cmd/mt-schemas-explain/main.go
+++ b/cmd/mt-schemas-explain/main.go
@@ -49,7 +49,7 @@ func main() {
 		log.Fatalf("can't read schemas file %q: %s", schemasFile, err.Error())
 	}
 
-	for _, schema := range schemas {
+	for _, schema := range schemas.List() {
 		fmt.Println("#", schema.Name)
 		fmt.Printf("pattern:   %10s\n", schema.Pattern)
 		fmt.Printf("priority:  %10d\n", schema.Priority)

--- a/conf/schemas.go
+++ b/conf/schemas.go
@@ -45,6 +45,10 @@ func NewSchemas(schemas []Schema) Schemas {
 	return s
 }
 
+func (s Schemas) List() []Schema {
+	return s.raw
+}
+
 func (s *Schemas) BuildIndex() {
 	s.index = make([]Schema, 0)
 	for _, schema := range s.raw {


### PR DESCRIPTION
conf.Schemas is no longer a slice.
- added a Schemas.List() method to return the list of schemas read
  from the config.