### PR TITLE
Allow copy/pasta for cassandra config

### DIFF
--- a/docs/cassandra.md
+++ b/docs/cassandra.md
@@ -54,14 +54,14 @@ These settings are good for development and geared towards Cassandra 3.0
 For clustered scenarios, you may want to initialize Cassandra yourself with a schema like:
 
 ```
-CREATE KEYSPACE IF NOT EXISTS metrictank WITH replication = {'class': 'NetworkTopologyStrategy', 'us-central1': '3'}  AND durable_writes = true;
+CREATE KEYSPACE IF NOT EXISTS metrictank WITH replication = {'class': 'NetworkTopologyStrategy', 'DC1': '3'}  AND durable_writes = true;
 
 CREATE TABLE IF NOT EXISTS metrictank.metric (
     key ascii,
     ts int,
     data blob,
     PRIMARY KEY (key, ts)
-) WITH WITH CLUSTERING ORDER BY (ts DESC)
+) WITH CLUSTERING ORDER BY (ts DESC)
     AND compaction = {'class': 'org.apache.cassandra.db.compaction.TimeWindowCompactionStrategy'}
     AND compression = {'sstable_compression': 'org.apache.cassandra.io.compress.LZ4Compressor'};
 


### PR DESCRIPTION
Fix duplicate word so command doesn't fail on copy paste. Also change datacenter to the cassandra default, for test setup ease.