### PR TITLE
Correct readyness

### DIFF
--- a/api/middleware/cluster.go
+++ b/api/middleware/cluster.go
@@ -1,0 +1,14 @@
+package middleware
+
+import (
+	"github.com/raintank/metrictank/cluster"
+	macaron "gopkg.in/macaron.v1"
+)
+
+func NodeReady() macaron.Handler {
+	return func(c *Context) {
+		if !cluster.Manager.IsReady() {
+			c.Error(503, "node not ready")
+		}
+	}
+}

--- a/api/routes.go
+++ b/api/routes.go
@@ -22,6 +22,7 @@ func (s *Server) RegisterRoutes() {
 	bind := binding.Bind
 	withOrg := middleware.RequireOrg()
 	cBody := middleware.CaptureBody
+	ready := middleware.NodeReady()
 
 	r.Get("/", s.appStatus)
 	r.Get("/node", s.getNodeStatus)
@@ -30,21 +31,21 @@ func (s *Server) RegisterRoutes() {
 	r.Get("/cluster", s.getClusterStatus)
 	r.Post("/cluster", bind(models.ClusterMembers{}), s.postClusterMembers)
 
-	r.Combo("/getdata", bind(models.GetData{})).Get(s.getData).Post(s.getData)
+	r.Combo("/getdata", ready, bind(models.GetData{})).Get(s.getData).Post(s.getData)
 
-	r.Combo("/index/find", bind(models.IndexFind{})).Get(s.indexFind).Post(s.indexFind)
-	r.Combo("/index/list", bind(models.IndexList{})).Get(s.indexList).Post(s.indexList)
-	r.Combo("/index/delete", bind(models.IndexDelete{})).Get(s.indexDelete).Post(s.indexDelete)
-	r.Combo("/index/get", bind(models.IndexGet{})).Get(s.indexGet).Post(s.indexGet)
+	r.Combo("/index/find", ready, bind(models.IndexFind{})).Get(s.indexFind).Post(s.indexFind)
+	r.Combo("/index/list", ready, bind(models.IndexList{})).Get(s.indexList).Post(s.indexList)
+	r.Combo("/index/delete", ready, bind(models.IndexDelete{})).Get(s.indexDelete).Post(s.indexDelete)
+	r.Combo("/index/get", ready, bind(models.IndexGet{})).Get(s.indexGet).Post(s.indexGet)
 
 	r.Options("/*", func(ctx *macaron.Context) {
 		ctx.Write(nil)
 	})
 
 	// Graphite endpoints
-	r.Combo("/render", cBody, withOrg, bind(models.GraphiteRender{})).Get(s.renderMetrics).Post(s.renderMetrics)
-	r.Combo("/metrics/find", withOrg, bind(models.GraphiteFind{})).Get(s.metricsFind).Post(s.metricsFind)
-	r.Get("/metrics/index.json", withOrg, s.metricsIndex)
-	r.Post("/metrics/delete", withOrg, bind(models.MetricsDelete{}), s.metricsDelete)
+	r.Combo("/render", cBody, withOrg, ready, bind(models.GraphiteRender{})).Get(s.renderMetrics).Post(s.renderMetrics)
+	r.Combo("/metrics/find", withOrg, ready, bind(models.GraphiteFind{})).Get(s.metricsFind).Post(s.metricsFind)
+	r.Get("/metrics/index.json", withOrg, ready, s.metricsIndex)
+	r.Post("/metrics/delete", withOrg, ready, bind(models.MetricsDelete{}), s.metricsDelete)
 
 }

--- a/cluster/cluster.go
+++ b/cluster/cluster.go
@@ -45,6 +45,7 @@ func Init(name, version string, started time.Time, apiScheme string, apiPort int
 				ApiScheme:     apiScheme,
 				Started:       started,
 				Version:       version,
+				Priority:      10000,
 				Primary:       primary,
 				PrimaryChange: time.Now(),
 				StateChange:   time.Now(),

--- a/cluster/cluster_test.go
+++ b/cluster/cluster_test.go
@@ -10,6 +10,8 @@ func TestPeersForQuery(t *testing.T) {
 	Init("node1", "test", time.Now(), "http", 6060)
 	Manager.SetPrimary(true)
 	Manager.SetPartitions([]int32{1, 2})
+	maxPrio = 10
+	Manager.SetPriority(10)
 	Manager.SetReady()
 	Convey("when cluster in single mode", t, func() {
 		selected, err := MembersForQuery()
@@ -27,18 +29,21 @@ func TestPeersForQuery(t *testing.T) {
 			Primary:    true,
 			Partitions: []int32{1, 2},
 			State:      NodeReady,
+			Priority:   10,
 		},
 		"node3": {
 			Name:       "node3",
 			Primary:    true,
 			Partitions: []int32{3, 4},
 			State:      NodeReady,
+			Priority:   10,
 		},
 		"node4": {
 			Name:       "node4",
 			Primary:    true,
 			Partitions: []int32{3, 4},
 			State:      NodeReady,
+			Priority:   10,
 		},
 	}
 	Manager.Unlock()

--- a/cluster/node.go
+++ b/cluster/node.go
@@ -38,6 +38,35 @@ func NodeStateFromString(s string) NodeState {
 	return NodeNotReady
 }
 
+// UnmarshalJSON supports unmarshalling according to the older
+// integer based, as well as the new string based, representation
+func (n *NodeState) UnmarshalJSON(data []byte) error {
+	s := string(data)
+	switch s {
+	case "0", `"NodeNotReady"`:
+		*n = NodeNotReady
+	case "1", `"NodeReady"`:
+		*n = NodeReady
+	case "2", `"NodeUnreachable"`:
+		*n = NodeUnreachable
+	default:
+		return fmt.Errorf("unrecognized NodeState %q", s)
+	}
+	return nil
+}
+
+func (n NodeState) MarshalJSON() ([]byte, error) {
+	switch n {
+	case NodeNotReady:
+		return []byte(`"NodeNotReady"`), nil
+	case NodeReady:
+		return []byte(`"NodeReady"`), nil
+	case NodeUnreachable:
+		return []byte(`"NodeUnreachable"`), nil
+	}
+	return nil, fmt.Errorf("impossible nodestate %v", n)
+}
+
 type Error struct {
 	code int
 	err  error

--- a/dashboard.json
+++ b/dashboard.json
@@ -326,7 +326,7 @@
               "yaxis": 2
             },
             {
-              "alias": "ready",
+              "alias": "/ready/",
               "fill": 3,
               "lines": true,
               "linewidth": 0,

--- a/docker/docker-cluster/docker-compose.yml
+++ b/docker/docker-cluster/docker-compose.yml
@@ -12,15 +12,15 @@ services:
     environment:
       WAIT_HOSTS: kafka:9092,cassandra:9042
       WAIT_TIMEOUT: 30
-      MT_KAFKA_MDM_IN_PARTITIONS: 0,1,2,3
-      MT_KAFKA_CLUSTER_PARTITIONS: 0,1,2,3
-      MT_INSTANCE: metrictank0
-      MT_LOG_LEVEL: 2
-      MT_CLUSTER_MODE: multi
-      MT_CLUSTER_PRIMARY_NODE: "true"
-      MT_CLUSTER_BIND_ADDR: "metrictank0:7946"
       MT_CASSANDRA_CREATE_KEYSPACE: "true"
       MT_CASSANDRA_IDX_CREATE_KEYSPACE: "true"
+      MT_CLUSTER_BIND_ADDR: "metrictank0:7946"
+      MT_CLUSTER_MODE: multi
+      MT_CLUSTER_PRIMARY_NODE: "true"
+      MT_INSTANCE: metrictank0
+      MT_KAFKA_CLUSTER_PARTITIONS: 0,1,2,3
+      MT_KAFKA_MDM_IN_PARTITIONS: 0,1,2,3
+      MT_LOG_LEVEL: 2
     links:
      - cassandra
 
@@ -35,14 +35,14 @@ services:
     environment:
       WAIT_HOSTS: kafka:9092,cassandra:9042,metrictank0:6060
       WAIT_TIMEOUT: 30
-      MT_KAFKA_MDM_IN_PARTITIONS: 0,1,2,3
-      MT_KAFKA_CLUSTER_PARTITIONS: 0,1,2,3
-      MT_INSTANCE: metrictank1
-      MT_LOG_LEVEL: 2
+      MT_CLUSTER_BIND_ADDR: "metrictank1:7946"
       MT_CLUSTER_MODE: multi
       MT_CLUSTER_PEERS: metrictank0,metrictank2,metrictank3
-      MT_CLUSTER_BIND_ADDR: "metrictank1:7946"
       MT_CLUSTER_PRIMARY_NODE: "false"
+      MT_INSTANCE: metrictank1
+      MT_KAFKA_CLUSTER_PARTITIONS: 0,1,2,3
+      MT_KAFKA_MDM_IN_PARTITIONS: 0,1,2,3
+      MT_LOG_LEVEL: 2
     links:
      - cassandra
      - metrictank0
@@ -58,14 +58,14 @@ services:
     environment:
       WAIT_HOSTS: kafka:9092,cassandra:9042,metrictank0:6060
       WAIT_TIMEOUT: 30
-      MT_KAFKA_MDM_IN_PARTITIONS: 4,5,6,7
-      MT_KAFKA_CLUSTER_PARTITIONS: 4,5,6,7
-      MT_INSTANCE: metrictank2
-      MT_LOG_LEVEL: 2
+      MT_CLUSTER_BIND_ADDR: "metrictank2:7946"
       MT_CLUSTER_MODE: multi
       MT_CLUSTER_PEERS: metrictank0,metrictank1,metrictank3
       MT_CLUSTER_PRIMARY_NODE: "true"
-      MT_CLUSTER_BIND_ADDR: "metrictank2:7946"
+      MT_INSTANCE: metrictank2
+      MT_KAFKA_CLUSTER_PARTITIONS: 4,5,6,7
+      MT_KAFKA_MDM_IN_PARTITIONS: 4,5,6,7
+      MT_LOG_LEVEL: 2
     links:
      - cassandra
      - metrictank0
@@ -81,14 +81,14 @@ services:
     environment:
       WAIT_HOSTS: kafka:9092,cassandra:9042,metrictank0:6060
       WAIT_TIMEOUT: 30
-      MT_KAFKA_MDM_IN_PARTITIONS: 4,5,6,7
-      MT_KAFKA_CLUSTER_PARTITIONS: 4,5,6,7
-      MT_INSTANCE: metrictank3
-      MT_LOG_LEVEL: 2
+      MT_CLUSTER_BIND_ADDR: "metrictank3:7946"
       MT_CLUSTER_MODE: multi
       MT_CLUSTER_PEERS: metrictank0,metrictank1,metrictank2
-      MT_CLUSTER_BIND_ADDR: "metrictank3:7946"
       MT_CLUSTER_PRIMARY_NODE: "false"
+      MT_INSTANCE: metrictank3
+      MT_KAFKA_CLUSTER_PARTITIONS: 4,5,6,7
+      MT_KAFKA_MDM_IN_PARTITIONS: 4,5,6,7
+      MT_LOG_LEVEL: 2
     links:
      - cassandra
      - metrictank0

--- a/docker/docker-cluster/metrictank.ini
+++ b/docker/docker-cluster/metrictank.ini
@@ -19,7 +19,7 @@ gc-interval = 1h
 # duration before secondary nodes start serving requests
 # shorter warmup means metrictank will need to query cassandra more if it doesn't have requested data yet.
 # in clusters, best to assure the primary has saved all the data that a newly warmup instance will need to query, to prevent gaps in charts
-warm-up-period = 1h
+warm-up-period = 1s
 
 ## metric data storage in cassandra ##
 

--- a/docker/extra/dashboards/metrictank-clustering.json
+++ b/docker/extra/dashboards/metrictank-clustering.json
@@ -1,0 +1,626 @@
+{
+  "__inputs": [],
+  "__requires": [
+    {
+      "type": "grafana",
+      "id": "grafana",
+      "name": "Grafana",
+      "version": "4.5.0-beta1"
+    },
+    {
+      "type": "panel",
+      "id": "graph",
+      "name": "Graph",
+      "version": ""
+    }
+  ],
+  "annotations": {
+    "list": []
+  },
+  "editable": true,
+  "gnetId": null,
+  "graphTooltip": 1,
+  "hideControls": false,
+  "id": null,
+  "links": [],
+  "refresh": false,
+  "rows": [
+    {
+      "collapse": false,
+      "height": 250,
+      "panels": [
+        {
+          "aliasColors": {
+            "ingest": "#EAB839"
+          },
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
+          "datasource": "$datasource",
+          "fill": 0,
+          "id": 31,
+          "legend": {
+            "avg": false,
+            "current": false,
+            "hideEmpty": true,
+            "max": false,
+            "min": false,
+            "show": true,
+            "total": false,
+            "values": false
+          },
+          "lines": false,
+          "linewidth": 4,
+          "links": [],
+          "minSpan": 3,
+          "nullPointMode": "null",
+          "percentage": false,
+          "pointradius": 1,
+          "points": true,
+          "renderer": "flot",
+          "repeat": "instance",
+          "seriesOverrides": [
+            {
+              "alias": "ingest",
+              "fill": 3,
+              "lines": true,
+              "linewidth": 0,
+              "points": false,
+              "yaxis": 2
+            }
+          ],
+          "spaceLength": 10,
+          "span": 3,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "hide": false,
+              "refId": "A",
+              "target": "aliasByNode(metrictank.stats.$environment.$instance.input.kafka-mdm.partition.*.lag.gauge64, 7)"
+            },
+            {
+              "hide": false,
+              "refId": "B",
+              "target": "alias(groupByNode(perSecond(metrictank.stats.$environment.$instance.input.*.metrics_received.counter32), 3, 'sum'), 'ingest')",
+              "textEditor": false
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeShift": null,
+          "title": "ingest & lag $instance",
+          "tooltip": {
+            "shared": true,
+            "sort": 1,
+            "value_type": "individual"
+          },
+          "transparent": true,
+          "type": "graph",
+          "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            },
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            }
+          ]
+        }
+      ],
+      "repeat": null,
+      "repeatIteration": null,
+      "repeatRowId": null,
+      "showTitle": false,
+      "title": "Row title",
+      "titleSize": "h6"
+    },
+    {
+      "collapse": false,
+      "height": 217,
+      "panels": [
+        {
+          "aliasColors": {
+            "primary": "#64B0C8",
+            "promotion wait": "#E5AC0E",
+            "ready": "#629E51",
+            "too old": "#890F02"
+          },
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
+          "datasource": "$datasource",
+          "editable": true,
+          "error": false,
+          "fill": 0,
+          "grid": {},
+          "id": 17,
+          "legend": {
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "show": true,
+            "total": false,
+            "values": false
+          },
+          "lines": false,
+          "linewidth": 2,
+          "links": [],
+          "minSpan": 3,
+          "nullPointMode": "null",
+          "percentage": false,
+          "pointradius": 1,
+          "points": true,
+          "renderer": "flot",
+          "repeat": "instance",
+          "seriesOverrides": [
+            {
+              "alias": "/primary/",
+              "fill": 3,
+              "lines": true,
+              "linewidth": 0,
+              "points": false,
+              "stack": "A",
+              "yaxis": 2
+            },
+            {
+              "alias": "/ready/",
+              "fill": 3,
+              "lines": true,
+              "linewidth": 0,
+              "points": false,
+              "stack": "A",
+              "yaxis": 2
+            }
+          ],
+          "spaceLength": 10,
+          "span": 3,
+          "stack": false,
+          "steppedLine": true,
+          "targets": [
+            {
+              "refId": "A",
+              "target": "aliasByNode(metrictank.stats.$environment.$instance.cluster.self.state.primary.gauge1, 7)"
+            },
+            {
+              "refId": "B",
+              "target": "aliasByNode(metrictank.stats.$environment.$instance.cluster.self.promotion_wait.gauge32, 6)"
+            },
+            {
+              "refId": "C",
+              "target": "aliasByNode(metrictank.stats.$environment.$instance.cluster.self.state.ready.gauge1, 7)"
+            },
+            {
+              "refId": "D",
+              "target": "aliasByNode(metrictank.stats.$environment.$instance.cluster.self.priority.gauge32, 6)"
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeShift": null,
+          "title": "status $instance",
+          "tooltip": {
+            "msResolution": false,
+            "shared": true,
+            "sort": 0,
+            "value_type": "cumulative"
+          },
+          "transparent": true,
+          "type": "graph",
+          "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "format": "s",
+              "logBase": 1,
+              "max": null,
+              "min": 0,
+              "show": true
+            },
+            {
+              "format": "short",
+              "logBase": 1,
+              "max": 2,
+              "min": 0,
+              "show": true
+            }
+          ]
+        }
+      ],
+      "repeat": null,
+      "repeatIteration": null,
+      "repeatRowId": null,
+      "showTitle": false,
+      "title": "Row",
+      "titleSize": "h6"
+    },
+    {
+      "collapse": false,
+      "height": 250,
+      "panels": [
+        {
+          "aliasColors": {
+            "join": "#3F6833",
+            "leave": "#E24D42",
+            "primary-not-ready": "#E24D42",
+            "primary-ready": "#629E51",
+            "secondary-not-ready": "#58140C",
+            "secondary-ready": "#3F6833",
+            "total.primary-not-ready": "#3F6833",
+            "total.primary-ready": "#9AC48A",
+            "total.secondary-not-ready": "#052B51",
+            "total.secondary-ready": "#2F575E",
+            "update": "#511749"
+          },
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
+          "datasource": "$datasource",
+          "fill": 1,
+          "id": 32,
+          "legend": {
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "show": true,
+            "total": false,
+            "values": false
+          },
+          "lines": false,
+          "linewidth": 1,
+          "links": [],
+          "minSpan": 3,
+          "nullPointMode": "null",
+          "percentage": false,
+          "pointradius": 3,
+          "points": true,
+          "renderer": "flot",
+          "repeat": "instance",
+          "seriesOverrides": [
+            {
+              "alias": "/primary-not-ready/",
+              "fill": 4,
+              "lines": true,
+              "linewidth": 0,
+              "points": false,
+              "stack": "B",
+              "yaxis": 2,
+              "zindex": -1
+            },
+            {
+              "alias": "/primary-ready/",
+              "fill": 4,
+              "lines": true,
+              "linewidth": 0,
+              "points": false,
+              "stack": "B",
+              "yaxis": 2,
+              "zindex": -1
+            },
+            {
+              "alias": "/secondary-not-ready/",
+              "fill": 4,
+              "lines": true,
+              "linewidth": 0,
+              "points": false,
+              "stack": "B",
+              "yaxis": 2,
+              "zindex": -1
+            },
+            {
+              "alias": "/secondary-ready/",
+              "fill": 4,
+              "lines": true,
+              "linewidth": 0,
+              "points": false,
+              "stack": "B",
+              "yaxis": 2,
+              "zindex": -1
+            }
+          ],
+          "spaceLength": 10,
+          "span": 3,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "hide": false,
+              "refId": "A",
+              "target": "aliasByNode(perSecond(metrictank.stats.$environment.$instance.cluster.events.*.counter32), 6)"
+            },
+            {
+              "refId": "B",
+              "target": "aliasByNode(metrictank.stats.$environment.$instance.cluster.total.state.*.gauge32, 7)"
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeShift": null,
+          "title": "cluster status - $instance perspective",
+          "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+          },
+          "transparent": true,
+          "type": "graph",
+          "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            },
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            }
+          ]
+        }
+      ],
+      "repeat": null,
+      "repeatIteration": null,
+      "repeatRowId": null,
+      "showTitle": false,
+      "title": "clustering",
+      "titleSize": "h6"
+    },
+    {
+      "collapse": false,
+      "height": "250px",
+      "panels": [
+        {
+          "aliasColors": {
+            "max": "#890F02",
+            "median": "#CCA300",
+            "p90": "#C15C17",
+            "reqs": "#2F575E"
+          },
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
+          "datasource": "$datasource",
+          "editable": true,
+          "error": false,
+          "fill": 1,
+          "grid": {},
+          "id": 5,
+          "legend": {
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "show": true,
+            "total": false,
+            "values": false
+          },
+          "lines": false,
+          "linewidth": 2,
+          "links": [],
+          "minSpan": 3,
+          "nullPointMode": "null",
+          "percentage": false,
+          "pointradius": 1,
+          "points": true,
+          "renderer": "flot",
+          "repeat": "instance",
+          "seriesOverrides": [
+            {
+              "alias": "/idle/",
+              "lines": true,
+              "linewidth": 0,
+              "points": false,
+              "stack": true,
+              "yaxis": 2
+            },
+            {
+              "alias": "reqs",
+              "fill": 0,
+              "lines": true,
+              "linewidth": 1,
+              "nullPointMode": "null as zero",
+              "points": false,
+              "yaxis": 2
+            }
+          ],
+          "spaceLength": 10,
+          "span": 3,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "refId": "E",
+              "target": "aliasByNode(perSecond(metrictank.stats.$environment.$instance.api.request.*.status.*.counter32), 6, 8)",
+              "textEditor": false
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeShift": null,
+          "title": "requests $instance",
+          "tooltip": {
+            "msResolution": false,
+            "shared": true,
+            "sort": 0,
+            "value_type": "cumulative"
+          },
+          "transparent": true,
+          "type": "graph",
+          "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "format": "ms",
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            },
+            {
+              "format": "short",
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            }
+          ]
+        }
+      ],
+      "repeat": null,
+      "repeatIteration": null,
+      "repeatRowId": null,
+      "showTitle": false,
+      "title": "New row",
+      "titleSize": "h6"
+    }
+  ],
+  "schemaVersion": 14,
+  "style": "dark",
+  "tags": [],
+  "templating": {
+    "list": [
+      {
+        "current": {
+          "text": "monitoring",
+          "value": "monitoring"
+        },
+        "datasource": null,
+        "hide": 0,
+        "includeAll": false,
+        "label": "",
+        "multi": false,
+        "name": "datasource",
+        "options": [],
+        "query": "graphite",
+        "refresh": 1,
+        "regex": "",
+        "type": "datasource"
+      },
+      {
+        "allFormat": "glob",
+        "allValue": null,
+        "current": {},
+        "datasource": "$datasource",
+        "hide": 0,
+        "includeAll": false,
+        "label": null,
+        "multi": false,
+        "multiFormat": "glob",
+        "name": "environment",
+        "options": [],
+        "query": "metrictank.stats.*",
+        "refresh": 1,
+        "refresh_on_load": false,
+        "regex": "",
+        "sort": 0,
+        "tagValuesQuery": "",
+        "tags": [],
+        "tagsQuery": "",
+        "type": "query",
+        "useTags": false
+      },
+      {
+        "allFormat": "glob",
+        "allValue": null,
+        "current": {},
+        "datasource": "$datasource",
+        "hide": 0,
+        "includeAll": true,
+        "label": null,
+        "multi": true,
+        "multiFormat": "glob",
+        "name": "instance",
+        "options": [],
+        "query": "metrictank.stats.$environment.*",
+        "refresh": 1,
+        "refresh_on_load": false,
+        "regex": "",
+        "sort": 0,
+        "tagValuesQuery": "",
+        "tags": [],
+        "tagsQuery": "",
+        "type": "query",
+        "useTags": false
+      }
+    ]
+  },
+  "time": {
+    "from": "now-5m",
+    "to": "now"
+  },
+  "timepicker": {
+    "collapse": false,
+    "enable": true,
+    "notice": false,
+    "now": true,
+    "refresh_intervals": [
+      "5s",
+      "10s",
+      "30s",
+      "1m",
+      "5m",
+      "15m",
+      "30m",
+      "1h",
+      "2h",
+      "1d"
+    ],
+    "status": "Stable",
+    "time_options": [
+      "5m",
+      "15m",
+      "1h",
+      "6h",
+      "12h",
+      "24h",
+      "2d",
+      "7d",
+      "30d"
+    ],
+    "type": "timepicker"
+  },
+  "timezone": "browser",
+  "title": "Metrictank clustering",
+  "version": 3
+}

