### PR TITLE
Improve the performance of memory index find

### DIFF
--- a/idx/memory/memory.go
+++ b/idx/memory/memory.go
@@ -427,7 +427,7 @@ func (m *MemoryIdx) find(orgId int, pattern string) ([]*Node, error) {
 		}
 	}
 
-	log.Debug("memory-idx: reached pattern length. %d nodes matched", pos, len(children))
+	log.Debug("memory-idx: reached pattern length. %d nodes matched", len(children))
 	for _, c := range children {
 		results = append(results, c)
 	}

--- a/idx/memory/memory.go
+++ b/idx/memory/memory.go
@@ -340,10 +340,10 @@ func (m *MemoryIdx) find(orgId int, pattern string) ([]*Node, error) {
 
 	nodes := strings.Split(pattern, ".")
 
-	// pos is the index of the last node we know for sure
-	// for a query like foo.bar.baz, pos is 2
-	// for a query like foo.bar.* or foo.bar, pos is 1
-	// for a query like foo.b*.baz, pos is 0
+	// pos is the index of the first node with special chars, or one past the last node if exact
+	// for a query like foo.bar.baz, pos is 3
+	// for a query like foo.bar.* or foo.bar, pos is 2
+	// for a query like foo.b*.baz, pos is 1
 	pos := len(nodes)
 	for i := 0; i < len(nodes); i++ {
 		if strings.ContainsAny(nodes[i], "*{}[]?") {

--- a/idx/memory/memory.go
+++ b/idx/memory/memory.go
@@ -639,7 +639,7 @@ func getMatcher(path string) (func([]string) []string, error) {
 		}, nil
 	}
 
-	// Match a particular value
+	// Exact match one or more values
 	return func(children []string) []string {
 		var results []string
 		for _, p := range patterns {

--- a/idx/memory/memory.go
+++ b/idx/memory/memory.go
@@ -606,19 +606,33 @@ func getMatcher(path string) (func([]string) []string, error) {
 		}, nil
 	}
 
+	var patterns []string
+	if strings.ContainsAny(path, "{}") {
+		patterns = expandQueries(path)
+	} else {
+		patterns = []string{path}
+	}
+
 	// Convert to regex and match
-	if strings.ContainsAny(path, "*{}[]?") {
-		r, err := regexp.Compile(toRegexp(path))
-		if err != nil {
-			log.Debug("memory-idx: regexp failed to compile. %s - %s", path, err)
-			return nil, err
+	if strings.ContainsAny(path, "*[]?") {
+		regexes := make([]*regexp.Regexp, 0, len(patterns))
+		for _, p := range patterns {
+			r, err := regexp.Compile(toRegexp(p))
+			if err != nil {
+				log.Debug("memory-idx: regexp failed to compile. %s - %s", p, err)
+				return nil, err
+			}
+			regexes = append(regexes, r)
 		}
+
 		return func(children []string) []string {
-			matches := make([]string, 0)
-			for _, c := range children {
-				if r.MatchString(c) {
-					log.Debug("memory-idx: %s regex matches %s", c, r.String())
-					matches = append(matches, c)
+			var matches []string
+			for _, r := range regexes {
+				for _, c := range children {
+					if r.MatchString(c) {
+						log.Debug("memory-idx: %s =~ %s", c, r.String())
+						matches = append(matches, c)
+					}
 				}
 			}
 			return matches
@@ -627,43 +641,62 @@ func getMatcher(path string) (func([]string) []string, error) {
 
 	// Match a particular value
 	return func(children []string) []string {
-		for _, c := range children {
-			if c == path {
-				log.Debug("memory-idx: %s matches %s", c, path)
-				return []string{c}
+		var results []string
+		for _, p := range patterns {
+			for _, c := range children {
+				if c == p {
+					log.Debug("memory-idx: %s matches %s", c, p)
+					results = append(results, c)
+					break
+				}
 			}
 		}
-		return []string{}
+		return results
 	}, nil
 }
 
-func toRegexp(pattern string) string {
+// We don't use filepath.Match as it doesn't support {} because that's not posix, it's a bashism
+// the easiest way of implementing this extra feature is just expanding single queries
+// that contain these queries into multiple queries, which will be checked separately
+// and the results of which will be ORed.
+func expandQueries(query string) []string {
+	queries := []string{query}
+
 	// as long as we find a { followed by a }, split it up into subqueries, and process
 	// all queries again
 	// we only stop once there are no more queries that still have {..} in them
-	p := pattern
+	keepLooking := true
+	for keepLooking {
+		expanded := make([]string, 0)
+		keepLooking = false
+		for _, query := range queries {
+			lbrace := strings.Index(query, "{")
+			rbrace := -1
+			if lbrace > -1 {
+				rbrace = strings.Index(query[lbrace:], "}")
+				if rbrace > -1 {
+					rbrace += lbrace
+				}
+			}
 
-	pos := 0
-	for pos < len(p) {
-
-		lbrace := strings.Index(p[pos:], "{")
-		rbrace := -1
-		if lbrace > -1 {
-			lbrace += pos
-			rbrace = strings.Index(p[lbrace:], "}")
-			if rbrace > -1 {
-				rbrace += lbrace
+			if lbrace > -1 && rbrace > -1 {
+				keepLooking = true
+				expansion := query[lbrace+1 : rbrace]
+				options := strings.Split(expansion, ",")
+				for _, option := range options {
+					expanded = append(expanded, query[:lbrace]+option+query[rbrace+1:])
+				}
+			} else {
+				expanded = append(expanded, query)
 			}
 		}
-
-		if lbrace == -1 || rbrace == -1 {
-			break
-		}
-		p = p[:lbrace] + "(" + strings.Replace(p[lbrace+1:rbrace], ",", "|", -1) + ")" + p[rbrace+1:]
-		pos = rbrace + 1
-
+		queries = expanded
 	}
+	return queries
+}
 
+func toRegexp(pattern string) string {
+	p := pattern
 	p = strings.Replace(p, "*", ".*", -1)
 	p = strings.Replace(p, "?", ".?", -1)
 	p = "^" + p + "$"

--- a/idx/memory/memory.go
+++ b/idx/memory/memory.go
@@ -399,7 +399,7 @@ func (m *MemoryIdx) find(orgId int, pattern string) ([]*Node, error) {
 					}
 				}
 			} else if (matchAll) {
-				log.Debug("Matching all children")
+				log.Debug("memory-idx: Matching all children")
 				for _, c := range c.Children {
 					matches = append(matches, c)
 				}

--- a/idx/memory/memory.go
+++ b/idx/memory/memory.go
@@ -371,15 +371,10 @@ func (m *MemoryIdx) find(orgId int, pattern string) ([]*Node, error) {
 	for i := pos; i < len(nodes); i++ {
 		p := nodes[i]
 
-		matchAll := "*" == p
-		var regex *regexp.Regexp
-		if !matchAll && strings.ContainsAny(nodes[i], "*{}[]?") {
-			r, err := regexp.Compile(toRegexp(p))
-			if err != nil {
-				log.Debug("memory-idx: regexp failed to compile. %s - %s", p, err)
-				return nil, err
-			}
-			regex = r
+		matcher, err := getMatcher(p)
+
+		if err != nil {
+			return nil, err
 		}
 
 		grandChildren := make([]*Node, 0)
@@ -390,28 +385,7 @@ func (m *MemoryIdx) find(orgId int, pattern string) ([]*Node, error) {
 				continue
 			}
 			log.Debug("memory-idx: searching %d children of %s that match %s", len(c.Children), c.Path, nodes[i])
-			matches := make([]string, 0)
-			if regex != nil {
-				for _, c := range c.Children {
-					if regex.MatchString(c) {
-						log.Debug("memory-idx: %s regex matches %s", c, regex.String())
-						matches = append(matches, c)
-					}
-				}
-			} else if (matchAll) {
-				log.Debug("memory-idx: Matching all children")
-				for _, c := range c.Children {
-					matches = append(matches, c)
-				}
-			} else {
-				for _, c := range c.Children {
-					if c == p {
-						log.Debug("memory-idx: %s matches %s", c, p)
-						matches = append(matches, c)
-						break
-					}
-				}
-			}
+			matches := matcher(c.Children)
 			for _, m := range matches {
 				newBranch := c.Path + "." + m
 				if c.Path == "" {
@@ -621,6 +595,46 @@ func (m *MemoryIdx) Prune(orgId int, oldest time.Time) ([]idx.Archive, error) {
 	}
 	statPruneDuration.Value(time.Since(pre))
 	return pruned, nil
+}
+
+func getMatcher(path string) (func([]string) []string, error) {
+	// Matches everything
+	if path == "*" {
+		return func(children []string) []string {
+			log.Debug("memory-idx: Matching all children")
+			return children
+		}, nil
+	}
+
+	// Convert to regex and match
+	if strings.ContainsAny(path, "*{}[]?") {
+		r, err := regexp.Compile(toRegexp(path))
+		if err != nil {
+			log.Debug("memory-idx: regexp failed to compile. %s - %s", path, err)
+			return nil, err
+		}
+		return func(children []string) []string {
+			matches := make([]string, 0)
+			for _, c := range children {
+				if r.MatchString(c) {
+					log.Debug("memory-idx: %s regex matches %s", c, r.String())
+					matches = append(matches, c)
+				}
+			}
+			return matches
+		}, nil
+	}
+
+	// Match a particular value
+	return func(children []string) []string {
+		for _, c := range children {
+			if c == path {
+				log.Debug("memory-idx: %s matches %s", c, path)
+				return []string{c}
+			}
+		}
+		return []string{}
+	}, nil
 }
 
 func toRegexp(pattern string) string {

--- a/idx/memory/memory_find_test.go
+++ b/idx/memory/memory_find_test.go
@@ -131,6 +131,8 @@ func Init() {
 		{Pattern: "*.dc3.host960.cpu.1.*", ExpectedResults: 8},
 		{Pattern: "*.dc3.host96{1,3}.cpu.1.*", ExpectedResults: 16},
 		{Pattern: "*.dc3.{host,server}96{1,3}.cpu.1.*", ExpectedResults: 16},
+
+		{Pattern: "*.dc3.{host,server}9[6-9]{1,3}.cpu.1.*", ExpectedResults: 64},
 	}
 }
 


### PR DESCRIPTION
I am testing out metrictank for usage with some timeseries with high cardinality nodes. I noticed that this caused some find operations to really lag.

I decided to look through the code to see if there was a way to speed up the find behavior. I noticed a couple of things that looked like they could be adjusted:
1. Different code path for {a,b,c} lists versus other special chars. I turned these into (a|b|c) to simplify the code flow. This did not really change the performance of the benchmarks
2. Break loop early when doing exact string match. No need to continue looking for matches and adding nodes at that point.
3. Compile the regex once for all queued children. This means that even if we have 100k children queued up in the BFS, we only compile the regex once, instead of once per child node.
4. Special case '*' and avoid regex altogether. This ended up being a pretty huge improvement.


*WARNING* : I have never written go before, so this PR might need some extra attention. For instance, I initially created an interface to simplify the code (Matcher, with RegexMatcher, ExactMatcher and AllMatcher). Turns out whatever I did just made it WAAAY slower. I still liked the code that way, but I think it needs a go experts eye to help adjust that.

Benchmarks on a 2-core 12GB RAM ubuntu-16.04 VM (dedicated):
```
benchmark                      old ns/op     new ns/op     delta
BenchmarkFind-2                257933        148660        -42.36%
BenchmarkConcurrent4Find-2     144912        87049         -39.93%
BenchmarkConcurrent8Find-2     128865        83874         -34.91%

benchmark                      old allocs     new allocs     delta
BenchmarkFind-2                1110           658            -40.72%
BenchmarkConcurrent4Find-2     1111           658            -40.77%
BenchmarkConcurrent8Find-2     1111           658            -40.77%

benchmark                      old bytes     new bytes     delta
BenchmarkFind-2                55552         30501         -45.09%
BenchmarkConcurrent4Find-2     55601         30500         -45.14%
BenchmarkConcurrent8Find-2     55618         30493         -45.17%
```

And on my 8-core mac (running bunches of other things)
```
benchmark                      old ns/op     new ns/op     delta
BenchmarkFind-8                181536        108696        -40.12%
BenchmarkConcurrent4Find-8     73666         45098         -38.78%
BenchmarkConcurrent8Find-8     66373         51848         -21.88%

benchmark                      old allocs     new allocs     delta
BenchmarkFind-8                1111           658            -40.77%
BenchmarkConcurrent4Find-8     1111           658            -40.77%
BenchmarkConcurrent8Find-8     1111           658            -40.77%

benchmark                      old bytes     new bytes     delta
BenchmarkFind-8                55620         30502         -45.16%
BenchmarkConcurrent4Find-8     55621         30497         -45.17%
BenchmarkConcurrent8Find-8     55628         30495         -45.18%
```