### PR TITLE
Fix panic when failing to lookup a branch

### DIFF
--- a/idx/memory/memory.go
+++ b/idx/memory/memory.go
@@ -401,7 +401,12 @@ func (m *MemoryIdx) find(orgId int, pattern string) ([]*Node, error) {
 				if c.Path == "" {
 					newBranch = m
 				}
-				grandChildren = append(grandChildren, tree.Items[newBranch])
+				nextNode, ok := tree.Items[newBranch]
+				if !ok {
+					log.Warn("memory-idx: tried to traverse non-existent branch '%s'", newBranch)
+					continue
+				}
+				grandChildren = append(grandChildren, nextNode)
 			}
 		}
 		children = grandChildren

--- a/idx/memory/memory_test.go
+++ b/idx/memory/memory_test.go
@@ -118,7 +118,10 @@ func TestFind(t *testing.T) {
 		s.Time = 1 * 86400
 		ix.AddOrUpdate(s, 1)
 	}
-
+	for _, s := range getMetricData(2, 2, 5, 10, ".blank.metric.foo") {
+		s.Time = 1 * 86400
+		ix.AddOrUpdate(s, 1)
+	}
 	Convey("When listing root nodes", t, func() {
 		Convey("root nodes for orgId 1", func() {
 			nodes, err := ix.Find(1, "*", 0)


### PR DESCRIPTION
This is a simple workaround fix for #668 

As I noted in the issue, the issue comes from failing to lookup a branch that we formulate.

The side effect here is that metrics with a '.' prefixing them will become unfindable. Better than crashing, but Perhaps just rejecting them up front is better. Either way, this defensive behavior seems reasonable to me.