### PR TITLE
support from/to patterns for find query

### DIFF
--- a/api/models/graphite.go
+++ b/api/models/graphite.go
@@ -11,17 +11,21 @@ import (
 	"gopkg.in/macaron.v1"
 )
 
+type FromTo struct {
+	From  string `json:"from" form:"from"`
+	Until string `json:"until" form:"until"`
+	To    string `json:"to" form:"to"` // graphite uses 'until' but we allow to alternatively cause it's shorter
+	Tz    string `json:"tz" form:"tz"`
+}
+
 type GraphiteRender struct {
+	FromTo
 	MaxDataPoints uint32   `json:"maxDataPoints" form:"maxDataPoints" binding:"Default(800)"`
 	Targets       []string `json:"target" form:"target"`
 	TargetsRails  []string `form:"target[]"` // # Rails/PHP/jQuery common practice format: ?target[]=path.1&target[]=path.2 -> like graphite, we allow this.
-	From          string   `json:"from" form:"from"`
-	Until         string   `json:"until" form:"until"`
-	To            string   `json:"to" form:"to"`
 	Format        string   `json:"format" form:"format" binding:"In(,json,msgp,pickle)"`
 	NoProxy       bool     `json:"local" form:"local"` //this is set to true by graphite-web when it passes request to cluster servers
 	Process       string   `json:"process" form:"process" binding:"In(,none,stable,any);Default(stable)"`
-	Tz            string   `json:"tz" form:"tz"`
 }
 
 func (gr GraphiteRender) Validate(ctx *macaron.Context, errs binding.Errors) binding.Errors {
@@ -49,9 +53,8 @@ func (gr GraphiteRender) Validate(ctx *macaron.Context, errs binding.Errors) bin
 }
 
 type GraphiteFind struct {
+	FromTo
 	Query  string `json:"query" form:"query" binding:"Required"`
-	From   int64  `json:"from" form:"from"`
-	Until  int64  `json:"until" form:"until"`
 	Format string `json:"format" form:"format" binding:"In(,completer,json,treejson,pickle)"`
 	Jsonp  string `json:"jsonp" form:"jsonp"`
 }


### PR DESCRIPTION
that's how Grafana queries now.
pretty much reuse the exact same logic as render

without this, find queries result in 422's when using a recent grafana, because grafana uses patterns, whereas graphite normally just supports timestamps, but we can easily reuse the same logic