### PR TITLE
fixing some seriously badly named variable

### DIFF
--- a/mdata/cache/ccache_metric.go
+++ b/mdata/cache/ccache_metric.go
@@ -81,9 +81,9 @@ func (mc *CCacheMetric) Add(prev uint32, itergen chunk.IterGen) {
 	// this is common in a scenario where a metric continuously gets queried
 	// for a range that starts less than one chunkspan before now().
 	if prev == 0 {
-		ts, ok := mc.seekDesc(ts - 1)
+		res, ok := mc.seekDesc(ts - 1)
 		if ok {
-			prev = ts
+			prev = res
 		}
 	}
 


### PR DESCRIPTION
This doesn't change anything in the logic.
The variable name `ts` is very confusing in this block, because the outer context has another variable that's called `ts` as well.