--- a/input/carbon/carbon.go
+++ b/input/carbon/carbon.go
@@ -117,8 +117,10 @@ func (c *Carbon) Start(handler input.Handler) {
 	go c.accept()
 }
 
-// MaintainPriority is a no-op. priority for carbon not implemented
+// MaintainPriority is very simplistic for carbon. there is no backfill,
+// so mark as ready immediately.
 func (c *Carbon) MaintainPriority() {
+	cluster.Manager.SetPriority(0)
 }
 
 func (c *Carbon) accept() {

--- a/input/kafkamdm/kafkamdm.go
+++ b/input/kafkamdm/kafkamdm.go
@@ -300,9 +300,9 @@ func (k *KafkaMdm) consumePartition(topic string, partition int32, currentOffset
 				log.Error(3, "kafka-mdm failed to commit offset for %s:%d, %s", topic, partition, err)
 			}
 			k.lagMonitor.StoreOffset(partition, currentOffset, ts)
-			newest, err := k.client.GetOffset(topic, partition, sarama.OffsetNewest)
+			newest, err := k.tryGetOffset(topic, partition, sarama.OffsetNewest, 1, 0)
 			if err != nil {
-				log.Error(3, "kafka-mdm failed to get log-size of partition %s:%d. %s", topic, partition, err)
+				log.Error(3, "kafka-mdm %s", err)
 			} else {
 				partitionLogSizeMetric.Set(int(newest))
 			}

--- a/input/kafkamdm/kafkamdm.go
+++ b/input/kafkamdm/kafkamdm.go
@@ -269,6 +269,7 @@ func (k *KafkaMdm) consumePartition(topic string, partition int32, currentOffset
 				partitionLogSizeMetric.Set(int(offset))
 			}
 			if currentOffset < 0 {
+				// we're set to consume oldest/newest and
 				// we have not yet consumed any messages.
 				continue
 			}

--- a/input/kafkamdm/kafkamdm.go
+++ b/input/kafkamdm/kafkamdm.go
@@ -218,42 +218,73 @@ func (k *KafkaMdm) Start(handler input.Handler) {
 	}
 }
 
