### PR TITLE
make function non-anonymous for clearer display in profiles

### DIFF
--- a/api/init.go
+++ b/api/init.go
@@ -7,15 +7,19 @@ import (
 	"gopkg.in/raintank/schema.v1"
 )
 
+// default size is probably bigger than what most responses need, but it saves [re]allocations
+// also it's possible that occasionnally more size is needed, causing a realloc of underlying array, and that extra space will stick around until next GC run.
 const defaultPointSliceSize = 2000
 
 var pointSlicePool sync.Pool
 
+func pointSlicePoolAllocNew() interface{} {
+	return make([]schema.Point, 0, defaultPointSliceSize)
+}
+
 func init() {
 	pointSlicePool = sync.Pool{
-		// default size is probably bigger than what most responses need, but it saves [re]allocations
-		// also it's possible that occasionnally more size is needed, causing a realloc of underlying array, and that extra space will stick around until next GC run.
-		New: func() interface{} { return make([]schema.Point, 0, defaultPointSliceSize) },
+		New: pointSlicePoolAllocNew,
 	}
 	expr.Pool(&pointSlicePool)
 }


### PR DESCRIPTION
before:
 `2161.15MB 14.91% 46.70%  2161.65MB 14.92%
 github.com/raintank/metrictank/api.init.2.func1`

after:
 `5139.31MB 23.00% 23.00%  5143.81MB 23.02% 
 github.com/raintank/metrictank/api.pointSlicePoolAllocNew`

note that assigning the func to a var like below did not cut it:
```
pointSlicePoolAllocNew := func() interface{} { return make([]schema.Point, 0, defaultPointSliceSize) }
pointSlicePool = sync.Pool{
  New: pointSlicePoolAllocNew,
}
```