### PR TITLE
add missing argument to NewCassandraStore()

### DIFF
--- a/cmd/mt-whisper-importer-writer/main.go
+++ b/cmd/mt-whisper-importer-writer/main.go
@@ -144,7 +144,7 @@ func main() {
 	cassFlags.Parse(os.Args[cassI+1 : len(os.Args)])
 	cassandra.Enabled = true
 
-	store, err := mdata.NewCassandraStore(*cassandraAddrs, *cassandraKeyspace, *cassandraConsistency, *cassandraCaPath, *cassandraUsername, *cassandraPassword, *cassandraHostSelectionPolicy, *cassandraTimeout, *cassandraReadConcurrency, *cassandraReadConcurrency, *cassandraReadQueueSize, 0, *cassandraRetries, *cqlProtocolVersion, *windowFactor, *cassandraSSL, *cassandraAuth, *cassandraHostVerification, nil)
+	store, err := mdata.NewCassandraStore(*cassandraAddrs, *cassandraKeyspace, *cassandraConsistency, *cassandraCaPath, *cassandraUsername, *cassandraPassword, *cassandraHostSelectionPolicy, *cassandraTimeout, *cassandraReadConcurrency, *cassandraReadConcurrency, *cassandraReadQueueSize, 0, *cassandraRetries, *cqlProtocolVersion, *windowFactor, 60, *cassandraSSL, *cassandraAuth, *cassandraHostVerification, nil)
 	if err != nil {
 		panic(fmt.Sprintf("Failed to initialize cassandra: %q", err))
 	}


### PR DESCRIPTION
Add missing read timeout in importer-writer. This is hard coded because it doesn't matter in the case of the `mt-whisper-importer-writer`, as it doesn't read.