+// tryGetOffset will to query kafka repeatedly for the requested offset and give up after attempts unsuccesfull attempts
+// an error is returned when it had to give up
+func (k *KafkaMdm) tryGetOffset(topic string, partition int32, offset int64, attempts int, sleep time.Duration) (int64, error) {
+
+	var val int64
+	var err error
+	var offsetStr string
+
+	switch offset {
+	case sarama.OffsetNewest:
+		offsetStr = "newest"
+	case sarama.OffsetOldest:
+		offsetStr = "oldest"
+	default:
+		offsetStr = strconv.FormatInt(offset, 10)
+	}
+
+	attempt := 1
+	for {
+		val, err = k.client.GetOffset(topic, partition, offset)
+		if err == nil {
+			break
+		}
+
+		err = fmt.Errorf("failed to get offset %s of partition %s:%d. %s (attempt %d/%d)", offsetStr, topic, partition, err, attempt, attempts)
+		if attempt == attempts {
+			break
+		}
+		log.Warn("kafka-mdm %s", err)
+		attempt += 1
+		time.Sleep(sleep)
+	}
+	return val, err
+}
+
 // this will continually consume from the topic until k.stopConsuming is triggered.
 func (k *KafkaMdm) consumePartition(topic string, partition int32, currentOffset int64) {
 	k.wg.Add(1)
 	defer k.wg.Done()
 
+	partitionOffsetMetric := partitionOffset[partition]
+	partitionLogSizeMetric := partitionLogSize[partition]
+	partitionLagMetric := partitionLag[partition]
+
+	// determine the pos of the topic and the initial offset of our consumer
+	newest, err := k.tryGetOffset(topic, partition, sarama.OffsetNewest, 7, time.Second*10)
+	if err != nil {
+		log.Fatal(3, "kafka-mdm %s", err)
+	}
+	if currentOffset == sarama.OffsetNewest {
+		currentOffset = newest
+	} else if currentOffset == sarama.OffsetOldest {
+		currentOffset, err = k.tryGetOffset(topic, partition, sarama.OffsetOldest, 7, time.Second*10)
+		if err != nil {
+			log.Fatal(3, "kafka-mdm %s", err)
+		}
+	}
+
+	partitionOffsetMetric.Set(int(currentOffset))
+	partitionLogSizeMetric.Set(int(newest))
+	partitionLagMetric.Set(int(newest - currentOffset))
+
+	log.Info("kafka-mdm: consuming from %s:%d from offset %d", topic, partition, currentOffset)
 	pc, err := k.consumer.ConsumePartition(topic, partition, currentOffset)
 	if err != nil {
 		log.Fatal(4, "kafka-mdm: failed to start partitionConsumer for %s:%d. %s", topic, partition, err)
 	}
-
-	partitionOffsetMetric := partitionOffset[partition]
-	partitionLogSizeMetric := partitionLogSize[partition]
-	partitionLagMetric := partitionLag[partition]
-	var initialOffset int64
-	offset, err := k.client.GetOffset(topic, partition, sarama.OffsetNewest)
-	if err != nil {
-		log.Error(3, "kafka-mdm failed to get log-size of partition %s:%d. %s", topic, partition, err)
-	} else {
-		partitionLogSizeMetric.Set(int(offset))
-	}
-	var err2 error
-	if currentOffset == sarama.OffsetNewest {
-		initialOffset = offset
-	} else if currentOffset == sarama.OffsetOldest {
-		initialOffset, err2 = k.client.GetOffset(topic, partition, currentOffset)
-		if err != nil {
-			log.Error(3, "kafka-mdm failed to get oldest offset of partition %s:%d. %s", topic, partition, err)
-		}
-	}
-
-	if err == nil && err2 == nil {
-		partitionOffsetMetric.Set(int(initialOffset))
-		partitionLagMetric.Set(int(offset - initialOffset))
-	}
-
-	log.Info("kafka-mdm: consuming from %s:%d from offset %d", topic, partition, currentOffset)
 	messages := pc.Messages()
 	ticker := time.NewTicker(offsetCommitInterval)
 	for {
@@ -269,22 +300,16 @@ func (k *KafkaMdm) consumePartition(topic string, partition int32, currentOffset
 				log.Error(3, "kafka-mdm failed to commit offset for %s:%d, %s", topic, partition, err)
 			}
 			k.lagMonitor.StoreOffset(partition, currentOffset, ts)
-			offset, err := k.client.GetOffset(topic, partition, sarama.OffsetNewest)
+			newest, err := k.client.GetOffset(topic, partition, sarama.OffsetNewest)
 			if err != nil {
 				log.Error(3, "kafka-mdm failed to get log-size of partition %s:%d. %s", topic, partition, err)
 			} else {
-				partitionLogSizeMetric.Set(int(offset))
+				partitionLogSizeMetric.Set(int(newest))
 			}
 
-			effectiveOffset := currentOffset
-			if currentOffset < 0 {
-				// we're set to consume oldest/newest and we have not yet consumed any messages.
-				// so we're still stuck at the offset we got initially.
-				effectiveOffset = initialOffset
-			}
-			partitionOffsetMetric.Set(int(effectiveOffset))
+			partitionOffsetMetric.Set(int(currentOffset))
 			if err == nil {
-				lag := int(offset - effectiveOffset)
+				lag := int(newest - currentOffset)
 				partitionLagMetric.Set(lag)
 				k.lagMonitor.StoreLag(partition, lag)
 			}

--- a/input/kafkamdm/lag_monitor.go
+++ b/input/kafkamdm/lag_monitor.go
@@ -5,6 +5,8 @@ import (
 	"time"
 )
 
+// lagLogger maintains a set of most recent lag measurements
+// and is able to provide the lowest value seen.
 type lagLogger struct {
 	sync.Mutex
 	pos          int
@@ -18,6 +20,8 @@ func newLagLogger(size int) *lagLogger {
 	}
 }
 
+// Store saves the current value, potentially overwriting an old value
+// if needed.
 func (l *lagLogger) Store(lag int) {
 	l.Lock()
 	defer l.Unlock()
@@ -33,6 +37,11 @@ func (l *lagLogger) Store(lag int) {
 	l.measurements[l.pos] = lag
 }
 
+// Min returns the lowest lag seen or 0 if:
+// * no lags reported yet
+// * reported lag was negative, which can happen when:
+//   - kafka had to recover, and a previous offset loaded from offsetMgr was bigger than current offset
+//   - a rollover of the offset counter
 func (l *lagLogger) Min() int {
 	l.Lock()
 	defer l.Unlock()
@@ -55,6 +64,12 @@ type rateLogger struct {
 	rate       int64
 }
 
+func newRateLogger() *rateLogger {
+	return &rateLogger{}
+}
+
+// Store saves the current offset updates the rate if it is confident
+// note that offset may be -2 or -1
 func (o *rateLogger) Store(offset int64, ts time.Time) {
 	o.Lock()
 	defer o.Unlock()
@@ -96,29 +111,22 @@ func (o *rateLogger) Store(offset int64, ts time.Time) {
 	return
 }
 
+// Rate returns the last reliable rate calculation
+// * generally, it's the last reported measurement
+// * occasionally, it's one report interval in the past (due to rollover)
+// * exceptionally, it's an old measurement (if you keep adjusting the system clock)
+// after startup, reported rate may be 0 if we haven't been up long enough to determine it yet.
 func (o *rateLogger) Rate() int64 {
 	o.Lock()
 	defer o.Unlock()
 	return o.rate
 }
 
-func newRateLogger() *rateLogger {
-	return &rateLogger{}
-}
-
-/*
-   LagMonitor is used to determine how upToDate this node is.
-   We periodically collect the lag for each partition, keeping the last N
-   measurements in a moving window. We also collect the ingest rate of each
-   partition. Using these measurements we can then compute a overall score
-   for this each partition. The score is just the minimum lag seen in the last
-   N measurements divided by the ingest rate. So if the ingest rate is 1k/second
-   and the lag is 10000 messages. Then our reported lag is 10, meaning 10seconds.
-   If the rate is 1k/second and the lag is 200 then our lag is reported as 0, meaning
-   the node is less then 1second behind.
-
-   The node's overall lag is then the highest lag of all partitions.
-*/
+// LagMonitor determines how upToDate this node is.
+// For each partition, we periodically collect:
+// * the consumption lag (we keep the last N measurements)
+// * ingest rate
+// We then combine this data into a score, see the Metric() method.
 type LagMonitor struct {
 	lag  map[int32]*lagLogger
 	rate map[int32]*rateLogger
@@ -136,12 +144,29 @@ func NewLagMonitor(size int, partitions []int32) *LagMonitor {
 	return m
 }
 
+// Metric computes the overall score of up-to-date-ness of this node,
+// as an estimated number of seconds behind kafka.
+// We first compute the score for each partition like so:
+// (minimum lag seen in last N measurements) / ingest rate.
+// example:
+// lag (in messages/metrics)     ingest rate       --->    score (seconds behind)
+//                       10k       1k/second                 10
+//                       200       1k/second                  0 (less than 1s behind)
+//     0 (see lag.Min() docs)              *                  0 !!! PROBLEM
+//                   anything     0 (after startup)          same as lag
+//
+// The returned total score for the node is the max of the scores of individual partitions.
+// Note that one or more StoreOffset() (rate) calls may have been made but no StoreLag().
+// This can happen in 3 cases:
+// - we're not consuming yet
+// - trouble querying the partition for latest offset
+// - consumePartition() has called StoreOffset() but the code hasn't advanced yet to StoreLag()
 func (l *LagMonitor) Metric() int {
 	max := 0
 	for p, lag := range l.lag {
 		rate := l.rate[p]
-		l := lag.Min()
-		r := rate.Rate()
+		l := lag.Min()   // accurate lag, or 0 if no reports yet or in some other conditions
+		r := rate.Rate() // accurate rate, or 0 if we're not sure.
 		if r == 0 {
 			r = 1
 		}

--- a/input/kafkamdm/lag_monitor.go
+++ b/input/kafkamdm/lag_monitor.go
@@ -73,8 +73,8 @@ func newRateLogger() *rateLogger {
 	return &rateLogger{}
 }
 
-// Store saves the current offset updates the rate if it is confident
-// note that offset may be -2 or -1
+// Store saves the current offset and updates the rate if it is confident
+// offset must be concrete values, not logical values like -2 (oldest) or -1 (newest)
 func (o *rateLogger) Store(offset int64, ts time.Time) {
 	o.Lock()
 	defer o.Unlock()
@@ -96,14 +96,6 @@ func (o *rateLogger) Store(offset int64, ts time.Time) {
 		// in which case we can't reliably work out how
 		// long it has really been since we last took a measurement.
 		// but set a new baseline for next time
-		o.lastTs = ts
-		o.lastOffset = offset
-		return
-	}
-	if o.lastOffset < 0 {
-		// last offset is symbolical value representing "newest" or "latest"
-		// it can't be used to compute a rate (it would lead to a value way too high)
-		// so set the new baseline and hopefully we can compute the rate next time
 		o.lastTs = ts
 		o.lastOffset = offset
 		return

--- a/input/kafkamdm/lag_monitor.go
+++ b/input/kafkamdm/lag_monitor.go
@@ -95,6 +95,14 @@ func (o *rateLogger) Store(offset int64, ts time.Time) {
 		o.lastOffset = offset
 		return
 	}
+	if o.lastOffset < 0 {
+		// last offset is symbolical value representing "newest" or "latest"
+		// it can't be used to compute a rate (it would lead to a value way too high)
+		// so set the new baseline and hopefully we can compute the rate next time
+		o.lastTs = ts
+		o.lastOffset = offset
+		return
+	}
 	metrics := offset - o.lastOffset
 	o.lastTs = ts
 	o.lastOffset = offset

--- a/input/kafkamdm/lag_monitor_test.go
+++ b/input/kafkamdm/lag_monitor_test.go
@@ -10,7 +10,7 @@ import (
 func TestLagLogger(t *testing.T) {
 	logger := newLagLogger(5)
 	Convey("with 0 measurements", t, func() {
-		So(logger.Min(), ShouldEqual, 0)
+		So(logger.Min(), ShouldEqual, -1)
 	})
 	Convey("with 1 measurements", t, func() {
 		logger.Store(10)
@@ -18,6 +18,10 @@ func TestLagLogger(t *testing.T) {
 	})
 	Convey("with 2 measurements", t, func() {
 		logger.Store(5)
+		So(logger.Min(), ShouldEqual, 5)
+	})
+	Convey("with a negative measurement", t, func() {
+		logger.Store(-5)
 		So(logger.Min(), ShouldEqual, 5)
 	})
 	Convey("with lots of measurements", t, func() {
@@ -104,7 +108,7 @@ func TestRateLoggerSmallIncrements(t *testing.T) {
 func TestLagMonitor(t *testing.T) {
 	mon := NewLagMonitor(10, []int32{0, 1, 2, 3})
 	Convey("with 0 measurements", t, func() {
-		So(mon.Metric(), ShouldEqual, 0)
+		So(mon.Metric(), ShouldEqual, 10000)
 	})
 	Convey("with lots of measurements", t, func() {
 		now := time.Now()


### PR DESCRIPTION
note that index init (backfill) is blocking, and plugin.MaintainPriority is only called afterwards. so when priority goes down from 10k, index is guaranteed to be loaded.

future nice to have:
* if a peer errors 503, try next-best peer that hosts the same shard if it's also ready