### PR TITLE
queries should fail when shards are missing. fixes #670

### DIFF
--- a/cluster/cluster_test.go
+++ b/cluster/cluster_test.go
@@ -12,7 +12,8 @@ func TestPeersForQuery(t *testing.T) {
 	Manager.SetPartitions([]int32{1, 2})
 	Manager.SetReady()
 	Convey("when cluster in single mode", t, func() {
-		selected := MembersForQuery()
+		selected, err := MembersForQuery()
+		So(err, ShouldBeNil)
 		So(selected, ShouldHaveLength, 1)
 		So(selected[0], ShouldResemble, Manager.ThisNode())
 	})
@@ -42,7 +43,8 @@ func TestPeersForQuery(t *testing.T) {
 	}
 	Manager.Unlock()
 	Convey("when cluster in multi mode", t, func() {
-		selected := MembersForQuery()
+		selected, err := MembersForQuery()
+		So(err, ShouldBeNil)
 		So(selected, ShouldHaveLength, 2)
 		nodeNames := []string{}
 		for _, n := range selected {
@@ -56,7 +58,8 @@ func TestPeersForQuery(t *testing.T) {
 		Convey("members should be selected randomly with even distribution", func() {
 			peerCount := make(map[string]int)
 			for i := 0; i < 1000; i++ {
-				selected = MembersForQuery()
+				selected, err = MembersForQuery()
+				So(err, ShouldBeNil)
 				for _, p := range selected {
 					peerCount[p.Name]++
 				}
@@ -70,5 +73,10 @@ func TestPeersForQuery(t *testing.T) {
 			}
 		})
 	})
-
+	Convey("when shards missing", t, func() {
+		minAvailableShards = 5
+		selected, err := MembersForQuery()
+		So(err, ShouldEqual, InsufficientShardsAvailable)
+		So(selected, ShouldHaveLength, 0)
+	})
 }

--- a/cluster/config.go
+++ b/cluster/config.go
@@ -12,15 +12,16 @@ import (
 )
 
 var (
-	ClusterName     string
-	primary         bool
-	peersStr        string
-	mode            string
-	maxPrio         int
-	clusterPort     int
-	clusterHost     net.IP
-	clusterBindAddr string
-	httpTimeout     time.Duration
+	ClusterName        string
+	primary            bool
+	peersStr           string
+	mode               string
+	maxPrio            int
+	clusterPort        int
+	clusterHost        net.IP
+	clusterBindAddr    string
+	httpTimeout        time.Duration
+	minAvailableShards int
 
 	client http.Client
 )
@@ -34,6 +35,7 @@ func ConfigSetup() {
 	clusterCfg.StringVar(&mode, "mode", "single", "Operating mode of cluster. (single|multi)")
 	clusterCfg.DurationVar(&httpTimeout, "http-timeout", time.Second*60, "How long to wait before aborting http requests to cluster peers and returning a http 503 service unavailable")
 	clusterCfg.IntVar(&maxPrio, "max-priority", 10, "maximum priority before a node should be considered not-ready.")
+	clusterCfg.IntVar(&minAvailableShards, "min-available-shards", 0, "minimum number of shards that must be available for a query to be handled.")
 	globalconf.Register("cluster", clusterCfg)
 }
 

--- a/docker/docker-cluster/metrictank.ini
+++ b/docker/docker-cluster/metrictank.ini
@@ -195,6 +195,8 @@ bind-addr = 0.0.0.0:7946
 peers =
 # Operating mode of cluster. (single|multi)
 mode = single
+# minimum number of shards that must be available for a query to be handled.
+min-available-shards = 0
 # How long to wait before aborting http requests to cluster peers and returning a http 503 service unavailable
 http-timeout = 60s
 

--- a/docker/docker-dev-custom-cfg-kafka/metrictank.ini
+++ b/docker/docker-dev-custom-cfg-kafka/metrictank.ini
@@ -195,6 +195,8 @@ bind-addr = 0.0.0.0:7946
 peers =
 # Operating mode of cluster. (single|multi)
 mode = single
+# minimum number of shards that must be available for a query to be handled.
+min-available-shards = 0
 # How long to wait before aborting http requests to cluster peers and returning a http 503 service unavailable
 http-timeout = 60s
 

--- a/docs/config.md
+++ b/docs/config.md
@@ -245,6 +245,8 @@ bind-addr = 0.0.0.0:7946
 peers =
 # Operating mode of cluster. (single|multi)
 mode = single
+# minimum number of shards that must be available for a query to be handled.
+min-available-shards = 0
 # How long to wait before aborting http requests to cluster peers and returning a http 503 service unavailable
 http-timeout = 60s
 ```

--- a/metrictank-sample.ini
+++ b/metrictank-sample.ini
@@ -198,6 +198,8 @@ bind-addr = 0.0.0.0:7946
 peers =
 # Operating mode of cluster. (single|multi)
 mode = single
+# minimum number of shards that must be available for a query to be handled.
+min-available-shards = 0
 # How long to wait before aborting http requests to cluster peers and returning a http 503 service unavailable
 http-timeout = 60s
 

--- a/scripts/config/metrictank-docker.ini
+++ b/scripts/config/metrictank-docker.ini
@@ -195,6 +195,8 @@ bind-addr = 0.0.0.0:7946
 peers =
 # Operating mode of cluster. (single|multi)
 mode = single
+# minimum number of shards that must be available for a query to be handled.
+min-available-shards = 0
 # How long to wait before aborting http requests to cluster peers and returning a http 503 service unavailable
 http-timeout = 60s
 

--- a/scripts/config/metrictank-package.ini
+++ b/scripts/config/metrictank-package.ini
@@ -195,6 +195,8 @@ bind-addr = 0.0.0.0:7946
 peers =
 # Operating mode of cluster. (single|multi)
 mode = single
+# minimum number of shards that must be available for a query to be handled.
+min-available-shards = 0
 # How long to wait before aborting http requests to cluster peers and returning a http 503 service unavailable
 http-timeout = 60s
 


### PR DESCRIPTION
- adds config option for min-available-shards.  If the number of
  shards found in the cluster when processing a query is less then
  this number, then the query is aborted and a 503 error is returned.