### PR TITLE
allow target[]=foo specification

### DIFF
--- a/api/graphite.go
+++ b/api/graphite.go
@@ -177,6 +177,11 @@ func (s *Server) renderMetrics(ctx *middleware.Context, request models.GraphiteR
 	fromUnix += 1
 	toUnix += 1
 
+	// note: the model is already validated to assure at least one of them has len >0
+	if len(request.Targets) == 0 {
+		request.Targets = request.TargetsRails
+	}
+
 	exprs, err := expr.ParseMany(request.Targets)
 	if err != nil {
 		ctx.Error(http.StatusBadRequest, err.Error())

--- a/api/models/graphite.go
+++ b/api/models/graphite.go
@@ -13,7 +13,8 @@ import (
 
 type GraphiteRender struct {
 	MaxDataPoints uint32   `json:"maxDataPoints" form:"maxDataPoints" binding:"Default(800)"`
-	Targets       []string `json:"target" form:"target" binding:"Required"`
+	Targets       []string `json:"target" form:"target"`
+	TargetsRails  []string `form:"target[]"` // # Rails/PHP/jQuery common practice format: ?target[]=path.1&target[]=path.2 -> like graphite, we allow this.
 	From          string   `json:"from" form:"from"`
 	Until         string   `json:"until" form:"until"`
 	To            string   `json:"to" form:"to"`
@@ -24,21 +25,24 @@ type GraphiteRender struct {
 }
 
 func (gr GraphiteRender) Validate(ctx *macaron.Context, errs binding.Errors) binding.Errors {
-	if len(gr.Targets) < 1 {
-		errs = append(errs, binding.Error{
-			FieldNames:     []string{"target"},
-			Classification: "RequiredError",
-			Message:        "Required",
-		})
-	} else {
-		for _, val := range gr.Targets {
-			if val == "" {
-				errs = append(errs, binding.Error{
-					FieldNames:     []string{"target"},
-					Classification: "RequiredError",
-					Message:        "Required",
-				})
-			}
+	if len(gr.Targets) == 0 {
+		if len(gr.TargetsRails) == 0 {
+			errs = append(errs, binding.Error{
+				FieldNames:     []string{"target"},
+				Classification: "RequiredError",
+				Message:        "Required",
+			})
+			return errs
+		}
+		gr.Targets = gr.TargetsRails
+	}
+	for _, val := range gr.Targets {
+		if val == "" {
+			errs = append(errs, binding.Error{
+				FieldNames:     []string{"target"},
+				Classification: "RequiredError",
+				Message:        "Required",
+			})
 		}
 	}
 	return errs


### PR DESCRIPTION
Rails/PHP/jQuery common practice format: target[]=path.1&target[]=path.2
Not really correct, but graphite allows it. So now we do also.