### PR TITLE
Prevent multiple keyspace creations in Cassandra

### DIFF
--- a/cmd/mt-split-metrics-by-ttl/main.go
+++ b/cmd/mt-split-metrics-by-ttl/main.go
@@ -21,6 +21,7 @@ var (
 	cassandraTimeout             = flag.Int("cassandra-timeout", 1000, "cassandra timeout in milliseconds")
 	cassandraRetries             = flag.Int("cassandra-retries", 0, "how many times to retry a query before failing it")
 	cqlProtocolVersion           = flag.Int("cql-protocol-version", 4, "cql protocol version to use")
+	cassandraCreateKeyspace      = flag.Bool("cassandra-create-keyspace", true, "enable the creation of the metrictank keyspace")
 
 	cassandraSSL              = flag.Bool("cassandra-ssl", false, "enable SSL connection to cassandra")
 	cassandraCaPath           = flag.String("cassandra-ca-path", "/etc/metrictank/ca.pem", "cassandra CA certificate path when using SSL")
@@ -68,7 +69,7 @@ func main() {
 		panic(fmt.Sprintf("Error creating directory: %s", err))
 	}
 
-	store, err := mdata.NewCassandraStore(*cassandraAddrs, *cassandraKeyspace, *cassandraConsistency, *cassandraCaPath, *cassandraUsername, *cassandraPassword, *cassandraHostSelectionPolicy, *cassandraTimeout, cassandraReadConcurrency, cassandraReadConcurrency, cassandraReadQueueSize, 0, *cassandraRetries, *cqlProtocolVersion, windowFactor, cassandraOmitReadTimeout, *cassandraSSL, *cassandraAuth, *cassandraHostVerification, ttls)
+	store, err := mdata.NewCassandraStore(*cassandraAddrs, *cassandraKeyspace, *cassandraConsistency, *cassandraCaPath, *cassandraUsername, *cassandraPassword, *cassandraHostSelectionPolicy, *cassandraTimeout, cassandraReadConcurrency, cassandraReadConcurrency, cassandraReadQueueSize, 0, *cassandraRetries, *cqlProtocolVersion, windowFactor, cassandraOmitReadTimeout, *cassandraSSL, *cassandraAuth, *cassandraHostVerification, *cassandraCreateKeyspace, ttls)
 	if err != nil {
 		panic(fmt.Sprintf("Failed to instantiate cassandra: %s", err))
 	}

--- a/cmd/mt-store-cat/main.go
+++ b/cmd/mt-store-cat/main.go
@@ -34,9 +34,9 @@ var (
 	//cassandraWriteConcurrency    = flag.Int("cassandra-write-concurrency", 10, "max number of concurrent writes to cassandra.")
 	cassandraReadQueueSize = flag.Int("cassandra-read-queue-size", 200000, "max number of outstanding reads before reads will be dropped. This is important if you run queries that result in many reads in parallel.")
 	//cassandraWriteQueueSize      = flag.Int("cassandra-write-queue-size", 100000, "write queue size per cassandra worker. should be large engough to hold all at least the total number of series expected, divided by how many workers you have")
-	cassandraRetries   = flag.Int("cassandra-retries", 0, "how many times to retry a query before failing it")
-	cqlProtocolVersion = flag.Int("cql-protocol-version", 4, "cql protocol version to use")
-	cassandraCreateKeyspace      = flag.Bool("cassandra-create-keyspace", true, "enable the creation of the metrictank keyspace")
+	cassandraRetries        = flag.Int("cassandra-retries", 0, "how many times to retry a query before failing it")
+	cqlProtocolVersion      = flag.Int("cql-protocol-version", 4, "cql protocol version to use")
+	cassandraCreateKeyspace = flag.Bool("cassandra-create-keyspace", true, "enable the creation of the metrictank keyspace")
 
 	cassandraSSL              = flag.Bool("cassandra-ssl", false, "enable SSL connection to cassandra")
 	cassandraCaPath           = flag.String("cassandra-ca-path", "/etc/metrictank/ca.pem", "cassandra CA certificate path when using SSL")

--- a/cmd/mt-store-cat/main.go
+++ b/cmd/mt-store-cat/main.go
@@ -36,6 +36,7 @@ var (
 	//cassandraWriteQueueSize      = flag.Int("cassandra-write-queue-size", 100000, "write queue size per cassandra worker. should be large engough to hold all at least the total number of series expected, divided by how many workers you have")
 	cassandraRetries   = flag.Int("cassandra-retries", 0, "how many times to retry a query before failing it")
 	cqlProtocolVersion = flag.Int("cql-protocol-version", 4, "cql protocol version to use")
+	cassandraCreateKeyspace      = flag.Bool("cassandra-create-keyspace", true, "enable the creation of the metrictank keyspace")
 
 	cassandraSSL              = flag.Bool("cassandra-ssl", false, "enable SSL connection to cassandra")
 	cassandraCaPath           = flag.String("cassandra-ca-path", "/etc/metrictank/ca.pem", "cassandra CA certificate path when using SSL")
@@ -156,7 +157,7 @@ func main() {
 		}
 	}
 
-	store, err := mdata.NewCassandraStore(*cassandraAddrs, *cassandraKeyspace, *cassandraConsistency, *cassandraCaPath, *cassandraUsername, *cassandraPassword, *cassandraHostSelectionPolicy, *cassandraTimeout, *cassandraReadConcurrency, *cassandraReadConcurrency, *cassandraReadQueueSize, 0, *cassandraRetries, *cqlProtocolVersion, *windowFactor, *cassandraOmitReadTimeout, *cassandraSSL, *cassandraAuth, *cassandraHostVerification, nil)
+	store, err := mdata.NewCassandraStore(*cassandraAddrs, *cassandraKeyspace, *cassandraConsistency, *cassandraCaPath, *cassandraUsername, *cassandraPassword, *cassandraHostSelectionPolicy, *cassandraTimeout, *cassandraReadConcurrency, *cassandraReadConcurrency, *cassandraReadQueueSize, 0, *cassandraRetries, *cqlProtocolVersion, *windowFactor, *cassandraOmitReadTimeout, *cassandraSSL, *cassandraAuth, *cassandraHostVerification, *cassandraCreateKeyspace, nil)
 	if err != nil {
 		log.Fatal(4, "failed to initialize cassandra. %s", err)
 	}

--- a/cmd/mt-whisper-importer-writer/main.go
+++ b/cmd/mt-whisper-importer-writer/main.go
@@ -82,6 +82,7 @@ var (
 	cassandraReadQueueSize       = globalFlags.Int("cassandra-read-queue-size", 100, "max number of outstanding reads before blocking. value doesn't matter much")
 	cassandraRetries             = globalFlags.Int("cassandra-retries", 0, "how many times to retry a query before failing it")
 	cqlProtocolVersion           = globalFlags.Int("cql-protocol-version", 4, "cql protocol version to use")
+	cassandraCreateKeyspace      = globalFlags.Bool("cassandra-create-keyspace", true, "enable the creation of the metrictank keyspace")
 
 	cassandraSSL              = globalFlags.Bool("cassandra-ssl", false, "enable SSL connection to cassandra")
 	cassandraCaPath           = globalFlags.String("cassandra-ca-path", "/etc/metrictank/ca.pem", "cassandra CA certificate path when using SSL")
@@ -144,7 +145,7 @@ func main() {
 	cassFlags.Parse(os.Args[cassI+1 : len(os.Args)])
 	cassandra.Enabled = true
 
-	store, err := mdata.NewCassandraStore(*cassandraAddrs, *cassandraKeyspace, *cassandraConsistency, *cassandraCaPath, *cassandraUsername, *cassandraPassword, *cassandraHostSelectionPolicy, *cassandraTimeout, *cassandraReadConcurrency, *cassandraReadConcurrency, *cassandraReadQueueSize, 0, *cassandraRetries, *cqlProtocolVersion, *windowFactor, 60, *cassandraSSL, *cassandraAuth, *cassandraHostVerification, nil)
+	store, err := mdata.NewCassandraStore(*cassandraAddrs, *cassandraKeyspace, *cassandraConsistency, *cassandraCaPath, *cassandraUsername, *cassandraPassword, *cassandraHostSelectionPolicy, *cassandraTimeout, *cassandraReadConcurrency, *cassandraReadConcurrency, *cassandraReadQueueSize, 0, *cassandraRetries, *cqlProtocolVersion, *windowFactor, 60, *cassandraSSL, *cassandraAuth, *cassandraHostVerification, *cassandraCreateKeyspace, nil)
 	if err != nil {
 		panic(fmt.Sprintf("Failed to initialize cassandra: %q", err))
 	}

--- a/docker/docker-cluster/docker-compose.yml
+++ b/docker/docker-cluster/docker-compose.yml
@@ -19,6 +19,8 @@ services:
       MT_CLUSTER_MODE: multi
       MT_CLUSTER_PRIMARY_NODE: "true"
       MT_CLUSTER_BIND_ADDR: "metrictank0:7946"
+      MT_CASSANDRA_CREATE_KEYSPACE: "true"
+      MT_CASSANDRA_IDX_CREATE_KEYSPACE: "true"
     links:
      - cassandra
 

--- a/docker/docker-cluster/metrictank.ini
+++ b/docker/docker-cluster/metrictank.ini
@@ -52,6 +52,8 @@ cassandra-write-queue-size = 100000
 cassandra-retries = 0
 # CQL protocol version. cassandra 3.x needs v3 or 4.
 cql-protocol-version = 4
+# enable the creation of the mdata keyspace and tables, only one node needs this
+cassandra-create-keyspace = true
 
 # enable SSL connection to cassandra
 cassandra-ssl = false
@@ -283,6 +285,8 @@ auth = false
 username = cassandra
 # password for authentication
 password = cassandra
+# enable the creation of the index keyspace and tables, only one node needs this
+create-keyspace = true
 
 ### in-memory only
 [memory-idx]

--- a/docker/docker-cluster/metrictank.ini
+++ b/docker/docker-cluster/metrictank.ini
@@ -53,7 +53,7 @@ cassandra-retries = 0
 # CQL protocol version. cassandra 3.x needs v3 or 4.
 cql-protocol-version = 4
 # enable the creation of the mdata keyspace and tables, only one node needs this
-cassandra-create-keyspace = true
+cassandra-create-keyspace = false
 
 # enable SSL connection to cassandra
 cassandra-ssl = false
@@ -286,7 +286,7 @@ username = cassandra
 # password for authentication
 password = cassandra
 # enable the creation of the index keyspace and tables, only one node needs this
-create-keyspace = true
+create-keyspace = false
 
 ### in-memory only
 [memory-idx]

--- a/docker/docker-dev-custom-cfg-kafka/metrictank.ini
+++ b/docker/docker-dev-custom-cfg-kafka/metrictank.ini
@@ -52,6 +52,8 @@ cassandra-write-queue-size = 100000
 cassandra-retries = 0
 # CQL protocol version. cassandra 3.x needs v3 or 4.
 cql-protocol-version = 4
+# enable the creation of the mdata keyspace and tables, only one node needs this
+cassandra-create-keyspace = true
 
 # enable SSL connection to cassandra
 cassandra-ssl = false
@@ -283,6 +285,8 @@ auth = false
 username = cassandra
 # password for authentication
 password = cassandra
+# enable the creation of the index keyspace and tables, only one node needs this
+create-keyspace = true
 
 ### in-memory only
 [memory-idx]

--- a/docker/docker-standard/docker-compose.yml
+++ b/docker/docker-standard/docker-compose.yml
@@ -8,9 +8,9 @@ services:
      - "6060:6060"
      - "2003:2003"
     environment:
-     WAIT_HOSTS: cassandra:9042
-     WAIT_TIMEOUT: 60
-     MT_HTTP_MULTI_TENANT: "false"
+      WAIT_HOSTS: cassandra:9042
+      WAIT_TIMEOUT: 60
+      MT_HTTP_MULTI_TENANT: "false"
     links:
      - cassandra
 

--- a/docs/config.md
+++ b/docs/config.md
@@ -83,6 +83,8 @@ cassandra-write-queue-size = 100000
 cassandra-retries = 0
 # CQL protocol version. cassandra 3.x needs v3 or 4.
 cql-protocol-version = 4
+# enable the creation of the mdata keyspace and tables, only one node needs this
+cassandra-create-keyspace = true
 # enable SSL connection to cassandra
 cassandra-ssl = false
 # cassandra CA certficate path when using SSL
@@ -339,6 +341,8 @@ auth = false
 username = cassandra
 # password for authentication
 password = cassandra
+# enable the creation of the index keyspace and tables, only one node needs this
+create-keyspace = true
 ```
 
 ### in-memory only

--- a/idx/cassandra/cassandra.go
+++ b/idx/cassandra/cassandra.go
@@ -67,6 +67,7 @@ var (
 	ssl              bool
 	auth             bool
 	hostverification bool
+	createKeyspace   bool
 	keyspace         string
 	hosts            string
 	capath           string
@@ -99,6 +100,7 @@ func ConfigSetup() *flag.FlagSet {
 	casIdx.DurationVar(&maxStale, "max-stale", 0, "clear series from the index if they have not been seen for this much time.")
 	casIdx.DurationVar(&pruneInterval, "prune-interval", time.Hour*3, "Interval at which the index should be checked for stale series.")
 	casIdx.IntVar(&protoVer, "protocol-version", 4, "cql protocol version to use")
+	casIdx.BoolVar(&createKeyspace, "create-keyspace", true, "set to create keyspaces otherwise check to ensure they exist")
 
 	casIdx.BoolVar(&ssl, "ssl", false, "enable SSL connection to cassandra")
 	casIdx.StringVar(&capath, "ca-path", "/etc/metrictank/ca.pem", "cassandra CA certficate path when using SSL")
@@ -167,12 +169,28 @@ func (c *CasIdx) InitBare() error {
 		return err
 	}
 
-	// ensure the keyspace and table exist.
-	err = tmpSession.Query(fmt.Sprintf(KeyspaceSchema, keyspace)).Exec()
-	if err != nil {
-		log.Error(3, "cassandra-idx failed to initialize cassandra keyspace. %s", err)
-		return err
+	// create the keyspace or ensure it exists
+	if createKeyspace {
+		err = tmpSession.Query(fmt.Sprintf(KeyspaceSchema, keyspace)).Exec()
+		if err != nil {
+			log.Error(3, "cassandra-idx failed to initialize cassandra keyspace. %s", err)
+			return err
+		}
+	} else {
+		for attempt := 1; attempt > 0; attempt++ {
+			_, err = tmpSession.KeyspaceMetadata(keyspace)
+			if err != nil {
+				log.Warn("cassandra-idx cassandra keyspace not found. retry attempt: %v", attempt)
+				if attempt > 5 {
+					return err
+				}
+				time.Sleep(5 * time.Second)
+			} else {
+				break
+			}
+		}
 	}
+	
 	err = tmpSession.Query(fmt.Sprintf(TableSchema, keyspace)).Exec()
 	if err != nil {
 		log.Error(3, "cassandra-idx failed to initialize cassandra table. %s", err)

--- a/idx/cassandra/cassandra.go
+++ b/idx/cassandra/cassandra.go
@@ -100,7 +100,7 @@ func ConfigSetup() *flag.FlagSet {
 	casIdx.DurationVar(&maxStale, "max-stale", 0, "clear series from the index if they have not been seen for this much time.")
 	casIdx.DurationVar(&pruneInterval, "prune-interval", time.Hour*3, "Interval at which the index should be checked for stale series.")
 	casIdx.IntVar(&protoVer, "protocol-version", 4, "cql protocol version to use")
-	casIdx.BoolVar(&createKeyspace, "create-keyspace", true, "set to create keyspaces otherwise check to ensure they exist")
+	casIdx.BoolVar(&createKeyspace, "create-keyspace", true, "enable the creation of the index keyspace and tables, only one node needs this")
 
 	casIdx.BoolVar(&ssl, "ssl", false, "enable SSL connection to cassandra")
 	casIdx.StringVar(&capath, "ca-path", "/etc/metrictank/ca.pem", "cassandra CA certficate path when using SSL")
@@ -187,7 +187,7 @@ func (c *CasIdx) InitBare() error {
 			keyspaceMetadata, err = tmpSession.KeyspaceMetadata(keyspace)
 			if err != nil {
 				log.Warn("cassandra-idx cassandra keyspace not found. retry attempt: %v", attempt)
-				if attempt > 5 {
+				if attempt >= 5 {
 					return err
 				}
 				time.Sleep(5 * time.Second)
@@ -196,7 +196,7 @@ func (c *CasIdx) InitBare() error {
 					break
 				} else {
 					log.Warn("cassandra-idx cassandra table not found. retry attempt: %v", attempt)
-					if attempt > 5 {
+					if attempt >= 5 {
 						return err
 					}
 					time.Sleep(5 * time.Second)

--- a/mdata/store_cassandra.go
+++ b/mdata/store_cassandra.go
@@ -166,7 +166,7 @@ func GetTTLTable(ttl uint32, windowFactor int, nameFormat string) ttlTable {
 	}
 }
 
-func NewCassandraStore(addrs, keyspace, consistency, CaPath, Username, Password, hostSelectionPolicy string, timeout, readers, writers, readqsize, writeqsize, retries, protoVer, windowFactor, omitReadTimeout int, ssl, auth, hostVerification bool, ttls []uint32) (*CassandraStore, error) {
+func NewCassandraStore(addrs, keyspace, consistency, CaPath, Username, Password, hostSelectionPolicy string, timeout, readers, writers, readqsize, writeqsize, retries, protoVer, windowFactor, omitReadTimeout int, ssl, auth, hostVerification bool, createKeyspace bool, ttls []uint32) (*CassandraStore, error) {
 
 	stats.NewGauge32("store.cassandra.write_queue.size").Set(writeqsize)
 	stats.NewGauge32("store.cassandra.num_writers").Set(writers)
@@ -193,11 +193,28 @@ func NewCassandraStore(addrs, keyspace, consistency, CaPath, Username, Password,
 	if err != nil {
 		return nil, err
 	}
-	// ensure the keyspace and table exist.
-	err = tmpSession.Query(fmt.Sprintf(keyspace_schema, keyspace)).Exec()
-	if err != nil {
-		return nil, err
-	}
+
+	// create or verify the metrictank keyspace
+	if createKeyspace {
+		err = tmpSession.Query(fmt.Sprintf(keyspace_schema, keyspace)).Exec()
+		if err != nil {
+			return nil, err
+		}
+	} else {
+		// five attempts to verify the keyspace exists before returning an error
+		for attempt := 1; attempt > 0; attempt++ {
+			_, err = tmpSession.KeyspaceMetadata(keyspace)
+			if err != nil {
+				log.Warn("cassandra keyspace not found; attempt: %v", attempt)
+				if attempt > 5 {
+					return nil, err
+				}
+				time.Sleep(5 * time.Second)
+			} else {
+				break
+			}
+		}
+	} 
 
 	ttlTables := GetTTLTables(ttls, windowFactor, Table_name_format)
 	for _, result := range ttlTables {

--- a/mdata/store_cassandra.go
+++ b/mdata/store_cassandra.go
@@ -220,7 +220,7 @@ func NewCassandraStore(addrs, keyspace, consistency, CaPath, Username, Password,
 			keyspaceMetadata, err = tmpSession.KeyspaceMetadata(keyspace)
 			if err != nil {
 				log.Warn("cassandra keyspace not found; attempt: %v", attempt)
-				if attempt > 5 {
+				if attempt >= 5 {
 					return nil, err
 				}
 				time.Sleep(5 * time.Second)
@@ -228,7 +228,7 @@ func NewCassandraStore(addrs, keyspace, consistency, CaPath, Username, Password,
 				for _, result := range ttlTables {
 					if _, ok := keyspaceMetadata.Tables[result.Table]; !ok {
 						log.Warn("cassandra table %s not found; attempt: %v", result.Table, attempt)
-						if attempt > 5 {
+						if attempt >= 5 {
 							return nil, err
 						}
 						time.Sleep(5 * time.Second)

--- a/metrictank-sample.ini
+++ b/metrictank-sample.ini
@@ -55,6 +55,8 @@ cassandra-write-queue-size = 100000
 cassandra-retries = 0
 # CQL protocol version. cassandra 3.x needs v3 or 4.
 cql-protocol-version = 4
+# enable the creation of the mdata keyspace and tables, only one node needs this
+cassandra-create-keyspace = true
 
 # enable SSL connection to cassandra
 cassandra-ssl = false
@@ -286,6 +288,8 @@ auth = false
 username = cassandra
 # password for authentication
 password = cassandra
+# sets whether to create or check for the cassandra keyspaces
+create-keyspace = true
 
 ### in-memory only
 [memory-idx]

--- a/metrictank-sample.ini
+++ b/metrictank-sample.ini
@@ -288,7 +288,7 @@ auth = false
 username = cassandra
 # password for authentication
 password = cassandra
-# sets whether to create or check for the cassandra keyspaces
+# enable the creation of the index keyspace and tables, only one node needs this
 create-keyspace = true
 
 ### in-memory only

--- a/metrictank.go
+++ b/metrictank.go
@@ -74,7 +74,7 @@ var (
 	cassandraWindowFactor        = flag.Int("cassandra-window-factor", 20, "size of compaction window relative to TTL")
 	cassandraOmitReadTimeout     = flag.Int("cassandra-omit-read-timeout", 60, "if a read is older than this, it will directly be omitted without executing")
 	cqlProtocolVersion           = flag.Int("cql-protocol-version", 4, "cql protocol version to use")
-	cassandraCreateKeyspace      = flag.Bool("cassandra-create-keyspace", true, "enable the creation of the metrictank keyspace")
+	cassandraCreateKeyspace      = flag.Bool("cassandra-create-keyspace", true, "enable the creation of the mdata keyspace and tables, only one node needs this")
 
 	cassandraSSL              = flag.Bool("cassandra-ssl", false, "enable SSL connection to cassandra")
 	cassandraCaPath           = flag.String("cassandra-ca-path", "/etc/metrictank/ca.pem", "cassandra CA certificate path when using SSL")

--- a/metrictank.go
+++ b/metrictank.go
@@ -74,6 +74,7 @@ var (
 	cassandraWindowFactor        = flag.Int("cassandra-window-factor", 20, "size of compaction window relative to TTL")
 	cassandraOmitReadTimeout     = flag.Int("cassandra-omit-read-timeout", 60, "if a read is older than this, it will directly be omitted without executing")
 	cqlProtocolVersion           = flag.Int("cql-protocol-version", 4, "cql protocol version to use")
+	cassandraCreateKeyspace      = flag.Bool("cassandra-create-keyspace", true, "enable the creation of the metrictank keyspace")
 
 	cassandraSSL              = flag.Bool("cassandra-ssl", false, "enable SSL connection to cassandra")
 	cassandraCaPath           = flag.String("cassandra-ca-path", "/etc/metrictank/ca.pem", "cassandra CA certificate path when using SSL")
@@ -256,7 +257,7 @@ func main() {
 	/***********************************
 		Initialize our backendStore
 	***********************************/
-	store, err := mdata.NewCassandraStore(*cassandraAddrs, *cassandraKeyspace, *cassandraConsistency, *cassandraCaPath, *cassandraUsername, *cassandraPassword, *cassandraHostSelectionPolicy, *cassandraTimeout, *cassandraReadConcurrency, *cassandraWriteConcurrency, *cassandraReadQueueSize, *cassandraWriteQueueSize, *cassandraRetries, *cqlProtocolVersion, *cassandraWindowFactor, *cassandraOmitReadTimeout, *cassandraSSL, *cassandraAuth, *cassandraHostVerification, mdata.TTLs())
+	store, err := mdata.NewCassandraStore(*cassandraAddrs, *cassandraKeyspace, *cassandraConsistency, *cassandraCaPath, *cassandraUsername, *cassandraPassword, *cassandraHostSelectionPolicy, *cassandraTimeout, *cassandraReadConcurrency, *cassandraWriteConcurrency, *cassandraReadQueueSize, *cassandraWriteQueueSize, *cassandraRetries, *cqlProtocolVersion, *cassandraWindowFactor, *cassandraOmitReadTimeout, *cassandraSSL, *cassandraAuth, *cassandraHostVerification, *cassandraCreateKeyspace, mdata.TTLs())
 	if err != nil {
 		log.Fatal(4, "failed to initialize cassandra. %s", err)
 	}

--- a/scripts/config/metrictank-docker.ini
+++ b/scripts/config/metrictank-docker.ini
@@ -52,6 +52,8 @@ cassandra-write-queue-size = 100000
 cassandra-retries = 0
 # CQL protocol version. cassandra 3.x needs v3 or 4.
 cql-protocol-version = 4
+# enable the creation of the mdata keyspace and tables, only one node needs this
+cassandra-create-keyspace = true
 
 # enable SSL connection to cassandra
 cassandra-ssl = false
@@ -283,6 +285,8 @@ auth = false
 username = cassandra
 # password for authentication
 password = cassandra
+# enable the creation of the index keyspace and tables, only one node needs this
+create-keyspace = true
 
 ### in-memory only
 [memory-idx]

--- a/scripts/config/metrictank-package.ini
+++ b/scripts/config/metrictank-package.ini
@@ -52,6 +52,8 @@ cassandra-write-queue-size = 100000
 cassandra-retries = 0
 # CQL protocol version. cassandra 3.x needs v3 or 4.
 cql-protocol-version = 4
+# enable the creation of the mdata keyspace and tables, only one node needs this
+cassandra-create-keyspace = true
 
 # enable SSL connection to cassandra
 cassandra-ssl = false
@@ -283,6 +285,8 @@ auth = false
 username = cassandra
 # password for authentication
 password = cassandra
+# enable the creation of the index keyspace and tables, only one node needs this
+create-keyspace = true
 
 ### in-memory only
 [memory-idx]

--- a/vendor/github.com/gocql/gocql/AUTHORS
+++ b/vendor/github.com/gocql/gocql/AUTHORS
@@ -83,3 +83,13 @@ Nathan Youngman <git@nathany.com>
 Charles Law <charles.law@gmail.com>; <claw@conduce.com>
 Nathan Davies <nathanjamesdavies@gmail.com>
 Bo Blanton <bo.blanton@gmail.com>
+Vincent Rischmann <me@vrischmann.me>
+Jesse Claven <jesse.claven@gmail.com>
+Derrick Wippler <thrawn01@gmail.com>
+Leigh McCulloch <leigh@leighmcculloch.com>
+Ron Kuris <swcafe@gmail.com>
+Raphael Gavache <raphael.gavache@gmail.com>
+Yasser Abdolmaleki <yasser@yasser.ca>
+Krishnanand Thommandra <devtkrishna@gmail.com>
+Blake Atkinson <me@blakeatkinson.com>
+Dharmendra Parsaila <d4dharmu@gmail.com>

--- a/vendor/github.com/gocql/gocql/README.md
+++ b/vendor/github.com/gocql/gocql/README.md
@@ -172,9 +172,10 @@ Data Binding
 There are various ways to bind application level data structures to CQL statements:
 
 * You can write the data binding by hand, as outlined in the Tweet example. This provides you with the greatest flexibility, but it does mean that you need to keep your application code in sync with your Cassandra schema.
-* You can dynamically marshal an entire query result into an `[]map[string]interface{}` using the `SliceMap()` API. This returns a slice of row maps keyed by CQL column mames. This method requires no special interaction with the gocql API, but it does require your application to be able to deal with a key value view of your data.
+* You can dynamically marshal an entire query result into an `[]map[string]interface{}` using the `SliceMap()` API. This returns a slice of row maps keyed by CQL column names. This method requires no special interaction with the gocql API, but it does require your application to be able to deal with a key value view of your data.
 * As a refinement on the `SliceMap()` API you can also call `MapScan()` which returns `map[string]interface{}` instances in a row by row fashion.
 * The `Bind()` API provides a client app with a low level mechanism to introspect query meta data and extract appropriate field values from application level data structures.
+* The [gocqlx](https://github.com/scylladb/gocqlx) package is an idiomatic extension to gocql that provides usability features. With gocqlx you can bind the query parameters from maps and structs, use named query parameters (:identifier) and scan the query results into structs and slices. It comes with a fluent and flexible CQL query builder that supports full CQL spec, including BATCH statements and custom functions.
 * Building on top of the gocql driver, [cqlr](https://github.com/relops/cqlr) adds the ability to auto-bind a CQL iterator to a struct or to bind a struct to an INSERT statement.
 * Another external project that layers on top of gocql is [cqlc](http://relops.com/cqlc) which generates gocql compliant code from your Cassandra schema so that you can write type safe CQL statements in Go with a natural query syntax.
 * [gocassa](https://github.com/hailocab/gocassa) is an external project that layers on top of gocql to provide convenient query building and data binding.
@@ -185,7 +186,8 @@ Ecosystem
 
 The following community maintained tools are known to integrate with gocql:
 
-* [migrate](https://github.com/mattes/migrate) is a migration handling tool written in Go with Cassandra support.
+* [gocqlx](https://github.com/scylladb/gocqlx) is a gocql extension that automates data binding, adds named queries support, provides flexible query builders and plays well with gocql.
+* [journey](https://github.com/db-journey/journey) is a migration tool with Cassandra support.
 * [negronicql](https://github.com/mikebthun/negronicql) is gocql middleware for Negroni.
 * [cqlr](https://github.com/relops/cqlr) adds the ability to auto-bind a CQL iterator to a struct or to bind a struct to an INSERT statement.
 * [cqlc](http://relops.com/cqlc) generates gocql compliant code from your Cassandra schema so that you can write type safe CQL statements in Go with a natural query syntax.

--- a/vendor/github.com/gocql/gocql/control.go
+++ b/vendor/github.com/gocql/gocql/control.go
@@ -1,22 +1,22 @@
 package gocql
 
 import (
+	"context"
 	crand "crypto/rand"
 	"errors"
 	"fmt"
-	"log"
 	"math/rand"
 	"net"
 	"regexp"
 	"strconv"
+	"sync"
 	"sync/atomic"
 	"time"
-
-	"golang.org/x/net/context"
 )
 
 var (
-	randr *rand.Rand
+	randr    *rand.Rand
+	mutRandr sync.Mutex
 )
 
 func init() {
@@ -132,11 +132,13 @@ func hostInfo(addr string, defaultPort int) (*HostInfo, error) {
 
 	}
 
-	return &HostInfo{peer: ip, port: port}, nil
+	return &HostInfo{connectAddress: ip, port: port}, nil
 }
 
 func shuffleHosts(hosts []*HostInfo) []*HostInfo {
+	mutRandr.Lock()
 	perm := randr.Perm(len(hosts))
+	mutRandr.Unlock()
 	shuffled := make([]*HostInfo, len(hosts))
 
 	for i, host := range hosts {
@@ -159,7 +161,7 @@ func (c *controlConn) shuffleDial(endpoints []*HostInfo) (*Conn, error) {
 			return conn, nil
 		}
 
-		log.Printf("gocql: unable to dial control conn %v: %v\n", host.Peer(), err)
+		Logger.Printf("gocql: unable to dial control conn %v: %v\n", host.ConnectAddress(), err)
 	}
 
 	return nil, err
@@ -245,16 +247,27 @@ func (c *controlConn) setupConn(conn *Conn) error {
 
 	c.conn.Store(conn)
 
+	if v, ok := conn.conn.RemoteAddr().(*net.TCPAddr); ok {
+		c.session.handleNodeUp(copyBytes(v.IP), v.Port, false)
+		return nil
+	}
+
 	host, portstr, err := net.SplitHostPort(conn.conn.RemoteAddr().String())
 	if err != nil {
 		return err
 	}
+
 	port, err := strconv.Atoi(portstr)
 	if err != nil {
 		return err
 	}
 
-	c.session.handleNodeUp(net.ParseIP(host), port, false)
+	ip := net.ParseIP(host)
+	if ip == nil {
+		return fmt.Errorf("invalid remote addr: addr=%v host=%q", conn.conn.RemoteAddr(), host)
+	}
+
+	c.session.handleNodeUp(ip, port, false)
 
 	return nil
 }
@@ -312,7 +325,7 @@ func (c *controlConn) reconnect(refreshring bool) {
 		if err != nil {
 			// host is dead
 			// TODO: this is replicated in a few places
-			c.session.handleNodeDown(host.Peer(), host.Port())
+			c.session.handleNodeDown(host.ConnectAddress(), host.Port())
 		} else {
 			newConn = conn
 		}
@@ -337,7 +350,7 @@ func (c *controlConn) reconnect(refreshring bool) {
 
 	if err := c.setupConn(newConn); err != nil {
 		newConn.Close()
-		log.Printf("gocql: control unable to register events: %v\n", err)
+		Logger.Printf("gocql: control unable to register events: %v\n", err)
 		return
 	}
 
@@ -398,7 +411,7 @@ func (c *controlConn) withConn(fn func(*Conn) *Iter) *Iter {
 
 // query will return nil if the connection is closed or nil
 func (c *controlConn) query(statement string, values ...interface{}) (iter *Iter) {
-	q := c.session.Query(statement, values...).Consistency(One).RoutingKey([]byte{})
+	q := c.session.Query(statement, values...).Consistency(One).RoutingKey([]byte{}).Trace(nil)
 
 	for {
 		iter = c.withConn(func(conn *Conn) *Iter {
@@ -406,7 +419,7 @@ func (c *controlConn) query(statement string, values ...interface{}) (iter *Iter
 		})
 
 		if gocqlDebug && iter.err != nil {
-			log.Printf("control: error executing %q: %v\n", statement, iter.err)
+			Logger.Printf("control: error executing %q: %v\n", statement, iter.err)
 		}
 
 		q.attempts++
@@ -418,52 +431,13 @@ func (c *controlConn) query(statement string, values ...interface{}) (iter *Iter
 	return
 }
 
-func (c *controlConn) fetchHostInfo(ip net.IP, port int) (*HostInfo, error) {
-	// TODO(zariel): we should probably move this into host_source or atleast
-	// share code with it.
-	localHost := c.host()
-	if localHost == nil {
-		return nil, errors.New("unable to fetch host info, invalid conn host")
-	}
-
-	isLocal := localHost.Peer().Equal(ip)
-
-	var fn func(*HostInfo) error
-
-	// TODO(zariel): fetch preferred_ip address (is it >3.x only?)
-	if isLocal {
-		fn = func(host *HostInfo) error {
-			iter := c.query("SELECT data_center, rack, host_id, tokens, release_version FROM system.local WHERE key='local'")
-			iter.Scan(&host.dataCenter, &host.rack, &host.hostId, &host.tokens, &host.version)
-			return iter.Close()
-		}
-	} else {
-		fn = func(host *HostInfo) error {
-			iter := c.query("SELECT data_center, rack, host_id, tokens, release_version FROM system.peers WHERE peer=?", ip)
-			iter.Scan(&host.dataCenter, &host.rack, &host.hostId, &host.tokens, &host.version)
-			return iter.Close()
-		}
-	}
-
-	host := &HostInfo{
-		port: port,
-		peer: ip,
-	}
-
-	if err := fn(host); err != nil {
-		return nil, err
-	}
-
-	return host, nil
-}
-
 func (c *controlConn) awaitSchemaAgreement() error {
 	return c.withConn(func(conn *Conn) *Iter {
 		return &Iter{err: conn.awaitSchemaAgreement()}
 	}).err
 }
 
-func (c *controlConn) host() *HostInfo {
+func (c *controlConn) GetHostInfo() *HostInfo {
 	conn := c.conn.Load().(*Conn)
 	if conn == nil {
 		return nil

--- a/vendor/github.com/gocql/gocql/filters.go
+++ b/vendor/github.com/gocql/gocql/filters.go
@@ -48,10 +48,10 @@ func WhiteListHostFilter(hosts ...string) HostFilter {
 
 	m := make(map[string]bool, len(hostInfos))
 	for _, host := range hostInfos {
-		m[string(host.peer)] = true
+		m[host.ConnectAddress().String()] = true
 	}
 
 	return HostFilterFunc(func(host *HostInfo) bool {
-		return m[string(host.Peer())]
+		return m[host.ConnectAddress().String()]
 	})
 }

--- a/vendor/github.com/gocql/gocql/helpers.go
+++ b/vendor/github.com/gocql/gocql/helpers.go
@@ -57,6 +57,8 @@ func goType(t TypeInfo) reflect.Type {
 		return reflect.TypeOf(make([]interface{}, len(tuple.Elems)))
 	case TypeUDT:
 		return reflect.TypeOf(make(map[string]interface{}))
+	case TypeDate:
+		return reflect.TypeOf(*new(time.Time))
 	default:
 		return nil
 	}
@@ -250,6 +252,42 @@ func (iter *Iter) SliceMap() ([]map[string]interface{}, error) {
 
 // MapScan takes a map[string]interface{} and populates it with a row
 // that is returned from cassandra.
+//
+// Each call to MapScan() must be called with a new map object.
+// During the call to MapScan() any pointers in the existing map
+// are replaced with non pointer types before the call returns
+//
+//	iter := session.Query(`SELECT * FROM mytable`).Iter()
+//	for {
+//		// New map each iteration
+//		row = make(map[string]interface{})
+//		if !iter.MapScan(row) {
+//			break
+//		}
+//		// Do things with row
+//		if fullname, ok := row["fullname"]; ok {
+//			fmt.Printf("Full Name: %s\n", fullname)
+//		}
+//	}
+//
+// You can also pass pointers in the map before each call
+//
+//	var fullName FullName // Implements gocql.Unmarshaler and gocql.Marshaler interfaces
+//	var address net.IP
+//	var age int
+//	iter := session.Query(`SELECT * FROM scan_map_table`).Iter()
+//	for {
+//		// New map each iteration
+//		row := map[string]interface{}{
+//			"fullname": &fullName,
+//			"age":      &age,
+//			"address":  &address,
+//		}
+//		if !iter.MapScan(row) {
+//			break
+//		}
+//		fmt.Printf("First: %s Age: %d Address: %q\n", fullName.FirstName, age, address)
+//	}
 func (iter *Iter) MapScan(m map[string]interface{}) bool {
 	if iter.err != nil {
 		return false

--- a/vendor/github.com/gocql/gocql/host_source.go
+++ b/vendor/github.com/gocql/gocql/host_source.go
@@ -1,8 +1,8 @@
 package gocql
 
 import (
+	"errors"
 	"fmt"
-	"log"
 	"net"
 	"strconv"
 	"strings"
@@ -99,24 +99,40 @@ func (c cassVersion) nodeUpDelay() time.Duration {
 type HostInfo struct {
 	// TODO(zariel): reduce locking maybe, not all values will change, but to ensure
 	// that we are thread safe use a mutex to access all fields.
-	mu         sync.RWMutex
-	peer       net.IP
-	port       int
-	dataCenter string
-	rack       string
-	hostId     string
-	version    cassVersion
-	state      nodeState
-	tokens     []string
+	mu               sync.RWMutex
+	peer             net.IP
+	broadcastAddress net.IP
+	listenAddress    net.IP
+	rpcAddress       net.IP
+	preferredIP      net.IP
+	connectAddress   net.IP
+	port             int
+	dataCenter       string
+	rack             string
+	hostId           string
+	workload         string
+	graph            bool
+	dseVersion       string
+	partitioner      string
+	clusterName      string
+	version          cassVersion
+	state            nodeState
+	tokens           []string
 }
 
 func (h *HostInfo) Equal(host *HostInfo) bool {
 	h.mu.RLock()
 	defer h.mu.RUnlock()
-	host.mu.RLock()
-	defer host.mu.RUnlock()
+	//If both hosts pointers are same then lock is required only once because of below reasons:
+	//Reason 1: There is no point taking lock twice on same mutex variable.
+	//Reason 2: It may lead to deadlock e.g. if WLock is requested by other routine in between 1st & 2nd RLock
+	//So WLock will be blocked on 1st RLock and 2nd RLock will be blocked on requested WLock.
+	if h != host {
+		host.mu.RLock()
+		defer host.mu.RUnlock()
+	}
 
-	return h.peer.Equal(host.peer)
+	return h.ConnectAddress().Equal(host.ConnectAddress())
 }
 
 func (h *HostInfo) Peer() net.IP {
@@ -130,6 +146,77 @@ func (h *HostInfo) setPeer(peer net.IP) *HostInfo {
 	defer h.mu.Unlock()
 	h.peer = peer
 	return h
+}
+
+func (h *HostInfo) invalidConnectAddr() bool {
+	h.mu.RLock()
+	defer h.mu.RUnlock()
+	addr, _ := h.connectAddressLocked()
+	return !validIpAddr(addr)
+}
+
+func validIpAddr(addr net.IP) bool {
+	return addr != nil && !addr.IsUnspecified()
+}
+
+func (h *HostInfo) connectAddressLocked() (net.IP, string) {
+	if validIpAddr(h.connectAddress) {
+		return h.connectAddress, "connect_address"
+	} else if validIpAddr(h.rpcAddress) {
+		return h.rpcAddress, "rpc_adress"
+	} else if validIpAddr(h.preferredIP) {
+		// where does perferred_ip get set?
+		return h.preferredIP, "preferred_ip"
+	} else if validIpAddr(h.broadcastAddress) {
+		return h.broadcastAddress, "broadcast_address"
+	} else if validIpAddr(h.peer) {
+		return h.peer, "peer"
+	}
+	return net.IPv4zero, "invalid"
+}
+
+// Returns the address that should be used to connect to the host.
+// If you wish to override this, use an AddressTranslator or
+// use a HostFilter to SetConnectAddress()
+func (h *HostInfo) ConnectAddress() net.IP {
+	h.mu.RLock()
+	defer h.mu.RUnlock()
+
+	if addr, _ := h.connectAddressLocked(); validIpAddr(addr) {
+		return addr
+	}
+	panic(fmt.Sprintf("no valid connect address for host: %v. Is your cluster configured correctly?", h))
+}
+
+func (h *HostInfo) SetConnectAddress(address net.IP) *HostInfo {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	h.connectAddress = address
+	return h
+}
+
+func (h *HostInfo) BroadcastAddress() net.IP {
+	h.mu.RLock()
+	defer h.mu.RUnlock()
+	return h.broadcastAddress
+}
+
+func (h *HostInfo) ListenAddress() net.IP {
+	h.mu.RLock()
+	defer h.mu.RUnlock()
+	return h.listenAddress
+}
+
+func (h *HostInfo) RPCAddress() net.IP {
+	h.mu.RLock()
+	defer h.mu.RUnlock()
+	return h.rpcAddress
+}
+
+func (h *HostInfo) PreferredIP() net.IP {
+	h.mu.RLock()
+	defer h.mu.RUnlock()
+	return h.preferredIP
 }
 
 func (h *HostInfo) DataCenter() string {
@@ -169,6 +256,36 @@ func (h *HostInfo) setHostID(hostID string) *HostInfo {
 	defer h.mu.Unlock()
 	h.hostId = hostID
 	return h
+}
+
+func (h *HostInfo) WorkLoad() string {
+	h.mu.RLock()
+	defer h.mu.RUnlock()
+	return h.workload
+}
+
+func (h *HostInfo) Graph() bool {
+	h.mu.RLock()
+	defer h.mu.RUnlock()
+	return h.graph
+}
+
+func (h *HostInfo) DSEVersion() string {
+	h.mu.RLock()
+	defer h.mu.RUnlock()
+	return h.dseVersion
+}
+
+func (h *HostInfo) Partitioner() string {
+	h.mu.RLock()
+	defer h.mu.RUnlock()
+	return h.partitioner
+}
+
+func (h *HostInfo) ClusterName() string {
+	h.mu.RLock()
+	defer h.mu.RUnlock()
+	return h.clusterName
 }
 
 func (h *HostInfo) Version() cassVersion {
@@ -240,25 +357,28 @@ func (h *HostInfo) IsUp() bool {
 func (h *HostInfo) String() string {
 	h.mu.RLock()
 	defer h.mu.RUnlock()
-	return fmt.Sprintf("[hostinfo peer=%q port=%d data_centre=%q rack=%q host_id=%q version=%q state=%s num_tokens=%d]", h.peer, h.port, h.dataCenter, h.rack, h.hostId, h.version, h.state, len(h.tokens))
+
+	connectAddr, source := h.connectAddressLocked()
+	return fmt.Sprintf("[HostInfo connectAddress=%q peer=%q rpc_address=%q broadcast_address=%q "+
+		"preferred_ip=%q connect_addr=%q connect_addr_source=%q "+
+		"port=%d data_centre=%q rack=%q host_id=%q version=%q state=%s num_tokens=%d]",
+		h.connectAddress, h.peer, h.rpcAddress, h.broadcastAddress, h.preferredIP,
+		connectAddr, source,
+		h.port, h.dataCenter, h.rack, h.hostId, h.version, h.state, len(h.tokens))
 }
 
 // Polls system.peers at a specific interval to find new hosts
 type ringDescriber struct {
-	dcFilter   string
-	rackFilter string
-	session    *Session
-	closeChan  chan bool
-	// indicates that we can use system.local to get the connections remote address
-	localHasRpcAddr bool
-
+	session         *Session
 	mu              sync.Mutex
 	prevHosts       []*HostInfo
+	localHost       *HostInfo
 	prevPartitioner string
 }
 
-func checkSystemLocal(control *controlConn) (bool, error) {
-	iter := control.query("SELECT broadcast_address FROM system.local")
+// Returns true if we are using system_schema.keyspaces instead of system.schema_keyspaces
+func checkSystemSchema(control *controlConn) (bool, error) {
+	iter := control.query("SELECT * FROM system_schema.keyspaces")
 	if err := iter.err; err != nil {
 		if errf, ok := err.(*errorFrame); ok {
 			if errf.code == errSyntax {
@@ -272,106 +392,279 @@ func checkSystemLocal(control *controlConn) (bool, error) {
 	return true, nil
 }
 
-// Returns true if we are using system_schema.keyspaces instead of system.schema_keyspaces
-func checkSystemSchema(control *controlConn) (bool, error) {
-	iter := control.query("SELECT * FROM system_schema.keyspaces")
-	if err := iter.err; err != nil {
-		if errf, ok := err.(*errorFrame); ok {
-			if errf.code == errReadFailure {
-				return false, nil
+// Given a map that represents a row from either system.local or system.peers
+// return as much information as we can in *HostInfo
+func (r *ringDescriber) hostInfoFromMap(row map[string]interface{}) (*HostInfo, error) {
+	const assertErrorMsg = "Assertion failed for %s"
+	var ok bool
+
+	// Default to our connected port if the cluster doesn't have port information
+	host := HostInfo{
+		port: r.session.cfg.Port,
+	}
+
+	for key, value := range row {
+		switch key {
+		case "data_center":
+			host.dataCenter, ok = value.(string)
+			if !ok {
+				return nil, fmt.Errorf(assertErrorMsg, "data_center")
+			}
+		case "rack":
+			host.rack, ok = value.(string)
+			if !ok {
+				return nil, fmt.Errorf(assertErrorMsg, "rack")
+			}
+		case "host_id":
+			hostId, ok := value.(UUID)
+			if !ok {
+				return nil, fmt.Errorf(assertErrorMsg, "host_id")
+			}
+			host.hostId = hostId.String()
+		case "release_version":
+			version, ok := value.(string)
+			if !ok {
+				return nil, fmt.Errorf(assertErrorMsg, "release_version")
+			}
+			host.version.Set(version)
+		case "peer":
+			ip, ok := value.(string)
+			if !ok {
+				return nil, fmt.Errorf(assertErrorMsg, "peer")
+			}
+			host.peer = net.ParseIP(ip)
+		case "cluster_name":
+			host.clusterName, ok = value.(string)
+			if !ok {
+				return nil, fmt.Errorf(assertErrorMsg, "cluster_name")
+			}
+		case "partitioner":
+			host.partitioner, ok = value.(string)
+			if !ok {
+				return nil, fmt.Errorf(assertErrorMsg, "partitioner")
+			}
+		case "broadcast_address":
+			ip, ok := value.(string)
+			if !ok {
+				return nil, fmt.Errorf(assertErrorMsg, "broadcast_address")
+			}
+			host.broadcastAddress = net.ParseIP(ip)
+		case "preferred_ip":
+			ip, ok := value.(string)
+			if !ok {
+				return nil, fmt.Errorf(assertErrorMsg, "preferred_ip")
+			}
+			host.preferredIP = net.ParseIP(ip)
+		case "rpc_address":
+			ip, ok := value.(string)
+			if !ok {
+				return nil, fmt.Errorf(assertErrorMsg, "rpc_address")
+			}
+			host.rpcAddress = net.ParseIP(ip)
+		case "listen_address":
+			ip, ok := value.(string)
+			if !ok {
+				return nil, fmt.Errorf(assertErrorMsg, "listen_address")
+			}
+			host.listenAddress = net.ParseIP(ip)
+		case "workload":
+			host.workload, ok = value.(string)
+			if !ok {
+				return nil, fmt.Errorf(assertErrorMsg, "workload")
+			}
+		case "graph":
+			host.graph, ok = value.(bool)
+			if !ok {
+				return nil, fmt.Errorf(assertErrorMsg, "graph")
+			}
+		case "tokens":
+			host.tokens, ok = value.([]string)
+			if !ok {
+				return nil, fmt.Errorf(assertErrorMsg, "tokens")
+			}
+		case "dse_version":
+			host.dseVersion, ok = value.(string)
+			if !ok {
+				return nil, fmt.Errorf(assertErrorMsg, "dse_version")
 			}
 		}
-
-		return false, err
+		// TODO(thrawn01): Add 'port'? once CASSANDRA-7544 is complete
+		// Not sure what the port field will be called until the JIRA issue is complete
 	}
 
-	return true, nil
+	return &host, nil
 }
 
-func (r *ringDescriber) GetHosts() (hosts []*HostInfo, partitioner string, err error) {
-	r.mu.Lock()
-	defer r.mu.Unlock()
-	// we need conn to be the same because we need to query system.peers and system.local
-	// on the same node to get the whole cluster
-
-	const (
-		legacyLocalQuery = "SELECT data_center, rack, host_id, tokens, partitioner, release_version FROM system.local"
-		// only supported in 2.2.0, 2.1.6, 2.0.16
-		localQuery = "SELECT broadcast_address, data_center, rack, host_id, tokens, partitioner, release_version FROM system.local"
-	)
-
-	localHost := &HostInfo{}
-	if r.localHasRpcAddr {
-		iter := r.session.control.query(localQuery)
-		if iter == nil {
-			return r.prevHosts, r.prevPartitioner, nil
-		}
-
-		iter.Scan(&localHost.peer, &localHost.dataCenter, &localHost.rack,
-			&localHost.hostId, &localHost.tokens, &partitioner, &localHost.version)
-
-		if err = iter.Close(); err != nil {
-			return nil, "", err
-		}
-	} else {
-		iter := r.session.control.withConn(func(c *Conn) *Iter {
-			localHost = c.host
-			return c.query(legacyLocalQuery)
-		})
-
-		if iter == nil {
-			return r.prevHosts, r.prevPartitioner, nil
-		}
-
-		iter.Scan(&localHost.dataCenter, &localHost.rack, &localHost.hostId, &localHost.tokens, &partitioner, &localHost.version)
-
-		if err = iter.Close(); err != nil {
-			return nil, "", err
-		}
+// Ask the control node for it's local host information
+func (r *ringDescriber) GetLocalHostInfo() (*HostInfo, error) {
+	it := r.session.control.query("SELECT * FROM system.local WHERE key='local'")
+	if it == nil {
+		return nil, errors.New("Attempted to query 'system.local' on a closed control connection")
+	}
+	host, err := r.extractHostInfo(it)
+	if err != nil {
+		return nil, err
 	}
 
-	localHost.port = r.session.cfg.Port
-
-	hosts = []*HostInfo{localHost}
-
-	rows := r.session.control.query("SELECT rpc_address, data_center, rack, host_id, tokens, release_version FROM system.peers").Scanner()
-	if rows == nil {
-		return r.prevHosts, r.prevPartitioner, nil
+	if host.invalidConnectAddr() {
+		host.SetConnectAddress(r.session.control.GetHostInfo().ConnectAddress())
 	}
 
-	for rows.Next() {
-		host := &HostInfo{port: r.session.cfg.Port}
-		err := rows.Scan(&host.peer, &host.dataCenter, &host.rack, &host.hostId, &host.tokens, &host.version)
+	return host, nil
+}
+
+// Given an ip address and port, return a peer that matched the ip address
+func (r *ringDescriber) GetPeerHostInfo(ip net.IP, port int) (*HostInfo, error) {
+	it := r.session.control.query("SELECT * FROM system.peers WHERE peer=?", ip)
+	if it == nil {
+		return nil, errors.New("Attempted to query 'system.peers' on a closed control connection")
+	}
+	return r.extractHostInfo(it)
+}
+
+func (r *ringDescriber) extractHostInfo(it *Iter) (*HostInfo, error) {
+	row := make(map[string]interface{})
+
+	// expect only 1 row
+	it.MapScan(row)
+	if err := it.Close(); err != nil {
+		return nil, err
+	}
+
+	// extract all available info about the host
+	return r.hostInfoFromMap(row)
+}
+
+// Ask the control node for host info on all it's known peers
+func (r *ringDescriber) GetClusterPeerInfo() ([]*HostInfo, error) {
+	var hosts []*HostInfo
+
+	// Ask the node for a list of it's peers
+	it := r.session.control.query("SELECT * FROM system.peers")
+	if it == nil {
+		return nil, errors.New("Attempted to query 'system.peers' on a closed connection")
+	}
+
+	for {
+		row := make(map[string]interface{})
+		if !it.MapScan(row) {
+			break
+		}
+		// extract all available info about the peer
+		host, err := r.hostInfoFromMap(row)
 		if err != nil {
-			log.Println(err)
+			return nil, err
+		}
+
+		// If it's not a valid peer
+		if !r.IsValidPeer(host) {
+			Logger.Printf("Found invalid peer '%+v' "+
+				"Likely due to a gossip or snitch issue, this host will be ignored", host)
 			continue
 		}
+		hosts = append(hosts, host)
+	}
+	if it.err != nil {
+		return nil, fmt.Errorf("while scanning 'system.peers' table: %s", it.err)
+	}
+	return hosts, nil
+}
 
-		if r.matchFilter(host) {
-			hosts = append(hosts, host)
+// Return true if the host is a valid peer
+func (r *ringDescriber) IsValidPeer(host *HostInfo) bool {
+	return !(len(host.RPCAddress()) == 0 ||
+		host.hostId == "" ||
+		host.dataCenter == "" ||
+		host.rack == "" ||
+		len(host.tokens) == 0)
+}
+
+// Return a list of hosts the cluster knows about
+func (r *ringDescriber) GetHosts() ([]*HostInfo, string, error) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	// Update the localHost info with data from the connected host
+	localHost, err := r.GetLocalHostInfo()
+	if err != nil {
+		return r.prevHosts, r.prevPartitioner, err
+	} else if localHost.invalidConnectAddr() {
+		panic(fmt.Sprintf("unable to get localhost connect address: %v", localHost))
+	}
+
+	// Update our list of hosts by querying the cluster
+	hosts, err := r.GetClusterPeerInfo()
+	if err != nil {
+		return r.prevHosts, r.prevPartitioner, err
+	}
+
+	hosts = append(hosts, localHost)
+
+	// Filter the hosts if filter is provided
+	filteredHosts := hosts
+	if r.session.cfg.HostFilter != nil {
+		filteredHosts = filteredHosts[:0]
+		for _, host := range hosts {
+			if r.session.cfg.HostFilter.Accept(host) {
+				filteredHosts = append(filteredHosts, host)
+			}
 		}
 	}
 
-	if err = rows.Err(); err != nil {
-		return nil, "", err
-	}
+	r.prevHosts = filteredHosts
+	r.prevPartitioner = localHost.partitioner
+	r.localHost = localHost
 
-	r.prevHosts = hosts
-	r.prevPartitioner = partitioner
-
-	return hosts, partitioner, nil
+	return filteredHosts, localHost.partitioner, nil
 }
 
-func (r *ringDescriber) matchFilter(host *HostInfo) bool {
-	if r.dcFilter != "" && r.dcFilter != host.DataCenter() {
-		return false
+// Given an ip/port return HostInfo for the specified ip/port
+func (r *ringDescriber) GetHostInfo(ip net.IP, port int) (*HostInfo, error) {
+	// TODO(thrawn01): Is IgnorePeerAddr still useful now that we have DisableInitialHostLookup?
+	// TODO(thrawn01): should we also check for DisableInitialHostLookup and return if true?
+
+	// Ignore the port and connect address and use the address/port we already have
+	if r.session.control == nil || r.session.cfg.IgnorePeerAddr {
+		return &HostInfo{connectAddress: ip, port: port}, nil
 	}
 
-	if r.rackFilter != "" && r.rackFilter != host.Rack() {
-		return false
+	// Attempt to get the host info for our control connection
+	controlHost := r.session.control.GetHostInfo()
+	if controlHost == nil {
+		return nil, errors.New("invalid control connection")
 	}
 
-	return true
+	var (
+		host *HostInfo
+		err  error
+	)
+
+	// If we are asking about the same node our control connection has a connection too
+	if controlHost.ConnectAddress().Equal(ip) {
+		host, err = r.GetLocalHostInfo()
+	} else {
+		host, err = r.GetPeerHostInfo(ip, port)
+	}
+
+	// No host was found matching this ip/port
+	if err != nil {
+		return nil, err
+	}
+
+	if controlHost.ConnectAddress().Equal(ip) {
+		// Always respect the provided control node address and disregard the ip address
+		// the cassandra node provides. We do this as we are already connected and have a
+		// known valid ip address. This insulates gocql from client connection issues stemming
+		// from node misconfiguration. For instance when a node is run from a container, by
+		// default the node will report its ip address as 127.0.0.1 which is typically invalid.
+		host.SetConnectAddress(ip)
+	}
+
+	if host.invalidConnectAddr() {
+		return nil, fmt.Errorf("host ConnectAddress invalid: %v", host)
+	}
+
+	return host, nil
 }
 
 func (r *ringDescriber) refreshRing() error {
@@ -384,16 +677,24 @@ func (r *ringDescriber) refreshRing() error {
 		return err
 	}
 
+	prevHosts := r.session.ring.currentHosts()
+
 	// TODO: move this to session
-	// TODO: handle removing hosts here
 	for _, h := range hosts {
-		if r.session.cfg.HostFilter == nil || r.session.cfg.HostFilter.Accept(h) {
-			if host, ok := r.session.ring.addHostIfMissing(h); !ok {
-				r.session.pool.addHost(h)
-			} else {
-				host.update(h)
-			}
+		if host, ok := r.session.ring.addHostIfMissing(h); !ok {
+			r.session.pool.addHost(h)
+			r.session.policy.AddHost(h)
+		} else {
+			host.update(h)
 		}
+		delete(prevHosts, h.ConnectAddress().String())
+	}
+
+	// TODO(zariel): it may be worth having a mutex covering the overall ring state
+	// in a session so that everything sees a consistent state. Becuase as is today
+	// events can come in and due to ordering an UP host could be removed from the cluster
+	for _, host := range prevHosts {
+		r.session.removeHost(host)
 	}
 
 	r.session.metadata.setPartitioner(partitioner)

--- a/vendor/github.com/gocql/gocql/logger.go
+++ b/vendor/github.com/gocql/gocql/logger.go
@@ -1,0 +1,30 @@
+package gocql
+
+import (
+	"bytes"
+	"fmt"
+	"log"
+)
+
+type StdLogger interface {
+	Print(v ...interface{})
+	Printf(format string, v ...interface{})
+	Println(v ...interface{})
+}
+
+type testLogger struct {
+	capture bytes.Buffer
+}
+
+func (l *testLogger) Print(v ...interface{})                 { fmt.Fprint(&l.capture, v...) }
+func (l *testLogger) Printf(format string, v ...interface{}) { fmt.Fprintf(&l.capture, format, v...) }
+func (l *testLogger) Println(v ...interface{})               { fmt.Fprintln(&l.capture, v...) }
+func (l *testLogger) String() string                         { return l.capture.String() }
+
+type defaultLogger struct{}
+
+func (l *defaultLogger) Print(v ...interface{})                 { log.Print(v...) }
+func (l *defaultLogger) Printf(format string, v ...interface{}) { log.Printf(format, v...) }
+func (l *defaultLogger) Println(v ...interface{})               { log.Println(v...) }
+
+var Logger StdLogger = &defaultLogger{}

--- a/vendor/github.com/gocql/gocql/marshal.go
+++ b/vendor/github.com/gocql/gocql/marshal.go
@@ -21,7 +21,8 @@ import (
 )
 
 var (
-	bigOne = big.NewInt(1)
+	bigOne     = big.NewInt(1)
+	emptyValue reflect.Value
 )
 
 var (
@@ -80,7 +81,7 @@ func Marshal(info TypeInfo, value interface{}) ([]byte, error) {
 		return marshalDouble(info, value)
 	case TypeDecimal:
 		return marshalDecimal(info, value)
-	case TypeTimestamp:
+	case TypeTimestamp, TypeTime:
 		return marshalTimestamp(info, value)
 	case TypeList, TypeSet:
 		return marshalList(info, value)
@@ -96,6 +97,8 @@ func Marshal(info TypeInfo, value interface{}) ([]byte, error) {
 		return marshalTuple(info, value)
 	case TypeUDT:
 		return marshalUDT(info, value)
+	case TypeDate:
+		return marshalDate(info, value)
 	}
 
 	// detect protocol 2 UDT
@@ -114,6 +117,7 @@ func Unmarshal(info TypeInfo, data []byte, value interface{}) error {
 	if v, ok := value.(Unmarshaler); ok {
 		return v.UnmarshalCQL(info, data)
 	}
+
 	if isNullableValue(value) {
 		return unmarshalNullable(info, data, value)
 	}
@@ -139,7 +143,7 @@ func Unmarshal(info TypeInfo, data []byte, value interface{}) error {
 		return unmarshalDouble(info, data, value)
 	case TypeDecimal:
 		return unmarshalDecimal(info, data, value)
-	case TypeTimestamp:
+	case TypeTimestamp, TypeTime:
 		return unmarshalTimestamp(info, data, value)
 	case TypeList, TypeSet:
 		return unmarshalList(info, data, value)
@@ -155,6 +159,8 @@ func Unmarshal(info TypeInfo, data []byte, value interface{}) error {
 		return unmarshalTuple(info, data, value)
 	case TypeUDT:
 		return unmarshalUDT(info, data, value)
+	case TypeDate:
+		return unmarshalDate(info, data, value)
 	}
 
 	// detect protocol 2 UDT
@@ -172,7 +178,7 @@ func isNullableValue(value interface{}) bool {
 }
 
 func isNullData(info TypeInfo, data []byte) bool {
-	return len(data) == 0
+	return data == nil
 }
 
 func unmarshalNullable(info TypeInfo, data []byte, value interface{}) error {
@@ -193,6 +199,8 @@ func marshalVarchar(info TypeInfo, value interface{}) ([]byte, error) {
 	switch v := value.(type) {
 	case Marshaler:
 		return v.MarshalCQL(info)
+	case unsetColumn:
+		return nil, nil
 	case string:
 		return []byte(v), nil
 	case []byte:
@@ -223,12 +231,11 @@ func unmarshalVarchar(info TypeInfo, data []byte, value interface{}) error {
 		*v = string(data)
 		return nil
 	case *[]byte:
-		var dataCopy []byte
 		if data != nil {
-			dataCopy = make([]byte, len(data))
-			copy(dataCopy, data)
+			*v = copyBytes(data)
+		} else {
+			*v = nil
 		}
-		*v = dataCopy
 		return nil
 	}
 	rv := reflect.ValueOf(value)
@@ -258,6 +265,8 @@ func marshalSmallInt(info TypeInfo, value interface{}) ([]byte, error) {
 	switch v := value.(type) {
 	case Marshaler:
 		return v.MarshalCQL(info)
+	case unsetColumn:
+		return nil, nil
 	case int16:
 		return encShort(v), nil
 	case uint16:
@@ -334,6 +343,8 @@ func marshalTinyInt(info TypeInfo, value interface{}) ([]byte, error) {
 	switch v := value.(type) {
 	case Marshaler:
 		return v.MarshalCQL(info)
+	case unsetColumn:
+		return nil, nil
 	case int8:
 		return []byte{byte(v)}, nil
 	case uint8:
@@ -416,6 +427,8 @@ func marshalInt(info TypeInfo, value interface{}) ([]byte, error) {
 	switch v := value.(type) {
 	case Marshaler:
 		return v.MarshalCQL(info)
+	case unsetColumn:
+		return nil, nil
 	case int:
 		if v > math.MaxInt32 || v < math.MinInt32 {
 			return nil, marshalErrorf("marshal int: value %d out of range", v)
@@ -518,6 +531,8 @@ func marshalBigInt(info TypeInfo, value interface{}) ([]byte, error) {
 	switch v := value.(type) {
 	case Marshaler:
 		return v.MarshalCQL(info)
+	case unsetColumn:
+		return nil, nil
 	case int:
 		return encBigInt(int64(v)), nil
 	case uint:
@@ -634,6 +649,8 @@ func marshalVarint(info TypeInfo, value interface{}) ([]byte, error) {
 	)
 
 	switch v := value.(type) {
+	case unsetColumn:
+		return nil, nil
 	case uint64:
 		if v > uint64(math.MaxInt64) {
 			retBytes = make([]byte, 9)
@@ -853,6 +870,8 @@ func marshalBool(info TypeInfo, value interface{}) ([]byte, error) {
 	switch v := value.(type) {
 	case Marshaler:
 		return v.MarshalCQL(info)
+	case unsetColumn:
+		return nil, nil
 	case bool:
 		return encBool(v), nil
 	}
@@ -908,6 +927,8 @@ func marshalFloat(info TypeInfo, value interface{}) ([]byte, error) {
 	switch v := value.(type) {
 	case Marshaler:
 		return v.MarshalCQL(info)
+	case unsetColumn:
+		return nil, nil
 	case float32:
 		return encInt(int32(math.Float32bits(v))), nil
 	}
@@ -949,6 +970,8 @@ func marshalDouble(info TypeInfo, value interface{}) ([]byte, error) {
 	switch v := value.(type) {
 	case Marshaler:
 		return v.MarshalCQL(info)
+	case unsetColumn:
+		return nil, nil
 	case float64:
 		return encBigInt(int64(math.Float64bits(v))), nil
 	}
@@ -992,6 +1015,8 @@ func marshalDecimal(info TypeInfo, value interface{}) ([]byte, error) {
 	switch v := value.(type) {
 	case Marshaler:
 		return v.MarshalCQL(info)
+	case unsetColumn:
+		return nil, nil
 	case inf.Dec:
 		unscaled := encBigInt2C(v.UnscaledBig())
 		if unscaled == nil {
@@ -1063,6 +1088,8 @@ func marshalTimestamp(info TypeInfo, value interface{}) ([]byte, error) {
 	switch v := value.(type) {
 	case Marshaler:
 		return v.MarshalCQL(info)
+	case unsetColumn:
+		return nil, nil
 	case int64:
 		return encBigInt(v), nil
 	case time.Time:
@@ -1071,6 +1098,8 @@ func marshalTimestamp(info TypeInfo, value interface{}) ([]byte, error) {
 		}
 		x := int64(v.UTC().Unix()*1e3) + int64(v.UTC().Nanosecond()/1e6)
 		return encBigInt(x), nil
+	case time.Duration:
+		return encBigInt(v.Nanoseconds()), nil
 	}
 
 	if value == nil {
@@ -1102,7 +1131,10 @@ func unmarshalTimestamp(info TypeInfo, data []byte, value interface{}) error {
 		nsec := (x - sec*1000) * 1000000
 		*v = time.Unix(sec, nsec).In(time.UTC)
 		return nil
+	case *time.Duration:
+		*v = time.Duration(decBigInt(data))
 	}
+
 	rv := reflect.ValueOf(value)
 	if rv.Kind() != reflect.Ptr {
 		return unmarshalErrorf("can not unmarshal into non-pointer %T", value)
@@ -1111,6 +1143,68 @@ func unmarshalTimestamp(info TypeInfo, data []byte, value interface{}) error {
 	switch rv.Type().Kind() {
 	case reflect.Int64:
 		rv.SetInt(decBigInt(data))
+		return nil
+	}
+	return unmarshalErrorf("can not unmarshal %s into %T", info, value)
+}
+
+func marshalDate(info TypeInfo, value interface{}) ([]byte, error) {
+	var timestamp int64
+	switch v := value.(type) {
+	case Marshaler:
+		return v.MarshalCQL(info)
+	case unsetColumn:
+		return nil, nil
+	case int64:
+		timestamp = v
+		x := timestamp/86400000 + int64(1<<31)
+		return encInt(int32(x)), nil
+	case time.Time:
+		if v.IsZero() {
+			return []byte{}, nil
+		}
+		timestamp = int64(v.UTC().Unix()*1e3) + int64(v.UTC().Nanosecond()/1e6)
+		x := timestamp/86400000 + int64(1<<31)
+		return encInt(int32(x)), nil
+	case *time.Time:
+		if v.IsZero() {
+			return []byte{}, nil
+		}
+		timestamp = int64(v.UTC().Unix()*1e3) + int64(v.UTC().Nanosecond()/1e6)
+		x := timestamp/86400000 + int64(1<<31)
+		return encInt(int32(x)), nil
+	case string:
+		if v == "" {
+			return []byte{}, nil
+		}
+		t, err := time.Parse("2006-01-02", v)
+		if err != nil {
+			return nil, marshalErrorf("can not marshal %T into %s, date layout must be '2006-01-02'", value, info)
+		}
+		timestamp = int64(t.UTC().Unix()*1e3) + int64(t.UTC().Nanosecond()/1e6)
+		x := timestamp/86400000 + int64(1<<31)
+		return encInt(int32(x)), nil
+	}
+
+	if value == nil {
+		return nil, nil
+	}
+	return nil, marshalErrorf("can not marshal %T into %s", value, info)
+}
+
+func unmarshalDate(info TypeInfo, data []byte, value interface{}) error {
+	switch v := value.(type) {
+	case Unmarshaler:
+		return v.UnmarshalCQL(info, data)
+	case *time.Time:
+		if len(data) == 0 {
+			*v = time.Time{}
+			return nil
+		}
+		var origin uint32 = 1 << 31
+		var current uint32 = binary.BigEndian.Uint32(data)
+		timestamp := (int64(current) - int64(origin)) * 86400000
+		*v = time.Unix(0, timestamp*int64(time.Millisecond)).In(time.UTC)
 		return nil
 	}
 	return unmarshalErrorf("can not unmarshal %s into %T", info, value)
@@ -1145,6 +1239,8 @@ func marshalList(info TypeInfo, value interface{}) ([]byte, error) {
 	}
 
 	if value == nil {
+		return nil, nil
+	} else if _, ok := value.(unsetColumn); ok {
 		return nil, nil
 	}
 
@@ -1262,6 +1358,8 @@ func marshalMap(info TypeInfo, value interface{}) ([]byte, error) {
 
 	if value == nil {
 		return nil, nil
+	} else if _, ok := value.(unsetColumn); ok {
+		return nil, nil
 	}
 
 	rv := reflect.ValueOf(value)
@@ -1356,12 +1454,15 @@ func unmarshalMap(info TypeInfo, data []byte, value interface{}) error {
 
 func marshalUUID(info TypeInfo, value interface{}) ([]byte, error) {
 	switch val := value.(type) {
+	case unsetColumn:
+		return nil, nil
 	case UUID:
 		return val.Bytes(), nil
 	case []byte:
-		if len(val) == 16 {
-			return val, nil
+		if len(val) != 16 {
+			return nil, marshalErrorf("can not marshal []byte %d bytes long into %s, must be exactly 16 bytes long", len(val), info)
 		}
+		return val, nil
 	case string:
 		b, err := ParseUUID(val)
 		if err != nil {
@@ -1435,6 +1536,8 @@ func marshalInet(info TypeInfo, value interface{}) ([]byte, error) {
 	// ip address here otherwise the db value will be prefixed
 	// with the remaining byte values e.g. ::ffff:127.0.0.1 and not 127.0.0.1
 	switch val := value.(type) {
+	case unsetColumn:
+		return nil, nil
 	case net.IP:
 		t := val.To4()
 		if t == nil {
@@ -1495,13 +1598,14 @@ func unmarshalInet(info TypeInfo, data []byte, value interface{}) error {
 func marshalTuple(info TypeInfo, value interface{}) ([]byte, error) {
 	tuple := info.(TupleTypeInfo)
 	switch v := value.(type) {
+	case unsetColumn:
+		return nil, unmarshalErrorf("Invalid request: UnsetValue is unsupported for tuples")
 	case []interface{}:
-		var buf []byte
-
 		if len(v) != len(tuple.Elems) {
 			return nil, unmarshalErrorf("cannont marshal tuple: wrong number of elements")
 		}
 
+		var buf []byte
 		for i, elem := range v {
 			data, err := Marshal(tuple.Elems[i], elem)
 			if err != nil {
@@ -1516,7 +1620,51 @@ func marshalTuple(info TypeInfo, value interface{}) ([]byte, error) {
 		return buf, nil
 	}
 
-	return nil, unmarshalErrorf("cannot marshal %T into %s", value, tuple)
+	rv := reflect.ValueOf(value)
+	t := rv.Type()
+	k := t.Kind()
+
+	switch k {
+	case reflect.Struct:
+		if v := t.NumField(); v != len(tuple.Elems) {
+			return nil, marshalErrorf("can not marshal tuple into struct %v, not enough fields have %d need %d", t, v, len(tuple.Elems))
+		}
+
+		var buf []byte
+		for i, elem := range tuple.Elems {
+			data, err := Marshal(elem, rv.Field(i).Interface())
+			if err != nil {
+				return nil, err
+			}
+
+			n := len(data)
+			buf = appendInt(buf, int32(n))
+			buf = append(buf, data...)
+		}
+
+		return buf, nil
+	case reflect.Slice, reflect.Array:
+		size := rv.Len()
+		if size != len(tuple.Elems) {
+			return nil, marshalErrorf("can not marshal tuple into %v of length %d need %d elements", k, size, len(tuple.Elems))
+		}
+
+		var buf []byte
+		for i, elem := range tuple.Elems {
+			data, err := Marshal(elem, rv.Index(i).Interface())
+			if err != nil {
+				return nil, err
+			}
+
+			n := len(data)
+			buf = appendInt(buf, int32(n))
+			buf = append(buf, data...)
+		}
+
+		return buf, nil
+	}
+
+	return nil, marshalErrorf("cannot marshal %T into %s", value, tuple)
 }
 
 // currently only support unmarshal into a list of values, this makes it possible
@@ -1540,6 +1688,61 @@ func unmarshalTuple(info TypeInfo, data []byte, value interface{}) error {
 				return err
 			}
 			data = data[size:]
+		}
+
+		return nil
+	}
+
+	rv := reflect.ValueOf(value)
+	if rv.Kind() != reflect.Ptr {
+		return unmarshalErrorf("can not unmarshal into non-pointer %T", value)
+	}
+
+	rv = rv.Elem()
+	t := rv.Type()
+	k := t.Kind()
+
+	switch k {
+	case reflect.Struct:
+		if v := t.NumField(); v != len(tuple.Elems) {
+			return unmarshalErrorf("can not unmarshal tuple into struct %v, not enough fields have %d need %d", t, v, len(tuple.Elems))
+		}
+
+		for i, elem := range tuple.Elems {
+			m := readInt(data)
+			data = data[4:]
+
+			v := elem.New()
+			if err := Unmarshal(elem, data[:m], v); err != nil {
+				return err
+			}
+			rv.Field(i).Set(reflect.ValueOf(v).Elem())
+
+			data = data[m:]
+		}
+
+		return nil
+	case reflect.Slice, reflect.Array:
+		if k == reflect.Array {
+			size := rv.Len()
+			if size != len(tuple.Elems) {
+				return unmarshalErrorf("can not unmarshal tuple into array of length %d need %d elements", size, len(tuple.Elems))
+			}
+		} else {
+			rv.Set(reflect.MakeSlice(t, len(tuple.Elems), len(tuple.Elems)))
+		}
+
+		for i, elem := range tuple.Elems {
+			m := readInt(data)
+			data = data[4:]
+
+			v := elem.New()
+			if err := Unmarshal(elem, data[:m], v); err != nil {
+				return err
+			}
+			rv.Index(i).Set(reflect.ValueOf(v).Elem())
+
+			data = data[m:]
 		}
 
 		return nil
@@ -1573,6 +1776,8 @@ func marshalUDT(info TypeInfo, value interface{}) ([]byte, error) {
 	switch v := value.(type) {
 	case Marshaler:
 		return v.MarshalCQL(info)
+	case unsetColumn:
+		return nil, unmarshalErrorf("Invalid request: UnsetValue is unsupported for user defined types")
 	case UDTMarshaler:
 		var buf []byte
 		for _, e := range udt.Elements {
@@ -1590,7 +1795,7 @@ func marshalUDT(info TypeInfo, value interface{}) ([]byte, error) {
 		for _, e := range udt.Elements {
 			val, ok := v[e.Name]
 			if !ok {
-				return nil, marshalErrorf("missing UDT field in map: %s", e.Name)
+				continue
 			}
 
 			data, err := Marshal(e.Type, val)
@@ -1728,22 +1933,22 @@ func unmarshalUDT(info TypeInfo, data []byte, value interface{}) error {
 		return unmarshalErrorf("cannot unmarshal %s into %T", info, value)
 	}
 
-	fields := make(map[string]reflect.Value)
-	t := k.Type()
-	for i := 0; i < t.NumField(); i++ {
-		sf := t.Field(i)
-
-		if tag := sf.Tag.Get("cql"); tag != "" {
-			fields[tag] = k.Field(i)
-		}
-	}
-
 	if len(data) == 0 {
 		if k.CanSet() {
 			k.Set(reflect.Zero(k.Type()))
 		}
 
 		return nil
+	}
+
+	t := k.Type()
+	fields := make(map[string]reflect.Value, t.NumField())
+	for i := 0; i < t.NumField(); i++ {
+		sf := t.Field(i)
+
+		if tag := sf.Tag.Get("cql"); tag != "" {
+			fields[tag] = k.Field(i)
+		}
 	}
 
 	udt := info.(UDTTypeInfo)
@@ -1756,11 +1961,15 @@ func unmarshalUDT(info TypeInfo, data []byte, value interface{}) error {
 		size := readInt(data[:4])
 		data = data[4:]
 
-		var err error
 		if size >= 0 {
 			f, ok := fields[e.Name]
 			if !ok {
 				f = k.FieldByName(e.Name)
+				if f == emptyValue {
+					// skip fields which exist in the UDT but not in
+					// the struct passed in
+					continue
+				}
 			}
 
 			if !f.IsValid() || !f.CanAddr() {
@@ -1772,10 +1981,6 @@ func unmarshalUDT(info TypeInfo, data []byte, value interface{}) error {
 				return err
 			}
 			data = data[size:]
-		}
-
-		if err != nil {
-			return err
 		}
 	}
 
@@ -1797,6 +2002,10 @@ type NativeType struct {
 	proto  byte
 	typ    Type
 	custom string // only used for TypeCustom
+}
+
+func NewNativeType(proto byte, typ Type, custom string) NativeType {
+	return NativeType{proto, typ, custom}
 }
 
 func (t NativeType) New() interface{} {

--- a/vendor/github.com/gocql/gocql/metadata.go
+++ b/vendor/github.com/gocql/gocql/metadata.go
@@ -8,7 +8,6 @@ import (
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
-	"log"
 	"strconv"
 	"strings"
 	"sync"
@@ -91,7 +90,7 @@ func (c ColumnKind) String() string {
 	case ColumnStatic:
 		return "static"
 	default:
-		return fmt.Sprintf("unkown_column_%d", c)
+		return fmt.Sprintf("unknown_column_%d", c)
 	}
 }
 
@@ -248,7 +247,7 @@ func compileMetadata(
 		table.OrderedColumns = append(table.OrderedColumns, columns[i].Name)
 	}
 
-	if protoVersion == 1 {
+	if protoVersion == protoVersion1 {
 		compileV1Metadata(tables)
 	} else {
 		compileV2Metadata(tables)
@@ -417,6 +416,9 @@ func getKeyspaceMetadata(session *Session, keyspaceName string) (*KeyspaceMetada
 		var replication map[string]string
 
 		iter := session.control.query(stmt, keyspaceName)
+		if iter.NumRows() == 0 {
+			return nil, ErrKeyspaceDoesNotExist
+		}
 		iter.Scan(&keyspace.DurableWrites, &replication)
 		err := iter.Close()
 		if err != nil {
@@ -439,6 +441,9 @@ func getKeyspaceMetadata(session *Session, keyspaceName string) (*KeyspaceMetada
 		var strategyOptionsJSON []byte
 
 		iter := session.control.query(stmt, keyspaceName)
+		if iter.NumRows() == 0 {
+			return nil, ErrKeyspaceDoesNotExist
+		}
 		iter.Scan(&keyspace.DurableWrites, &keyspace.StrategyClass, &strategyOptionsJSON)
 		err := iter.Close()
 		if err != nil {
@@ -500,9 +505,8 @@ func getTableMetadata(session *Session, keyspaceName string) ([]TableMetadata, e
 			}
 			return r
 		}
-	} else if session.cfg.ProtoVersion < protoVersion4 {
+	} else if session.cfg.ProtoVersion == protoVersion1 {
 		// we have key aliases
-		// TODO: Do we need key_aliases?
 		stmt = `
 		SELECT
 			columnfamily_name,
@@ -855,7 +859,7 @@ func (t *typeParser) parse() typeParserResult {
 				var name string
 				decoded, err := hex.DecodeString(*param.name)
 				if err != nil {
-					log.Printf(
+					Logger.Printf(
 						"Error parsing type '%s', contains collection name '%s' with an invalid format: %v",
 						t.input,
 						*param.name,

--- a/vendor/github.com/gocql/gocql/query_executor.go
+++ b/vendor/github.com/gocql/gocql/query_executor.go
@@ -48,6 +48,7 @@ func (q *queryExecutor) executeQuery(qry ExecutableQuery) (*Iter, error) {
 
 		// Exit for loop if the query was successful
 		if iter.err == nil {
+			iter.host = host
 			return iter, nil
 		}
 

--- a/vendor/github.com/gocql/gocql/ring.go
+++ b/vendor/github.com/gocql/gocql/ring.go
@@ -1,6 +1,7 @@
 package gocql
 
 import (
+	"fmt"
 	"net"
 	"sync"
 	"sync/atomic"
@@ -52,8 +53,21 @@ func (r *ring) allHosts() []*HostInfo {
 	return hosts
 }
 
+func (r *ring) currentHosts() map[string]*HostInfo {
+	r.mu.RLock()
+	hosts := make(map[string]*HostInfo, len(r.hosts))
+	for k, v := range r.hosts {
+		hosts[k] = v
+	}
+	r.mu.RUnlock()
+	return hosts
+}
+
 func (r *ring) addHost(host *HostInfo) bool {
-	ip := host.Peer().String()
+	if host.invalidConnectAddr() {
+		panic(fmt.Sprintf("invalid host: %v", host))
+	}
+	ip := host.ConnectAddress().String()
 
 	r.mu.Lock()
 	if r.hosts == nil {
@@ -79,7 +93,10 @@ func (r *ring) addOrUpdate(host *HostInfo) *HostInfo {
 }
 
 func (r *ring) addHostIfMissing(host *HostInfo) (*HostInfo, bool) {
-	ip := host.Peer().String()
+	if host.invalidConnectAddr() {
+		panic(fmt.Sprintf("invalid host: %v", host))
+	}
+	ip := host.ConnectAddress().String()
 
 	r.mu.Lock()
 	if r.hosts == nil {
@@ -106,7 +123,7 @@ func (r *ring) removeHost(ip net.IP) bool {
 	_, ok := r.hosts[k]
 	if ok {
 		for i, host := range r.hostList {
-			if host.Peer().Equal(ip) {
+			if host.ConnectAddress().Equal(ip) {
 				r.hostList = append(r.hostList[:i], r.hostList[i+1:]...)
 				break
 			}

--- a/vendor/github.com/gocql/gocql/token.go
+++ b/vendor/github.com/gocql/gocql/token.go
@@ -184,7 +184,7 @@ func (t *tokenRing) String() string {
 		buf.WriteString("]")
 		buf.WriteString(t.tokens[i].String())
 		buf.WriteString(":")
-		buf.WriteString(t.hosts[i].Peer().String())
+		buf.WriteString(t.hosts[i].ConnectAddress().String())
 	}
 	buf.WriteString("\n}")
 	return string(buf.Bytes())

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -135,34 +135,34 @@
 			"revisionTime": "2016-06-27T17:00:12Z"
 		},
 		{
-			"checksumSHA1": "9dGSivFlYCZvic4tBgE0xtWF0x0=",
+			"checksumSHA1": "9J/H5Vie1fPxR1JTL00If9G6AQ4=",
 			"path": "github.com/gocql/gocql",
-			"revision": "47f897f054183a4c891f27b235f11221683982dc",
-			"revisionTime": "2016-11-07T21:46:42Z"
+			"revision": "066e974c166d59aa2d3aee45b234d8c21c631180",
+			"revisionTime": "2017-08-31T15:20:34Z"
 		},
 		{
 			"checksumSHA1": "Z3N6HDGWcvcNu0FloZRq54uO3h4=",
 			"path": "github.com/gocql/gocql/internal/lru",
-			"revision": "ffae44103aa14ada9e2b342329f44ce354f399fd",
-			"revisionTime": "2016-09-27T08:26:32Z"
+			"revision": "066e974c166d59aa2d3aee45b234d8c21c631180",
+			"revisionTime": "2017-08-31T15:20:34Z"
 		},
 		{
 			"checksumSHA1": "ctK9mwZKnt/8dHxx2Ef6nZTljZs=",
 			"path": "github.com/gocql/gocql/internal/murmur",
-			"revision": "ffae44103aa14ada9e2b342329f44ce354f399fd",
-			"revisionTime": "2016-09-27T08:26:32Z"
+			"revision": "066e974c166d59aa2d3aee45b234d8c21c631180",
+			"revisionTime": "2017-08-31T15:20:34Z"
 		},
 		{
 			"checksumSHA1": "tZQDfMMTKrYMXqen0zjJWLtOf1A=",
 			"path": "github.com/gocql/gocql/internal/streams",
-			"revision": "ffae44103aa14ada9e2b342329f44ce354f399fd",
-			"revisionTime": "2016-09-27T08:26:32Z"
+			"revision": "066e974c166d59aa2d3aee45b234d8c21c631180",
+			"revisionTime": "2017-08-31T15:20:34Z"
 		},
 		{
 			"checksumSHA1": "OzddgAh0uv3ukKhWW7QFUEFbxow=",
 			"path": "github.com/golang/snappy",
-			"revision": "723cc1e459b8eea2dea4583200fd60757d40097a",
-			"revisionTime": "2015-07-30T03:18:44Z"
+			"revision": "553a641470496b2327abcac10b36396bd98e45c9",
+			"revisionTime": "2017-02-15T23:32:05Z"
 		},
 		{
 			"checksumSHA1": "heMa8aseS2k6NeJYumwo/xeKToY=",
@@ -173,8 +173,8 @@
 		{
 			"checksumSHA1": "wg1YpUMVhnUaoz26QhOWEhIT1dE=",
 			"path": "github.com/hailocab/go-hostpool",
-			"revision": "0637eae892be221164aff5fcbccc57171aea6406",
-			"revisionTime": "2015-11-17T00:06:41Z"
+			"revision": "e80d13ce29ede4452c43dea11e79b9bc8a15b478",
+			"revisionTime": "2016-01-25T11:53:50Z"
 		},
 		{
 			"checksumSHA1": "cdOCt0Yb+hdErz8NAQqayxPmRsY=",


### PR DESCRIPTION
This commit allows MTs to be initiated that only verify the existence of a keyspace in cassandra instead of create a keyspace. This is pertains to https://github.com/raintank/metrictank/issues/605. I added a small timeout that allows for 5 retries to verify if the keyspace exists. Any advice on improving this timeout would be appreciated. I tried to keep it as simple as possible but feedback is much appreciated.