### PR TITLE
trace occurency of no-datapoints and of searchForward cache bug surpress

### DIFF
--- a/api/graphite.go
+++ b/api/graphite.go
@@ -249,6 +249,16 @@ func (s *Server) renderMetrics(ctx *middleware.Context, request models.GraphiteR
 		return
 	}
 
+	noDataPoints := true
+	for _, o := range out {
+		if len(o.Datapoints) != 0 {
+			noDataPoints = false
+		}
+	}
+	if noDataPoints {
+		span.SetTag("nodatapoints", true)
+	}
+
 	switch request.Format {
 	case "msgp":
 		response.Write(ctx, response.NewMsgp(200, models.SeriesByTarget(out)))

--- a/mdata/cache/ccache.go
+++ b/mdata/cache/ccache.go
@@ -142,7 +142,7 @@ func (c *CCache) evict(target *accnt.EvictTarget) {
 }
 
 func (c *CCache) Search(ctx context.Context, metric string, from, until uint32) *CCSearchResult {
-	_, span := tracing.NewSpan(ctx, c.tracer, "CCache.Search")
+	ctx, span := tracing.NewSpan(ctx, c.tracer, "CCache.Search")
 	defer span.Finish()
 	var hit chunk.IterGen
 	var cm *CCacheMetric
@@ -165,7 +165,7 @@ func (c *CCache) Search(ctx context.Context, metric string, from, until uint32) 
 		return res
 	}
 
-	cm.Search(metric, res, from, until)
+	cm.Search(ctx, metric, res, from, until)
 	if len(res.Start) == 0 && len(res.End) == 0 {
 		span.SetTag("cache", "miss")
 		accnt.CacheMetricMiss.Inc()


### PR DESCRIPTION
note: our condition of no-datapoints is designed to match grafana